### PR TITLE
Fix silent macOS launcher crash

### DIFF
--- a/build-dmg.sh
+++ b/build-dmg.sh
@@ -142,7 +142,7 @@ VENV="\$HOME_DIR/venv"
 LOG_DIR="\$HOME/OpenVoiceFlow"
 LOG="\$LOG_DIR/launcher.log"
 PY="\$VENV/bin/python3"
-PY_RUN="\$VENV/bin/OpenVoiceFlow"
+PY_RUN="\$PY"
 
 mkdir -p "\$LOG_DIR" "\$HOME_DIR/models" "\$LOG_DIR/logs"
 exec >> "\$LOG" 2>&1
@@ -238,11 +238,6 @@ if [[ ! -f "\$PY" || ! -f "\$DEPS_MARKER" ]]; then
     "\$VENV/bin/pip" install -q sounddevice numpy pynput rumps pyobjc-framework-Cocoa || fatal "Package install failed. Relaunch OpenVoiceFlow to retry. Log: \$LOG"
     touch "\$DEPS_MARKER"
 fi
-
-# Runtime shim name helps users find the process in permission panes.
-rm -f "\$PY_RUN" >/dev/null 2>&1 || true
-cp "\$PY" "\$PY_RUN"
-chmod +x "\$PY_RUN"
 
 notify "OpenVoiceFlow is launching..."
 

--- a/packaging/OpenVoiceFlowLauncher.m
+++ b/packaging/OpenVoiceFlowLauncher.m
@@ -64,6 +64,21 @@ static void requestAccessibilityAccess(void) {
     CFRelease(options);
 }
 
+static void showBootstrapFailure(int status) {
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = @"OpenVoiceFlow could not finish starting";
+    alert.informativeText = [NSString stringWithFormat:
+        @"The background service exited with status %d. Open the launcher log for details.",
+        status];
+    [alert addButtonWithTitle:@"Open Launcher Log"];
+    [alert addButtonWithTitle:@"Close"];
+
+    if ([alert runModal] == NSAlertFirstButtonReturn) {
+        NSString *logPath = [@"~/OpenVoiceFlow/launcher.log" stringByExpandingTildeInPath];
+        [[NSWorkspace sharedWorkspace] openURL:[NSURL fileURLWithPath:logPath]];
+    }
+}
+
 static int runBootstrap(int argc, const char *argv[]) {
     NSString *scriptPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"launcher.sh"];
     NSMutableArray<NSString *> *arguments = [NSMutableArray arrayWithObject:scriptPath];
@@ -85,6 +100,9 @@ static int runBootstrap(int argc, const char *argv[]) {
     }
 
     [task waitUntilExit];
+    if (task.terminationStatus != 0) {
+        showBootstrapFailure(task.terminationStatus);
+    }
     return task.terminationStatus;
 }
 

--- a/tests/test_macos_permissions_packaging.py
+++ b/tests/test_macos_permissions_packaging.py
@@ -38,3 +38,20 @@ def test_launcher_requests_permissions_and_shows_only_one_fallback_dialog() -> N
     assert 'Contents/Resources/launcher.sh' in build_script
     assert "ask_permission_help" not in build_script
     assert "ask_permissions_menu" not in build_script
+
+
+def test_bootstrap_does_not_copy_the_python_framework_launcher() -> None:
+    """Renaming framework Python breaks its relative @executable_path lookup."""
+    build_script = BUILD_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'PY_RUN="\\$PY"' in build_script
+    assert 'cp "\\$PY" "\\$PY_RUN"' not in build_script
+
+
+def test_native_launcher_surfaces_bootstrap_failures() -> None:
+    """A bootstrap crash must show a visible error instead of silently exiting."""
+    launcher_source = LAUNCHER_SOURCE.read_text(encoding="utf-8")
+
+    assert "showBootstrapFailure" in launcher_source
+    assert "Open Launcher Log" in launcher_source
+    assert "task.terminationStatus != 0" in launcher_source


### PR DESCRIPTION
## Root cause
The DMG bootstrap copied the virtual-environment framework Python executable to a different path. That executable resolves its runtime relative to its own executable location, so the renamed copy aborted before the menu-bar app could start.

## Fix
- Execute the virtual-environment Python at its original path instead of copying and renaming it.
- Show a native startup error with an Open Launcher Log action if the bootstrap exits nonzero.
- Add regression coverage for both behaviors.

## Verification
- python3 -m pytest -q: 140 passed
- python3 -m ruff check voiceflow tests
- bash syntax validation
- Native Objective-C launcher compiled for arm64.