### PR TITLE
Fix macOS microphone and Accessibility permission onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Tracking toward **0.3.0** — the pre-publish readiness pass.
+## [0.3.1] — 2026-07-09
+
+### Fixed
+- The notarized macOS app now carries the hardened-runtime entitlements for
+  microphone input and Apple Events, allowing recording and auto-paste to
+  pass macOS privacy enforcement.
+- DMGs now use a small native launcher so macOS attributes Microphone and
+  Accessibility consent to OpenVoiceFlow instead of its Python bootstrap.
+- First launch uses the native macOS consent prompts and no longer stacks two
+  conflicting custom permission dialogs.
+
+## [0.3.0] — 2026-07-08
+
+The pre-publish readiness pass.
 
 ### Added
 - Pytest scaffold under `tests/` with regression tests for every

--- a/README.md
+++ b/README.md
@@ -570,6 +570,8 @@ System:
 - ~200 MB disk space
 - Microphone + Accessibility permission
 
+On first launch, allow both prompts. OpenVoiceFlow should appear by name under **System Settings → Privacy & Security → Microphone** and **Accessibility**. If microphone access was previously denied, relaunch OpenVoiceFlow and choose **Open Microphone Settings**, enable it, then relaunch once more.
+
 <br/>
 
 ---

--- a/assets/OpenVoiceFlow.entitlements
+++ b/assets/OpenVoiceFlow.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>

--- a/build-dmg.sh
+++ b/build-dmg.sh
@@ -4,9 +4,8 @@
 #   dist/OpenVoiceFlow-VERSION-arm64.dmg   (Apple Silicon)
 #   dist/OpenVoiceFlow-VERSION-x86_64.dmg  (Intel)
 #
-# The .app contains ONLY source code + a bash bootstrap launcher.
-# Dependencies are installed NATIVELY on the user's Mac at first launch.
-# No pre-compiled binaries = no Rosetta issues, no wrong-arch crashes.
+# The .app contains a tiny native permissions launcher plus source code and a
+# bash bootstrap. Python dependencies are installed natively on first launch.
 
 set -euo pipefail
 
@@ -23,6 +22,8 @@ DIST_DIR="$SCRIPT_DIR/dist"
 BUILD_ONLY_ARCH="${OVF_BUILD_ARCH_ONLY:-}"
 LOCAL_ONLY_MODE="${OVF_LOCAL_ONLY:-0}"
 ICON_FILE="$SCRIPT_DIR/assets/OpenVoiceFlow.icns"
+ENTITLEMENTS_FILE="$SCRIPT_DIR/assets/OpenVoiceFlow.entitlements"
+LAUNCHER_SOURCE="$SCRIPT_DIR/packaging/OpenVoiceFlowLauncher.m"
 SIGN_IDENTITY="${OVF_SIGN_IDENTITY:-}"
 NOTARIZE="${OVF_NOTARIZE:-0}"
 NOTARY_PROFILE="${OVF_NOTARY_PROFILE:-}"
@@ -36,6 +37,8 @@ echo "================================================"
 
 [[ "$(uname)" != "Darwin" ]] && echo "❌ Requires macOS." && exit 1
 [[ ! -f "$ICON_FILE" ]] && echo "❌ Missing app icon: $ICON_FILE" && exit 1
+[[ ! -f "$ENTITLEMENTS_FILE" ]] && echo "❌ Missing app entitlements: $ENTITLEMENTS_FILE" && exit 1
+[[ ! -f "$LAUNCHER_SOURCE" ]] && echo "❌ Missing native launcher: $LAUNCHER_SOURCE" && exit 1
 
 rm -rf "$DIST_DIR"; mkdir -p "$DIST_DIR"
 
@@ -49,7 +52,8 @@ sign_app_if_requested() {
 
     echo "  🔏 Signing app with: $SIGN_IDENTITY"
     xattr -cr "$APP_DIR" >/dev/null 2>&1 || true
-    /usr/bin/codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$APP_DIR"
+    /usr/bin/codesign --force --timestamp --options runtime \
+        --entitlements "$ENTITLEMENTS_FILE" --sign "$SIGN_IDENTITY" "$APP_DIR"
     /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_DIR"
 }
 
@@ -125,7 +129,8 @@ PLIST
     # Capture vars before heredoc
     local LAUNCHER_ARCH="$ARCH"
 
-    cat > "$APP_DIR/Contents/MacOS/${APP_NAME}" << LAUNCHER
+    local BOOTSTRAP="$APP_DIR/Contents/Resources/launcher.sh"
+    cat > "$BOOTSTRAP" << LAUNCHER
 #!/bin/bash
 # OpenVoiceFlow bootstrap — installs deps natively, then launches
 
