### PR TITLE
Fix first-launch onboarding and menu initialization crashes

### DIFF
--- a/build-dmg.sh
+++ b/build-dmg.sh
@@ -259,6 +259,8 @@ fi
 "\$PY_RUN" -c "
 import json
 import os
+import subprocess
+import sys
 
 
 cfg_path = os.path.expanduser('~/.openvoiceflow/config.json')
@@ -295,8 +297,10 @@ needs_setup = _needs_setup(cfg)
 
 if needs_setup:
     try:
-        from voiceflow.onboarding import run_onboarding
-        run_onboarding()
+        onboarding_code = 'from voiceflow.onboarding import run_onboarding; run_onboarding()'
+        result = subprocess.run([sys.executable, '-c', onboarding_code], check=False)
+        if result.returncode != 0:
+            print(f'Onboarding process exited with status {result.returncode}')
     except Exception as e:
         print(f'Onboarding error: {e}')
 

--- a/tests/test_macos_permissions_packaging.py
+++ b/tests/test_macos_permissions_packaging.py
@@ -55,3 +55,12 @@ def test_native_launcher_surfaces_bootstrap_failures() -> None:
     assert "showBootstrapFailure" in launcher_source
     assert "Open Launcher Log" in launcher_source
     assert "task.terminationStatus != 0" in launcher_source
+
+
+def test_tk_onboarding_runs_outside_the_long_lived_menu_process() -> None:
+    """A native Tk abort must not take down the menu-bar application."""
+    build_script = BUILD_SCRIPT.read_text(encoding="utf-8")
+
+    assert "import subprocess" in build_script
+    assert "subprocess.run([sys.executable, '-c', onboarding_code]" in build_script
+    assert "Onboarding process exited with status" in build_script

--- a/tests/test_menubar_initialization.py
+++ b/tests/test_menubar_initialization.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+
+class FakeMenu:
+    def __init__(self, initialized: bool) -> None:
+        self._menu = object() if initialized else None
+        self.clear_calls = 0
+
+    def clear(self) -> None:
+        self.clear_calls += 1
+
+
+def test_clear_submenu_skips_uninitialized_rumps_menu() -> None:
+    from voiceflow.menubar import _clear_submenu
+
+    menu = FakeMenu(initialized=False)
+    _clear_submenu(menu)
+
+    assert menu.clear_calls == 0
+
+
+def test_clear_submenu_clears_initialized_rumps_menu() -> None:
+    from voiceflow.menubar import _clear_submenu
+
+    menu = FakeMenu(initialized=True)
+    _clear_submenu(menu)
+
+    assert menu.clear_calls == 1

--- a/voiceflow/menubar.py
+++ b/voiceflow/menubar.py
@@ -10,6 +10,12 @@ except ImportError:
     rumps = None
 
 
+def _clear_submenu(menu) -> None:
+    """Clear a rumps submenu only after its native NSMenu exists."""
+    if getattr(menu, "_menu", None) is not None:
+        menu.clear()
+
+
 def run_menubar():
     """Launch OpenVoiceFlow as a menu bar app."""
     if rumps is None:
@@ -130,7 +136,7 @@ def run_menubar():
 
         def _build_backend_menu(self):
             """(Re)build backend submenu with current checkmarks."""
-            self.backend_menu.clear()
+            _clear_submenu(self.backend_menu)
             current_backend = self.config.get("llm_backend", "openrouter")
             for name in list(BACKENDS.keys()) + ["none"]:
                 item = rumps.MenuItem(
@@ -141,7 +147,7 @@ def run_menubar():
 
         def _build_hotkey_menu(self):
             """(Re)build hotkey submenu with current checkmarks."""
-            self.hotkey_menu.clear()
+            _clear_submenu(self.hotkey_menu)
             current_hotkey = self.config.get("hotkey", "right_cmd")
             for hk in ["left_fn", "right_cmd", "right_alt", "left_alt", "f5", "f6", "f7", "f8"]:
                 item = rumps.MenuItem(
@@ -152,7 +158,7 @@ def run_menubar():
 
         def _build_style_menu(self):
             """(Re)build style submenu with current checkmarks."""
-            self.style_menu.clear()
+            _clear_submenu(self.style_menu)
             current_style = self.config.get("style", "default")
             for style_id in VALID_STYLES:
                 label = get_style_label(style_id)


### PR DESCRIPTION
## Root causes
- The Command Line Tools Tk framework on macOS 15.6 aborts natively because it requires macOS 15.7. That abort killed the long-lived menu-bar process before its fallback could run.
- rumps submenu clear was called before the native NSMenu objects existed, raising a NoneType error.

## Fix
- Run Tk onboarding in a child process so a native abort cannot kill OpenVoiceFlow; fall back to local raw-transcription mode when onboarding cannot run.
- Skip submenu clearing until rumps has initialized the native submenu.
- Add focused regression tests.

## Verification
- Full suite: 143 passed
- Ruff clean
- build-dmg.sh syntax valid.