### PR TITLE
Prepare v0.3.2 macOS launcher hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-07-09
+
+### Fixed
+- The DMG bootstrap now executes the virtual-environment Python interpreter at
+  its original path, preventing a silent dynamic-library crash on launch.
+- Native startup failures now show an alert with a direct link to the launcher
+  log instead of making the app appear to do nothing.
+- First-run Tk onboarding runs in an isolated process, so an incompatible
+  system Tk build falls back to local transcription without killing the app.
+- Menu-bar settings no longer clear uninitialized native submenus during
+  startup.
+
 ## [0.3.1] — 2026-07-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openvoiceflow"
-version = "0.3.1"
+version = "0.3.2"
 description = "Free voice dictation for macOS — local transcription + optional LLM cleanup"
 readme = "README.md"
 license = "MIT"

--- a/voiceflow/__init__.py
+++ b/voiceflow/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "Shimoverse"
 __app_name__ = "OpenVoiceFlow"


### PR DESCRIPTION
The published v0.3.1 tag predates the launcher, Tk isolation, and menu initialization fixes. Prepare v0.3.2 so the corrected DMGs can be signed, notarized, and published without moving an existing release tag.

Verification: 143 tests passed, Ruff clean, reported package version 0.3.2.