@@ -146,13 +151,6 @@ echo "[\$(date)] Launching on \$(uname -m)"
 notify() { osascript -e "display notification \"\$1\" with title \"OpenVoiceFlow\"" 2>/dev/null || true; }
 fatal()  { osascript -e "display dialog \"\$1\" with title \"OpenVoiceFlow\" buttons {\"OK\"} default button \"OK\" with icon stop" 2>/dev/null; exit 1; }
 alert()  { osascript -e "display dialog \"\$1\" with title \"OpenVoiceFlow\" buttons {\"OK\"} default button \"OK\" with icon note" 2>/dev/null; }
-ask_permission_help() {
-    osascript -e 'display dialog "OpenVoiceFlow needs permissions to work.\n\nOpen Accessibility settings now?" with title "OpenVoiceFlow Permissions" buttons {"Later", "Open Settings"} default button "Open Settings" with icon note' 2>/dev/null
-}
-
-ask_permissions_menu() {
-    osascript -e 'display dialog "OpenVoiceFlow startup checks detected missing permissions. Choose which settings screen to open now." with title "OpenVoiceFlow Permissions" buttons {"Continue", "Microphone", "Accessibility"} default button "Accessibility" with icon note' 2>/dev/null
-}
 
 [[ -f /opt/homebrew/bin/brew ]] && eval "\$(/opt/homebrew/bin/brew shellenv)"
 [[ -f /usr/local/bin/brew   ]] && eval "\$(/usr/local/bin/brew shellenv)"
@@ -263,44 +261,6 @@ if [[ ! -f "\$MODEL" ]]; then
     mv "\$MODEL.download" "\$MODEL"
 fi
 
-AX_OK="\$("\$PY_RUN" - <<'PY'
-try:
-    from ApplicationServices import AXIsProcessTrusted
-    print("1" if AXIsProcessTrusted() else "0")
-except Exception:
-    print("0")
-PY
-)"
-
-if [[ "\$AX_OK" != "1" ]]; then
-    if ask_permission_help | grep -q "Open Settings"; then
-        open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" >/dev/null 2>&1 || true
-    fi
-fi
-
-# Trigger a one-time microphone permission check so OpenVoiceFlow appears
-# in the Microphone privacy list before first dictation.
-"\$PY_RUN" - <<'PY' >/dev/null 2>&1 || true
-try:
-    import sounddevice as sd
-    # Requesting a tiny recording buffer prompts mic permission if needed.
-    rec = sd.rec(1, samplerate=8000, channels=1, dtype='float32')
-    sd.wait()
-except Exception:
-    pass
-PY
-
-# Only surface the permissions menu when a permission is actually missing —
-# unconditionally it would block every launch with a dialog.
-if [[ "\$AX_OK" != "1" ]]; then
-    PERM_CHOICE="\$(ask_permissions_menu || true)"
-    if [[ "\$PERM_CHOICE" == *"Accessibility"* ]]; then
-        open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" >/dev/null 2>&1 || true
-    elif [[ "\$PERM_CHOICE" == *"Microphone"* ]]; then
-        open "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone" >/dev/null 2>&1 || true
-    fi
-fi
-
 "\$PY_RUN" -c "
 import json
 import os
@@ -365,7 +325,10 @@ except Exception as e:
 "
 LAUNCHER
 
-    chmod +x "$APP_DIR/Contents/MacOS/${APP_NAME}"
+    chmod +x "$BOOTSTRAP"
+    /usr/bin/clang -fobjc-arc -fblocks -arch "$ARCH" -mmacosx-version-min=12.0 \
+        "$LAUNCHER_SOURCE" -framework Cocoa -framework AVFoundation \
+        -framework ApplicationServices -o "$APP_DIR/Contents/MacOS/${APP_NAME}"
     sign_app_if_requested "$APP_DIR"
 
     local STAGING="$DIST_DIR/staging-$ARCH"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,7 +196,7 @@ Audio (`.wav`) is written only as a NamedTemporaryFile during batch processing a
 
 ## 5. Permissions model
 
-OpenVoiceFlow is unsandboxed and uses standard macOS TCC prompts. Each feature requires exactly the set below; the app degrades cleanly when a permission is missing.
+OpenVoiceFlow is unsandboxed and uses standard macOS TCC prompts. The DMG app starts through a small native launcher so macOS attributes Microphone, Accessibility, and Apple Events consent to the stable `com.openvoiceflow.dictation` bundle rather than to its Python bootstrap process. Signed builds carry the narrow audio-input and Apple Events entitlements required by the hardened runtime. Each feature requires exactly the set below; the app degrades cleanly when a permission is missing.
 
 | Permission | Required for | Where | Failure mode if missing |
 |---|---|---|---|

--- a/packaging/OpenVoiceFlowLauncher.m
+++ b/packaging/OpenVoiceFlowLauncher.m
@@ -1,0 +1,106 @@
+#import <AppKit/AppKit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#import <AVFoundation/AVFoundation.h>
+
+static BOOL isSmokeTest(void) {
+    const char *value = getenv("OVF_SMOKE_TEST");
+    return value != NULL && strcmp(value, "1") == 0;
+}
+
+static BOOL requestMicrophoneAccess(void) {
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    if (status == AVAuthorizationStatusAuthorized) {
+        return YES;
+    }
+    if (status != AVAuthorizationStatusNotDetermined) {
+        return NO;
+    }
+
+    __block BOOL granted = NO;
+    dispatch_semaphore_t completion = dispatch_semaphore_create(0);
+    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
+                             completionHandler:^(BOOL allowed) {
+                                 granted = allowed;
+                                 dispatch_semaphore_signal(completion);
+                             }];
+
+    while (dispatch_semaphore_wait(completion, dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC)) != 0) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+    return granted;
+}
+
+static void showMicrophoneHelp(void) {
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = @"Microphone access is off";
+    alert.informativeText = @"OpenVoiceFlow cannot record until it is enabled in Privacy & Security. "
+                             "Open the Microphone settings now, enable OpenVoiceFlow, then relaunch the app.";
+    [alert addButtonWithTitle:@"Open Microphone Settings"];
+    [alert addButtonWithTitle:@"Continue"];
+
+    if ([alert runModal] == NSAlertFirstButtonReturn) {
+        NSURL *settingsURL = [NSURL URLWithString:
+            @"x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"];
+        [[NSWorkspace sharedWorkspace] openURL:settingsURL];
+    }
+}
+
+static void requestAccessibilityAccess(void) {
+    if (AXIsProcessTrusted()) {
+        return;
+    }
+
+    const void *keys[] = {kAXTrustedCheckOptionPrompt};
+    const void *values[] = {kCFBooleanTrue};
+    CFDictionaryRef options = CFDictionaryCreate(
+        kCFAllocatorDefault,
+        keys,
+        values,
+        1,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks
+    );
+    AXIsProcessTrustedWithOptions(options);
+    CFRelease(options);
+}
+
+static int runBootstrap(int argc, const char *argv[]) {
+    NSString *scriptPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"launcher.sh"];
+    NSMutableArray<NSString *> *arguments = [NSMutableArray arrayWithObject:scriptPath];
+    for (int index = 1; index < argc; index++) {
+        [arguments addObject:[NSString stringWithUTF8String:argv[index]]];
+    }
+
+    NSTask *task = [[NSTask alloc] init];
+    task.executableURL = [NSURL fileURLWithPath:@"/bin/bash"];
+    task.arguments = arguments;
+
+    NSError *error = nil;
+    if (![task launchAndReturnError:&error]) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"OpenVoiceFlow could not start";
+        alert.informativeText = error.localizedDescription;
+        [alert runModal];
+        return 1;
+    }
+
+    [task waitUntilExit];
+    return task.terminationStatus;
+}
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+        if (!isSmokeTest()) {
+            [NSApp activateIgnoringOtherApps:YES];
+            if (!requestMicrophoneAccess()) {
+                showMicrophoneHelp();
+            }
+            requestAccessibilityAccess();
+        }
+
+        return runBootstrap(argc, argv);
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openvoiceflow"
-version = "0.3.0"
+version = "0.3.1"
 description = "Free voice dictation for macOS — local transcription + optional LLM cleanup"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_launch_self_check.py
+++ b/tests/test_launch_self_check.py
@@ -79,3 +79,44 @@ def test_validate_setup_pass_no_notify(stub_validate_setup_inputs, monkeypatch) 
     assert ok is True
     error_calls = [c for c in notify_calls if c[0] == "error"]
     assert not error_calls, f"happy path should not call notify.error; got: {error_calls}"
+
+
+def test_validate_setup_accessibility_failure_links_to_settings(
+    stub_validate_setup_inputs, monkeypatch
+) -> None:
+    """A missing Accessibility grant must provide a one-click settings URL."""
+    appmod = stub_validate_setup_inputs
+
+    monkeypatch.setattr(appmod, "find_whisper_cpp", lambda: "/opt/homebrew/bin/whisper-cli")
+    monkeypatch.setattr(appmod, "get_model_path", lambda name: "/fake/model")
+    monkeypatch.setattr(appmod.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(appmod.os.path, "getsize", lambda p: 142_000_000)
+    monkeypatch.setattr(appmod, "_is_accessibility_trusted", lambda: False)
+    monkeypatch.setattr(
+        appmod,
+        "load_config",
+        lambda: {
+            "llm_backend": "none",
+            "whisper_model": "base.en",
+            "sample_rate": 16000,
+            "channels": 1,
+        },
+    )
+
+    notify_calls: list = []
+    import voiceflow.notify as notify
+
+    monkeypatch.setattr(
+        notify,
+        "error",
+        lambda msg, **kw: notify_calls.append((msg, kw)),
+    )
+
+    vf = appmod.OpenVoiceFlow()
+    assert vf.validate_setup() is False
+    assert notify_calls
+    action = notify_calls[-1][1]["action"]
+    assert action == (
+        "Open Accessibility Settings",
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+    )

--- a/tests/test_macos_permissions_packaging.py
+++ b/tests/test_macos_permissions_packaging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = ROOT / "build-dmg.sh"
+ENTITLEMENTS = ROOT / "assets" / "OpenVoiceFlow.entitlements"
+LAUNCHER_SOURCE = ROOT / "packaging" / "OpenVoiceFlowLauncher.m"
+
+
+def test_signed_app_is_entitled_to_capture_audio() -> None:
+    """Hardened-runtime builds need explicit audio-input authorization."""
+    assert ENTITLEMENTS.is_file()
+
+    with ENTITLEMENTS.open("rb") as handle:
+        entitlements = plistlib.load(handle)
+
+    assert entitlements["com.apple.security.device.audio-input"] is True
+    assert entitlements["com.apple.security.automation.apple-events"] is True
+
+    build_script = BUILD_SCRIPT.read_text(encoding="utf-8")
+    assert 'ENTITLEMENTS_FILE="$SCRIPT_DIR/assets/OpenVoiceFlow.entitlements"' in build_script
+    assert '--entitlements "$ENTITLEMENTS_FILE"' in build_script
+
+
+def test_launcher_requests_permissions_and_shows_only_one_fallback_dialog() -> None:
+    """First launch should register both TCC services without stacked dialogs."""
+    build_script = BUILD_SCRIPT.read_text(encoding="utf-8")
+    launcher_source = LAUNCHER_SOURCE.read_text(encoding="utf-8")
+
+    assert "AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio" in launcher_source
+    assert "AXIsProcessTrustedWithOptions" in launcher_source
+    assert "kAXTrustedCheckOptionPrompt" in launcher_source
+    assert "Open Microphone Settings" in launcher_source
+    assert '-framework AVFoundation' in build_script
+    assert '-framework ApplicationServices' in build_script
+    assert 'Contents/Resources/launcher.sh' in build_script
+    assert "ask_permission_help" not in build_script
+    assert "ask_permissions_menu" not in build_script

--- a/voiceflow/__init__.py
+++ b/voiceflow/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Shimoverse"
 __app_name__ = "OpenVoiceFlow"

--- a/voiceflow/app.py
+++ b/voiceflow/app.py
@@ -221,10 +221,20 @@ class OpenVoiceFlow:
                 print(f"   • {e}")
             # B2: surface to menubar users + click-to-fix Notification Center.
             from . import notify
+            accessibility_missing = any(
+                "Accessibility permission not granted" in error for error in errors
+            )
             notify.error(
                 "Setup incomplete — " + (errors[0] if len(errors) == 1
                                           else f"{len(errors)} issues found"),
-                action=("Run openvoiceflow --doctor", None),
+                action=(
+                    (
+                        "Open Accessibility Settings",
+                        "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+                    )
+                    if accessibility_missing
+                    else ("Run openvoiceflow --doctor", None)
+                ),
             )
             return False
         return True


### PR DESCRIPTION
## What changed\n- Add a native app launcher so macOS attributes Microphone and Accessibility consent to OpenVoiceFlow rather than the copied Python runtime.\n- Add the required signed audio-input and Apple Events entitlements.\n- Remove the stacked custom permission dialogs and misleading Microphone settings detour.\n- Provide a direct Accessibility Settings action when startup detects a missing grant.\n\n## Verification\n- ........................................................................ [ 52%]
..................................................................       [100%]
138 passed in 0.72s (138 passed)\n- All checks passed!\n- Objective-C launcher compiles for arm64.