### PR TITLE
fix: detect the OS and degrade gracefully instead of crashing off-macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,51 @@ jobs:
       - name: Tests
         run: pytest -q
 
+  # OpenVoiceFlow is macOS-only, but installing it elsewhere must degrade
+  # to a friendly "unsupported OS" message — never a traceback. This job
+  # pins that guarantee on a real non-Mac host.
+  non-macos-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install package (core deps only — no [all] extras off-macOS)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Every module imports off-macOS
+        run: python -c "import voiceflow, voiceflow.app, voiceflow.recorder, voiceflow.menubar; print('✅ imports survive a non-Mac host')"
+      - name: Bare launch exits with guidance, not a traceback
+        run: |
+          set +e
+          output=$(HOME=$(mktemp -d) openvoiceflow 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          test "$status" -eq 1
+          echo "$output" | grep -qi "macos"
+          echo "$output" | grep -q "pip uninstall openvoiceflow"
+          ! echo "$output" | grep -q "Traceback"
+      - name: Doctor still works off-macOS (valid JSON, OS check FAILs)
+        run: |
+          set +e
+          output=$(HOME=$(mktemp -d) openvoiceflow --doctor --json 2>/dev/null)
+          status=$?
+          set -e
+          test "$status" -eq 1
+          echo "$output" | python -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          first = data['checks'][0]
+          assert first['status'] == 'FAIL', first
+          assert 'macOS' in first['description'], first
+          print('✅ doctor degrades correctly off-macOS')
+          "
+      - name: Full test suite passes on Linux
+        run: HOME=$(mktemp -d) pytest -q
+
   build:
     runs-on: macos-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ openvoiceflow/
 │   ├── context.py                  ← frontmost-app detection + per-app style
 │   ├── learner.py                  ← auto-learn corrections via AX API
 │   ├── system.py                   ← paste_text, play_sound, log_transcript
+│   ├── platform_support.py         ← OS/arch/permission detection (macOS gate)
 │   ├── overlay.py                  ← PyObjC floating HUD
 │   ├── config.py                   ← DEFAULTS, validate_config, load/save
 │   ├── _secure_io.py               ← chmod-600 helpers (use this for new save sites!)
@@ -183,7 +184,7 @@ Useful for testing changes from the agent's shell. Many of these write to `~/.op
 | `--search QUERY` / `--search-date YYYY-MM-DD` / `--search-last DAYS` / `--limit N` | Full-text search over JSONL transcript logs. |
 | `--stats` | Print local-only usage counters. |
 | `--autostart on\|off` | Install or remove the LaunchAgent. |
-| `--doctor` | **Pending** — not yet implemented. Don't reference in docs as if it exists. |
+| `--doctor` | Self-check: OS, architecture, brew, whisper.cpp, model, API key, macOS permissions, file modes. `--json` for machine-readable output. Works (and reports the platform mismatch) on non-macOS hosts. |
 
 ## Where to ask
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `voiceflow/platform_support.py`: one place for OS, macOS-version,
+  architecture (Apple Silicon / Intel / Rosetta), and permission detection.
+- CLI platform gate: on Linux/Windows, `openvoiceflow` now prints a clear
+  "macOS-only" explanation with uninstall guidance and exits cleanly instead
+  of crashing with a traceback. `--doctor` and `--show-config` keep working
+  so users can inspect state first.
+- New doctor checks: operating system + version, architecture (warns on
+  Rosetta-translated Python and Intel Homebrew on Apple Silicon), and the
+  three macOS permissions dictation depends on (Microphone, Accessibility,
+  Input Monitoring) with click-to-fix System Settings links.
+- A launch below the supported macOS floor (12 Monterey) now prints an
+  upgrade warning.
+- CI: new `non-macos-guard` job on `ubuntu-latest` pins the "friendly
+  message, never a traceback" guarantee and runs the full suite on Linux.
+
+### Fixed
+- `voiceflow.recorder` no longer imports `sounddevice` at module load —
+  the import crashed the whole app (`OSError: PortAudio library not found`)
+  on machines without PortAudio before any error handling could run.
+- `find_whisper_cpp` / the doctor's Homebrew check use `shutil.which`
+  instead of spawning `which`, which crashed on Windows.
+- The keyboard-listener (pynput) import is now guarded in CLI and menu-bar
+  modes: a missing input backend produces a clear error instead of a crash.
+- Clipboard/keystroke/sound helpers (`pbcopy`, `pbpaste`, `osascript`,
+  `afplay`) no longer propagate `FileNotFoundError` when the binaries are
+  missing; failures surface as user-visible notifications.
+- `--autostart` refuses politely off-macOS instead of writing a
+  `~/Library/LaunchAgents` folder on Linux; on macOS it now prefers the
+  supported `launchctl bootstrap`/`bootout` verbs, falling back to the
+  deprecated `load`/`unload`.
+- `validate_setup` reports a broken audio backend (`OSError`) instead of
+  only a missing `sounddevice` package.
+
 ## [0.3.2] — 2026-07-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upgrade warning.
 - CI: new `non-macos-guard` job on `ubuntu-latest` pins the "friendly
   message, never a traceback" guarantee and runs the full suite on Linux.
+- Website: the download page now detects the visitor's OS. Windows, Linux,
+  ChromeOS, Android, and iPhone/iPad visitors get an inert "Not available
+  for <OS>" notice instead of a live DMG button; Safari-on-Mac visitors get
+  an Apple Silicon / Intel recommendation via a WebGL renderer fallback
+  (Chromium browsers already used architecture hints).
 
 ### Fixed
 - `voiceflow.recorder` no longer imports `sounddevice` at module load —

--- a/README.md
+++ b/README.md
@@ -576,6 +576,11 @@ System:
 - ~200 MB disk space
 - Microphone + Accessibility permission
 
+OpenVoiceFlow is macOS-only. On Linux or Windows it won't crash — it detects
+the OS, explains why dictation can't work there, and shows how to uninstall.
+Run `openvoiceflow --doctor` on any machine to check OS, architecture,
+dependencies, and macOS permissions (see [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)).
+
 On first launch, allow both prompts. OpenVoiceFlow should appear by name under **System Settings → Privacy & Security → Microphone** and **Accessibility**. If microphone access was previously denied, relaunch OpenVoiceFlow and choose **Open Microphone Settings**, enable it, then relaunch once more.
 
 <br/>

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -95,6 +95,30 @@ OpenVoiceFlow may contact these hosts. None are required after first-run setup i
 - **iOS / iPadOS / Android.** Not a mobile app.
 - **Web.** No browser build; the dictation model is system-wide hotkey + paste.
 
+### Behavior on unsupported operating systems
+
+Unsupported does not mean "crashes". If you pip-install OpenVoiceFlow on
+Linux or Windows and run it, the CLI detects the OS at startup
+(`voiceflow/platform_support.py`), prints an explanation of why dictation
+cannot work there plus uninstall guidance (`pip uninstall openvoiceflow`,
+`rm -rf ~/.openvoiceflow`), and exits with code 1 — no traceback, no
+background process, no config files written. Diagnostic commands
+(`--doctor`, `--show-config`, `--version`) keep working so you can inspect
+state before removing it. A CI job on `ubuntu-latest` pins this guarantee.
+
+## Doctor checks (`openvoiceflow --doctor`)
+
+The self-check covers, in order: operating system + version (fails below
+macOS 12, notes releases newer than our tested range), architecture
+(warns when Python runs under Rosetta or when Intel Homebrew is installed
+on Apple Silicon — both silently cost you Metal acceleration), Homebrew,
+whisper.cpp, the whisper model file, the LLM backend/API key, PyObjC,
+tkinter, the three macOS permissions dictation depends on (Microphone,
+Accessibility, Input Monitoring — each with a click-to-fix System
+Settings link), and config file modes. The Microphone check needs
+`pyobjc-framework-AVFoundation` to give a definitive answer; without it
+the doctor reports that macOS will prompt on first recording.
+
 ## "What about X?" mini-FAQ
 
 - **Linux PortAudio support?** Out of scope for v0.3. The transcription core (`sounddevice` + whisper.cpp) is portable in principle, but the menubar, overlay, and Accessibility-API integrations are AppKit-only.

--- a/docs/site.js
+++ b/docs/site.js
@@ -35,15 +35,22 @@
       title: 'Apple Silicon DMG',
       subtitle: 'Recommended for M1, M2, M3, M4, and newer Macs running macOS 12 or later.',
       badge: 'Apple Silicon',
-      confidence: 'Detected from browser architecture hints.',
     },
     x86_64: {
       href: 'downloads/OpenVoiceFlow-0.3.2-x86_64.dmg',
       title: 'Intel DMG',
       subtitle: 'Recommended for x86_64 Intel Macs running macOS 12 or later.',
       badge: 'Intel Mac',
-      confidence: 'Detected from browser architecture hints.',
     },
+  };
+
+  const OS_LABELS = {
+    windows: 'Windows',
+    linux: 'Linux',
+    chromeos: 'ChromeOS',
+    android: 'Android',
+    ios: 'iOS',
+    ipados: 'iPadOS',
   };
 
   function trackRecommendation(result) {
@@ -51,6 +58,7 @@
     window.va('event', {
       name: 'download_recommendation_detected',
       data: {
+        os: result.os || 'unknown',
         arch: result.arch || 'unknown',
         confidence: result.confidence || 'unknown',
         source: result.source || 'unknown',
@@ -66,30 +74,72 @@
     return '';
   }
 
-  async function detectMacArchitecture() {
+  function detectOS() {
     const ua = navigator.userAgent || '';
-    const platform = navigator.platform || '';
     const uaData = navigator.userAgentData;
-    const isMac = /Mac/i.test(platform) || /Macintosh|Mac OS X/i.test(ua);
+    const platform = String((uaData && uaData.platform) || navigator.platform || '').toLowerCase();
+    const isMacLike = platform.includes('mac') || /Macintosh|Mac OS X/i.test(ua);
 
+    if (/android/i.test(ua) || platform.includes('android')) return 'android';
+    if (/iphone|ipod/i.test(ua)) return 'ios';
+    // iPad Safari masquerades as a Mac but reports multitouch.
+    if (/ipad/i.test(ua) || (isMacLike && (navigator.maxTouchPoints || 0) > 1)) return 'ipados';
+    if (/CrOS/.test(ua) || platform.includes('cros') || platform.includes('chrome os')) return 'chromeos';
+    if (platform.includes('win') || /Windows/i.test(ua)) return 'windows';
+    if (isMacLike) return 'macos';
+    if (platform.includes('linux') || /Linux|X11/i.test(ua)) return 'linux';
+    return 'unknown';
+  }
+
+  // Safari never exposes userAgentData, so on Macs fall back to the WebGL
+  // renderer string: Apple Silicon reports "Apple M1/M2/..." GPUs, Intel
+  // Macs report Intel/AMD GPUs. Masked strings ("Apple GPU") stay unknown.
+  function webglArchitectureHint() {
+    try {
+      const canvas = document.createElement('canvas');
+      const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+      if (!gl) return '';
+      const ext = gl.getExtension('WEBGL_debug_renderer_info');
+      const renderer = String(
+        ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER) || ''
+      );
+      if (/Apple M\d/i.test(renderer)) return 'arm64';
+      if (/(intel|amd|radeon|iris|nvidia)/i.test(renderer)) return 'x86_64';
+      return '';
+    } catch (error) {
+      return '';
+    }
+  }
+
+  async function detectPlatform() {
+    const os = detectOS();
+    if (os !== 'macos' && os !== 'unknown') {
+      return { os, arch: '', confidence: 'high', source: 'not-mac' };
+    }
+
+    const uaData = navigator.userAgentData;
     if (uaData && typeof uaData.getHighEntropyValues === 'function') {
       try {
         const values = await uaData.getHighEntropyValues(['architecture', 'platform']);
         const hintedPlatform = String(values.platform || uaData.platform || '').toLowerCase();
         const hintedArch = normalizedArchitecture(values.architecture);
         if (hintedPlatform.includes('mac') && hintedArch) {
-          return { arch: hintedArch, confidence: 'high', source: 'userAgentData' };
+          return { os: 'macos', arch: hintedArch, confidence: 'high', source: 'userAgentData' };
         }
       } catch (error) {
         // Architecture hints are optional browser privacy surfaces.
       }
     }
 
-    if (!isMac) {
-      return { arch: '', confidence: 'none', source: 'not-mac' };
+    if (os === 'macos') {
+      const webglArch = webglArchitectureHint();
+      if (webglArch) {
+        return { os: 'macos', arch: webglArch, confidence: 'medium', source: 'webgl' };
+      }
+      return { os: 'macos', arch: '', confidence: 'low', source: 'mac-undetected' };
     }
 
-    return { arch: '', confidence: 'low', source: 'mac-undetected' };
+    return { os: 'unknown', arch: '', confidence: 'none', source: 'os-undetected' };
   }
 
   function setText(id, value) {
@@ -97,10 +147,38 @@
     if (node) node.textContent = value;
   }
 
+  function applyNotMacNotice(result) {
+    const label = OS_LABELS[result.os] || 'this device';
+    // Neutralize the CTA: an <a> without href is a non-interactive
+    // placeholder, so a Windows/Linux visitor can't download a DMG that
+    // will never run for them.
+    cta.removeAttribute('href');
+    cta.setAttribute('aria-disabled', 'true');
+    cta.classList.remove('btn-primary');
+    cta.classList.add('btn-unavailable');
+    cta.textContent = `Not available for ${label}`;
+    setText('downloadKicker', 'macOS required');
+    setText('downloadTitle', 'OpenVoiceFlow is a Mac-only app');
+    setText(
+      'downloadSubtitle',
+      `You appear to be browsing from ${label}. OpenVoiceFlow needs macOS 12 or newer — ` +
+      `there is no ${label} version, and the Mac DMGs will not run on this device. ` +
+      'Downloading for a Mac you own? Both builds stay available below.'
+    );
+    setText('downloadArchBadge', 'macOS 12+ only');
+    setText('downloadConfidence', 'Detection runs locally in your browser; nothing is uploaded.');
+  }
+
   function applyDownloadRecommendation(result) {
     document.querySelectorAll('[data-arch]').forEach(row => {
       row.classList.toggle('is-recommended', row.dataset.arch === result.arch);
     });
+
+    if (result.source === 'not-mac') {
+      applyNotMacNotice(result);
+      trackRecommendation(result);
+      return;
+    }
 
     if (result.arch && builds[result.arch]) {
       const build = builds[result.arch];
@@ -110,32 +188,28 @@
       setText('downloadTitle', build.title);
       setText('downloadSubtitle', build.subtitle);
       setText('downloadArchBadge', build.badge);
-      setText('downloadConfidence', build.confidence);
+      setText(
+        'downloadConfidence',
+        result.source === 'webgl'
+          ? 'Detected from this Mac’s GPU renderer string.'
+          : 'Detected from browser architecture hints.'
+      );
       trackRecommendation(result);
       return;
     }
 
     cta.href = builds.arm64.href;
     cta.textContent = 'Download Apple Silicon DMG';
-
-    if (result.source === 'not-mac') {
-      setText('downloadKicker', 'Mac download only');
-      setText('downloadTitle', 'Download OpenVoiceFlow for macOS');
-      setText('downloadSubtitle', 'OpenVoiceFlow currently ships for macOS 12+ on Apple Silicon and Intel Macs.');
-      setText('downloadArchBadge', 'macOS only');
-      setText('downloadConfidence', 'Both Mac builds are listed below.');
-    } else {
-      setText('downloadKicker', 'Choose your Mac build');
-      setText('downloadTitle', 'Pick Apple Silicon or Intel');
-      setText('downloadSubtitle', 'This browser did not expose enough detail to safely identify your chip.');
-      setText('downloadArchBadge', 'macOS 12+');
-      setText('downloadConfidence', 'Both Mac builds are listed below.');
-    }
+    setText('downloadKicker', 'Choose your Mac build');
+    setText('downloadTitle', 'Pick Apple Silicon or Intel');
+    setText('downloadSubtitle', 'This browser did not expose enough detail to safely identify your chip. Apple menu →  About This Mac shows it: an "Apple M…" chip needs the Apple Silicon DMG, an Intel processor needs the Intel DMG.');
+    setText('downloadArchBadge', 'macOS 12+');
+    setText('downloadConfidence', 'Both Mac builds are listed below.');
 
     trackRecommendation(result);
   }
 
-  detectMacArchitecture().then(applyDownloadRecommendation);
+  detectPlatform().then(applyDownloadRecommendation);
 })();
 
 (() => {

--- a/docs/style.css
+++ b/docs/style.css
@@ -556,6 +556,15 @@ code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace
 }
 .btn-ghost:hover { color: var(--text-primary); background: rgba(255,255,255,0.06); }
 
+/* Non-Mac visitors: the recommended-download CTA becomes an inert notice. */
+.btn-unavailable {
+  background: rgba(255,255,255,0.05);
+  color: var(--text-secondary);
+  border-color: var(--border);
+  cursor: not-allowed;
+}
+.btn-unavailable:hover { transform: none; }
+
 /* ─── Section layout ─────────────────────────────────────── */
 .section { padding: 100px 0; }
 .section-alt { background: var(--bg-alt); }

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -24,17 +24,15 @@ def test_check_record_has_required_fields() -> None:
     assert c.fix is None  # default
 
 
-def test_check_brew_uses_subprocess_which(monkeypatch) -> None:
+def test_check_brew_uses_shutil_which(monkeypatch) -> None:
+    """Binary discovery goes through shutil.which — portable, no `which`
+    subprocess (which doesn't exist on Windows and would crash there)."""
     from voiceflow import doctor
 
-    def fake_run(cmd, **kwargs):
-        class R:
-            returncode = 0
-            stdout = "/opt/homebrew/bin/brew\n"
-        assert cmd[0] == "command" or cmd[0] == "which", cmd
-        return R()
-
-    monkeypatch.setattr(doctor.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        doctor.shutil, "which",
+        lambda name: "/opt/homebrew/bin/brew" if name == "brew" else None,
+    )
     result = doctor.check_brew()
     assert result.status == doctor.Status.OK
     assert "brew" in result.name.lower()
@@ -43,13 +41,7 @@ def test_check_brew_uses_subprocess_which(monkeypatch) -> None:
 def test_check_brew_fail_when_missing(monkeypatch) -> None:
     from voiceflow import doctor
 
-    def fake_run(cmd, **kwargs):
-        class R:
-            returncode = 1
-            stdout = ""
-        return R()
-
-    monkeypatch.setattr(doctor.subprocess, "run", fake_run)
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
     result = doctor.check_brew()
     assert result.status == doctor.Status.FAIL
     assert result.fix is not None  # must offer a remedy
@@ -120,13 +112,17 @@ def test_check_pyobjc_when_missing_warns(monkeypatch) -> None:
 def test_run_all_checks_returns_list(monkeypatch) -> None:
     from voiceflow import doctor
 
+    # Pretend we're on macOS so the full check list runs on any CI host.
+    monkeypatch.setattr(doctor.platform_support, "is_macos", lambda: True)
+
     # Stub every check so the test doesn't poke at the user's real machine.
     fake = doctor.Check(
         name="stub", status=doctor.Status.OK, description="ok",
     )
     for fn_name in [
-        "check_brew", "check_whisper_cli", "check_model",
-        "check_api_key", "check_pyobjc", "check_tkinter",
+        "check_os", "check_architecture", "check_brew", "check_whisper_cli",
+        "check_model", "check_api_key", "check_pyobjc", "check_tkinter",
+        "check_microphone", "check_accessibility", "check_input_monitoring",
         "check_file_modes",
     ]:
         if fn_name in ("check_model", "check_api_key"):
@@ -137,6 +133,18 @@ def test_run_all_checks_returns_list(monkeypatch) -> None:
     results = doctor.run_all_checks({"llm_backend": "none", "whisper_model": "base.en"})
     assert isinstance(results, list)
     assert len(results) >= 5
+
+
+def test_run_all_checks_non_macos_reports_only_os(monkeypatch) -> None:
+    """Off-macOS the doctor must not emit misleading brew/whisper guidance —
+    just one clear FAIL explaining the platform requirement."""
+    from voiceflow import doctor
+
+    monkeypatch.setattr(doctor.platform_support, "is_macos", lambda: False)
+    results = doctor.run_all_checks({"llm_backend": "none", "whisper_model": "base.en"})
+    assert len(results) == 1
+    assert results[0].status == doctor.Status.FAIL
+    assert "macOS" in results[0].description
 
 
 def test_format_checks_text_renders(monkeypatch) -> None:

--- a/tests/test_launch_self_check.py
+++ b/tests/test_launch_self_check.py
@@ -58,6 +58,12 @@ def test_validate_setup_fail_calls_notify_error(stub_validate_setup_inputs, monk
 def test_validate_setup_pass_no_notify(stub_validate_setup_inputs, monkeypatch) -> None:
     appmod = stub_validate_setup_inputs
 
+    # Stub the audio backend so the happy path is hermetic on hosts
+    # without PortAudio (e.g. Linux CI).
+    import sys
+    import types
+    monkeypatch.setitem(sys.modules, "sounddevice", types.ModuleType("sounddevice"))
+
     monkeypatch.setattr(appmod, "find_whisper_cpp", lambda: "/opt/homebrew/bin/whisper-cli")
     monkeypatch.setattr(appmod, "get_model_path", lambda name: "/fake/model")
     monkeypatch.setattr(appmod.os.path, "exists", lambda p: True)

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -1,0 +1,184 @@
+"""Cross-platform compatibility guarantees.
+
+OpenVoiceFlow is macOS-only, but it must never CRASH elsewhere: a user who
+pip-installs it on Linux or Windows gets a clear "unsupported OS" message
+with uninstall guidance, and the diagnostic commands (--doctor,
+--show-config) keep working so they can inspect state first.
+
+These tests run on any host — macOS behavior is simulated via monkeypatch.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────
+# platform_support primitives
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_is_macos_matches_sys_platform() -> None:
+    from voiceflow import platform_support
+    assert platform_support.is_macos() == (sys.platform == "darwin")
+
+
+def test_macos_version_is_none_off_macos(monkeypatch) -> None:
+    from voiceflow import platform_support
+    monkeypatch.setattr(platform_support, "is_macos", lambda: False)
+    assert platform_support.macos_version() is None
+
+
+def test_macos_version_parses_tuple(monkeypatch) -> None:
+    from voiceflow import platform_support
+    monkeypatch.setattr(platform_support, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        platform_support.platform, "mac_ver", lambda: ("14.5", ("", "", ""), "arm64")
+    )
+    assert platform_support.macos_version() == (14, 5)
+
+
+def test_unsupported_message_names_os_and_uninstall() -> None:
+    from voiceflow import platform_support
+    msg = platform_support.unsupported_os_message()
+    assert "macOS" in msg
+    assert "pip uninstall openvoiceflow" in msg
+    assert ".openvoiceflow" in msg
+
+
+def test_permission_probes_never_raise() -> None:
+    """Best-effort probes must return True/False/None, never raise."""
+    from voiceflow import platform_support
+    for probe in (
+        platform_support.accessibility_status,
+        platform_support.input_monitoring_status,
+        platform_support.microphone_status,
+    ):
+        assert probe() in (True, False, None)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CLI entry-point gate
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_main_refuses_to_run_off_macos(monkeypatch, capsys) -> None:
+    """Bare `openvoiceflow` on a non-Mac exits 1 with guidance, no traceback."""
+    import voiceflow.__main__ as cli
+    monkeypatch.setattr(cli.platform_support, "is_macos", lambda: False)
+    monkeypatch.setattr(sys, "argv", ["openvoiceflow"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "macOS" in err
+    assert "pip uninstall openvoiceflow" in err
+
+
+def test_main_gate_blocks_menubar_too(monkeypatch, capsys) -> None:
+    import voiceflow.__main__ as cli
+    monkeypatch.setattr(cli.platform_support, "is_macos", lambda: False)
+    monkeypatch.setattr(sys, "argv", ["openvoiceflow", "--menubar"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+    assert excinfo.value.code == 1
+    assert "macOS" in capsys.readouterr().err
+
+
+def test_main_allows_show_config_off_macos(monkeypatch, capsys) -> None:
+    """Diagnostics survive the gate so users can inspect state pre-uninstall."""
+    import voiceflow.__main__ as cli
+    from voiceflow.config import DEFAULTS
+
+    monkeypatch.setattr(cli.platform_support, "is_macos", lambda: False)
+    monkeypatch.setattr(cli, "load_config", lambda: dict(DEFAULTS))
+    monkeypatch.setattr(sys, "argv", ["openvoiceflow", "--show-config"])
+
+    cli.main()  # must not raise SystemExit
+    out = capsys.readouterr().out
+    assert '"hotkey"' in out
+
+
+def test_main_allows_doctor_off_macos(monkeypatch, capsys) -> None:
+    import json
+
+    import voiceflow.__main__ as cli
+    from voiceflow import doctor
+    from voiceflow.config import DEFAULTS
+
+    monkeypatch.setattr(cli.platform_support, "is_macos", lambda: False)
+    monkeypatch.setattr(doctor.platform_support, "is_macos", lambda: False)
+    monkeypatch.setattr(cli, "load_config", lambda: dict(DEFAULTS))
+    monkeypatch.setattr(sys, "argv", ["openvoiceflow", "--doctor", "--json"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    assert excinfo.value.code == 1  # OS check FAILs — that's the diagnosis
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["checks"][0]["status"] == "FAIL"
+    assert "macOS" in parsed["checks"][0]["description"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Import safety — no module import may require macOS-only runtime pieces
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_recorder_imports_without_sounddevice(monkeypatch) -> None:
+    """recorder must import even when sounddevice can't (missing PortAudio).
+
+    This is the crash every non-Mac user hit: `import sounddevice` raises
+    OSError at module level without the PortAudio C library.
+    """
+    monkeypatch.setitem(sys.modules, "sounddevice", None)  # import → ImportError
+    monkeypatch.delitem(sys.modules, "voiceflow.recorder", raising=False)
+
+    import voiceflow.recorder  # must not raise
+
+    rec = voiceflow.recorder.AudioRecorder()
+    with pytest.raises(Exception):
+        rec.start()  # failure surfaces at use time, where app.py handles it
+
+
+def test_get_key_map_empty_when_pynput_unavailable(monkeypatch) -> None:
+    import voiceflow.app as appmod
+
+    monkeypatch.setattr(appmod, "AudioRecorder", lambda *a, **kw: object())
+    monkeypatch.setitem(sys.modules, "pynput", None)
+    monkeypatch.setitem(sys.modules, "pynput.keyboard", None)
+
+    vf = appmod.OpenVoiceFlow(use_overlay=False)
+    assert vf._get_key_map() == {}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Feature modules refuse politely off-macOS
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_autostart_requires_macos(monkeypatch) -> None:
+    from voiceflow import autostart
+    monkeypatch.setattr(autostart.platform_support, "is_macos", lambda: False)
+    success, msg = autostart.set_autostart(True)
+    assert success is False
+    assert "macOS" in msg
+
+
+def test_find_whisper_cpp_never_spawns_which(monkeypatch) -> None:
+    """Discovery must use shutil.which — a `which` subprocess crashes on
+    Windows (FileNotFoundError) and is slower everywhere."""
+    from voiceflow import transcriber
+
+    def forbid_run(*args, **kwargs):  # pragma: no cover - only on regression
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    monkeypatch.setattr(transcriber.subprocess, "run", forbid_run)
+    monkeypatch.setattr(transcriber.shutil, "which", lambda name: None)
+    monkeypatch.setattr(transcriber.os.path, "isfile", lambda p: False)
+
+    assert transcriber.find_whisper_cpp() is None

--- a/voiceflow/__main__.py
+++ b/voiceflow/__main__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from . import __version__
+from . import __version__, platform_support
 from .config import (
     VALID_BACKENDS,
     VALID_HOTKEYS,
@@ -159,6 +159,19 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Platform gate: OpenVoiceFlow is macOS-only. Refuse politely here —
+    # before any config write or heavy import — instead of crashing with a
+    # traceback deeper in the stack (sounddevice/pynput/pbcopy all assume
+    # macOS). Diagnostic commands stay usable so users can inspect state
+    # before uninstalling.
+    if not platform_support.is_macos() and not (args.doctor or args.show_config):
+        print(platform_support.unsupported_os_message(), file=sys.stderr)
+        sys.exit(1)
+
+    old_macos = platform_support.old_macos_warning()
+    if old_macos:
+        print(old_macos, file=sys.stderr)
 
     config = load_config()
 

--- a/voiceflow/app.py
+++ b/voiceflow/app.py
@@ -9,8 +9,8 @@ import sys
 import tempfile
 import threading
 import time
-from ctypes import CDLL, c_bool
 
+from . import platform_support
 from .config import load_config
 from .llm import cleanup_text
 from .recorder import AudioRecorder
@@ -79,23 +79,9 @@ def _maybe_voice_command_tutor(text_before: str, text_after: str) -> None:
 
 def _is_accessibility_trusted() -> bool:
     """Return True when the process is trusted for macOS Accessibility APIs."""
-    try:
-        from ApplicationServices import (  # type: ignore
-            AXIsProcessTrusted,
-        )
-        return bool(AXIsProcessTrusted())
-    except Exception:
-        pass
-
-    try:
-        app_services = CDLL(
-            "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
-        )
-        app_services.AXIsProcessTrusted.restype = c_bool
-        return bool(app_services.AXIsProcessTrusted())
-    except Exception:
-        # If we cannot query trust state, don't block startup on this check.
-        return True
+    status = platform_support.accessibility_status()
+    # If we cannot query trust state (None), don't block startup on this check.
+    return status is not False
 
 
 def _prompt_accessibility_consent() -> None:
@@ -197,12 +183,15 @@ class OpenVoiceFlow:
             else:
                 errors.append(f"Unknown LLM backend: {backend}")
 
-        # Audio
+        # Audio — sounddevice raises OSError (not ImportError) when the
+        # PortAudio C library itself is missing, so catch both.
         try:
             import sounddevice  # noqa: F401  (availability check)
             print("✅ Audio input available")
         except ImportError:
             errors.append("sounddevice not installed. Run: pip install sounddevice")
+        except OSError as e:
+            errors.append(f"Audio backend unavailable ({e}). Reinstall with: pip install sounddevice")
 
         # Accessibility / input monitoring
         if _is_accessibility_trusted():
@@ -240,8 +229,15 @@ class OpenVoiceFlow:
         return True
 
     def _get_key_map(self):
-        """Build hotkey map for available pynput keys."""
-        from pynput.keyboard import Key
+        """Build hotkey map for available pynput keys.
+
+        Returns an empty map when pynput cannot load (no macOS input
+        backend); callers treat a missing hotkey as "no key events".
+        """
+        try:
+            from pynput.keyboard import Key
+        except Exception:
+            return {}
         definitions = {
             "left_fn": "fn",
             "right_cmd": "cmd_r", "left_cmd": "cmd_l",
@@ -699,7 +695,18 @@ class OpenVoiceFlow:
 
     def run(self):
         """Start the OpenVoiceFlow listener (CLI mode)."""
-        from pynput.keyboard import Listener
+        # pynput needs a macOS input backend; on other systems (or a broken
+        # install) it can raise at import. Exit with guidance, not a traceback.
+        try:
+            from pynput.keyboard import Listener
+        except Exception as e:
+            print(f"❌ Keyboard listener unavailable ({e}).", file=sys.stderr)
+            print(
+                "   OpenVoiceFlow needs macOS to capture the dictation hotkey. "
+                "Reinstall with: pip install pynput",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         print("=" * 50)
         print("🎙️  OpenVoiceFlow — Voice Dictation")

--- a/voiceflow/autostart.py
+++ b/voiceflow/autostart.py
@@ -15,6 +15,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import platform_support
+
 LAUNCH_AGENTS_DIR = Path.home() / "Library" / "LaunchAgents"
 PLIST_NAME = "com.openvoiceflow.app.plist"
 PLIST_PATH = LAUNCH_AGENTS_DIR / PLIST_NAME
@@ -78,10 +80,33 @@ def set_autostart(enabled: bool) -> tuple[bool, str]:
     Returns:
         (success, message) tuple.
     """
+    if not platform_support.is_macos():
+        return False, (
+            "Launch at login uses macOS LaunchAgents and is not available on "
+            f"{platform_support.os_label()}."
+        )
     if enabled:
         return _enable_autostart()
     else:
         return _disable_autostart()
+
+
+def _launchctl(modern_args: list, legacy_args: list) -> subprocess.CompletedProcess:
+    """Run launchctl with the modern subcommand, falling back to the legacy one.
+
+    ``bootstrap``/``bootout`` are the supported interface on macOS 10.11+;
+    ``load``/``unload`` are deprecated but still function. Trying modern
+    first keeps us working when Apple eventually removes the legacy verbs,
+    and the fallback keeps us working everywhere they still exist.
+    """
+    result = subprocess.run(
+        ["launchctl"] + modern_args, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        result = subprocess.run(
+            ["launchctl"] + legacy_args, capture_output=True, text=True,
+        )
+    return result
 
 
 def _enable_autostart() -> tuple[bool, str]:
@@ -98,16 +123,16 @@ def _enable_autostart() -> tuple[bool, str]:
         plist_content = _build_plist(executable)
         PLIST_PATH.write_text(plist_content, encoding="utf-8")
 
+        gui_domain = f"gui/{os.getuid()}"
         # Unload first (ignore error if not loaded)
-        subprocess.run(
-            ["launchctl", "unload", str(PLIST_PATH)],
-            capture_output=True,
+        _launchctl(
+            ["bootout", gui_domain, str(PLIST_PATH)],
+            ["unload", str(PLIST_PATH)],
         )
         # Load the agent
-        result = subprocess.run(
-            ["launchctl", "load", str(PLIST_PATH)],
-            capture_output=True,
-            text=True,
+        result = _launchctl(
+            ["bootstrap", gui_domain, str(PLIST_PATH)],
+            ["load", str(PLIST_PATH)],
         )
         if result.returncode != 0:
             err = result.stderr.strip() or result.stdout.strip()
@@ -124,9 +149,9 @@ def _disable_autostart() -> tuple[bool, str]:
     """Unload and remove the LaunchAgent plist."""
     try:
         if PLIST_PATH.exists():
-            subprocess.run(
-                ["launchctl", "unload", str(PLIST_PATH)],
-                capture_output=True,
+            _launchctl(
+                ["bootout", f"gui/{os.getuid()}", str(PLIST_PATH)],
+                ["unload", str(PLIST_PATH)],
             )
             PLIST_PATH.unlink()
             return True, "LaunchAgent removed"

--- a/voiceflow/doctor.py
+++ b/voiceflow/doctor.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
+import shutil
 import urllib.error
 import urllib.request
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Optional
+
+from . import platform_support
 
 
 class Status(Enum):
@@ -90,23 +92,190 @@ def _tkinter_available() -> bool:
 # ─────────────────────────────────────────────────────────────────────
 
 
-def check_brew() -> Check:
-    try:
-        result = subprocess.run(
-            ["which", "brew"], capture_output=True, text=True, timeout=2,
-        )
-    except (subprocess.SubprocessError, OSError):
+def check_os() -> Check:
+    """Operating system + version. The first gate: everything else is moot
+    on a non-Mac, and old macOS releases miss APIs we rely on."""
+    if not platform_support.is_macos():
         return Check(
-            name="Homebrew",
+            name="Operating system",
             status=Status.FAIL,
-            description="Could not run `which brew`.",
-            fix=Fix(label="Install Homebrew", url="https://brew.sh"),
+            description=(
+                f"OpenVoiceFlow only supports macOS — detected "
+                f"{platform_support.os_label()}. Dictation cannot work here."
+            ),
+            fix=Fix(
+                label="See the support matrix (and uninstall guidance)",
+                url="https://github.com/shimoverse/openvoiceflow/blob/main/docs/COMPATIBILITY.md",
+            ),
         )
-    if result.returncode == 0 and result.stdout.strip():
+    ver = platform_support.macos_version()
+    if ver is None:
+        return Check(
+            name="Operating system",
+            status=Status.WARN,
+            description="macOS detected, but the version could not be determined.",
+        )
+    if ver < platform_support.MIN_MACOS:
+        return Check(
+            name="Operating system",
+            status=Status.FAIL,
+            description=(
+                f"{platform_support.os_label()} is below the supported minimum "
+                f"(macOS {platform_support.MIN_MACOS[0]})."
+            ),
+            fix=Fix(
+                label="Upgrade macOS via System Settings → General → Software Update",
+                url="x-apple.systempreferences:com.apple.Software-Update-Settings.extension",
+            ),
+        )
+    if ver[0] > platform_support.LATEST_TESTED_MACOS:
+        return Check(
+            name="Operating system",
+            status=Status.OK,
+            description=(
+                f"{platform_support.os_label()} — newer than the last "
+                f"maintainer-tested release (macOS {platform_support.LATEST_TESTED_MACOS}); "
+                "expected to work, please file an issue if it doesn't."
+            ),
+        )
+    return Check(
+        name="Operating system",
+        status=Status.OK,
+        description=f"{platform_support.os_label()} (supported).",
+    )
+
+
+def check_architecture() -> Check:
+    """CPU architecture + Rosetta/Homebrew mismatches.
+
+    The classic silent breakage on Apple Silicon: an x86_64 Python or an
+    Intel Homebrew under Rosetta installs an Intel whisper.cpp with no
+    Metal acceleration — everything "works" but transcription crawls.
+    """
+    arch = platform_support.arch()
+    if platform_support.is_rosetta_translated():
+        return Check(
+            name="Architecture",
+            status=Status.WARN,
+            description=(
+                "Python is running under Rosetta (x86_64 translated) on an "
+                "Apple Silicon Mac. whisper.cpp will miss Metal acceleration — "
+                "reinstall a native arm64 Python and Homebrew."
+            ),
+            fix=Fix(label="Native install guide", url="https://brew.sh"),
+        )
+    if platform_support.is_apple_silicon():
+        brew_path = shutil.which("brew") or ""
+        if brew_path.startswith("/usr/local"):
+            return Check(
+                name="Architecture",
+                status=Status.WARN,
+                description=(
+                    f"Apple Silicon ({arch}), but Intel Homebrew found at "
+                    f"{brew_path}. whisper.cpp installed from it runs under "
+                    "Rosetta without Metal — install native Homebrew "
+                    "(/opt/homebrew) and reinstall whisper-cpp."
+                ),
+                fix=Fix(label="Install native Homebrew", url="https://brew.sh"),
+            )
+        return Check(
+            name="Architecture",
+            status=Status.OK,
+            description=f"Apple Silicon ({arch}, native).",
+        )
+    return Check(
+        name="Architecture",
+        status=Status.OK,
+        description=f"Intel ({arch}).",
+    )
+
+
+def check_microphone() -> Check:
+    granted = platform_support.microphone_status()
+    if granted is True:
+        return Check(
+            name="Microphone permission",
+            status=Status.OK,
+            description="Granted.",
+        )
+    if granted is False:
+        return Check(
+            name="Microphone permission",
+            status=Status.FAIL,
+            description="Denied — recordings will be silent.",
+            fix=Fix(
+                label="Grant in System Settings → Privacy & Security → Microphone",
+                url="x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+            ),
+        )
+    return Check(
+        name="Microphone permission",
+        status=Status.OK,
+        description=(
+            "Not determined here — macOS asks on first recording. If "
+            "recordings are silent, grant access in System Settings → "
+            "Privacy & Security → Microphone."
+        ),
+    )
+
+
+def check_accessibility() -> Check:
+    trusted = platform_support.accessibility_status()
+    if trusted is True:
+        return Check(
+            name="Accessibility permission",
+            status=Status.OK,
+            description="Granted — auto-paste can send ⌘V keystrokes.",
+        )
+    if trusted is False:
+        return Check(
+            name="Accessibility permission",
+            status=Status.FAIL,
+            description="Not granted — auto-paste will fail (text stays on the clipboard).",
+            fix=Fix(
+                label="Grant in System Settings → Privacy & Security → Accessibility",
+                url="x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+            ),
+        )
+    return Check(
+        name="Accessibility permission",
+        status=Status.WARN,
+        description="Could not query the Accessibility trust state.",
+    )
+
+
+def check_input_monitoring() -> Check:
+    granted = platform_support.input_monitoring_status()
+    if granted is True:
+        return Check(
+            name="Input Monitoring permission",
+            status=Status.OK,
+            description="Granted — the dictation hotkey can be detected.",
+        )
+    if granted is False:
+        return Check(
+            name="Input Monitoring permission",
+            status=Status.FAIL,
+            description="Denied — the hotkey will never fire.",
+            fix=Fix(
+                label="Grant in System Settings → Privacy & Security → Input Monitoring",
+                url="x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
+            ),
+        )
+    return Check(
+        name="Input Monitoring permission",
+        status=Status.OK,
+        description="Not determined here — macOS asks when the hotkey listener starts.",
+    )
+
+
+def check_brew() -> Check:
+    path = shutil.which("brew")
+    if path:
         return Check(
             name="Homebrew",
             status=Status.OK,
-            description=f"Found at {result.stdout.strip()}",
+            description=f"Found at {path}",
         )
     return Check(
         name="Homebrew",
@@ -310,14 +479,27 @@ def check_file_modes() -> Check:
 
 
 def run_all_checks(config: dict) -> list:
-    """Run every check and return a list of ``Check`` records."""
+    """Run every check and return a list of ``Check`` records.
+
+    On a non-macOS machine only the OS check runs: every other check (and
+    every fix we could offer, like `brew install`) presumes macOS, so
+    reporting them would only produce misleading guidance.
+    """
+    os_check = check_os()
+    if not platform_support.is_macos():
+        return [os_check]
     return [
+        os_check,
+        check_architecture(),
         check_brew(),
         check_whisper_cli(),
         check_model(config),
         check_api_key(config),
         check_pyobjc(),
         check_tkinter(),
+        check_microphone(),
+        check_accessibility(),
+        check_input_monitoring(),
         check_file_modes(),
     ]
 

--- a/voiceflow/menubar.py
+++ b/voiceflow/menubar.py
@@ -229,7 +229,17 @@ def run_menubar():
                 )
                 return
 
-            from pynput.keyboard import Listener
+            try:
+                from pynput.keyboard import Listener
+            except Exception as e:
+                self.title = "🎙️❌"
+                self.status_item.title = "Status: Keyboard listener unavailable"
+                rumps.notification(
+                    "OpenVoiceFlow", "Keyboard Listener Error",
+                    f"Could not start the hotkey listener ({e}). "
+                    "Reinstall with: pip install pynput",
+                )
+                return
             self.listener = Listener(
                 on_press=self.vf.on_key_press,
                 on_release=self.vf.on_key_release,

--- a/voiceflow/platform_support.py
+++ b/voiceflow/platform_support.py
@@ -1,0 +1,192 @@
+"""Operating-system and hardware detection for OpenVoiceFlow.
+
+Single source of truth for "are we on a supported platform?" questions.
+OpenVoiceFlow supports macOS 12+ only; every helper here degrades to an
+informative answer (never an exception) so callers can gate features and
+print friendly guidance instead of crashing with a traceback on Linux,
+Windows, or an unsupported macOS release.
+
+See docs/COMPATIBILITY.md for the support matrix.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import platform
+import subprocess
+import sys
+from typing import Optional
+
+# Minimum supported macOS release (Monterey). Below this we refuse politely.
+MIN_MACOS = (12, 0)
+
+# Highest macOS major release the maintainers have exercised on real
+# hardware. Newer releases are expected to work; the doctor reports them
+# as untested rather than unsupported. Keep in sync with COMPATIBILITY.md.
+LATEST_TESTED_MACOS = 15
+
+
+def is_macos() -> bool:
+    """True when running on macOS (any version)."""
+    return sys.platform == "darwin"
+
+
+def macos_version() -> Optional[tuple]:
+    """Return the macOS version as an int tuple (e.g. ``(14, 5)``).
+
+    Returns None off-macOS or when the version cannot be parsed.
+    """
+    if not is_macos():
+        return None
+    ver = platform.mac_ver()[0]
+    try:
+        parts = tuple(int(p) for p in ver.split(".") if p)
+    except ValueError:
+        return None
+    return parts or None
+
+
+def os_label() -> str:
+    """Friendly OS name for user-facing messages (e.g. ``macOS 14.5``)."""
+    if is_macos():
+        ver = platform.mac_ver()[0]
+        return f"macOS {ver}".strip()
+    system = platform.system() or "an unknown operating system"
+    release = platform.release()
+    return f"{system} {release}".strip()
+
+
+def arch() -> str:
+    """Machine architecture of the running interpreter (arm64, x86_64, ...)."""
+    return platform.machine()
+
+
+def is_rosetta_translated() -> bool:
+    """True when this process is x86_64 code translated on Apple Silicon."""
+    if not is_macos():
+        return False
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "sysctl.proc_translated"],
+            capture_output=True, text=True, timeout=2,
+        )
+        return result.stdout.strip() == "1"
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def is_apple_silicon() -> bool:
+    """True on Apple Silicon hardware, even when running under Rosetta."""
+    if not is_macos():
+        return False
+    return arch() == "arm64" or is_rosetta_translated()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# macOS permission probes (best-effort; None = could not determine)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def accessibility_status() -> Optional[bool]:
+    """Whether the process is trusted for the Accessibility APIs.
+
+    Returns True/False when determinable, None when the query itself is
+    unavailable (off-macOS, or the framework could not be loaded).
+    """
+    if not is_macos():
+        return None
+    try:
+        from ApplicationServices import AXIsProcessTrusted  # type: ignore
+        return bool(AXIsProcessTrusted())
+    except Exception:
+        pass
+    try:
+        app_services = ctypes.CDLL(
+            "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
+        )
+        app_services.AXIsProcessTrusted.restype = ctypes.c_bool
+        return bool(app_services.AXIsProcessTrusted())
+    except Exception:
+        return None
+
+
+def input_monitoring_status() -> Optional[bool]:
+    """Whether Input Monitoring (keyboard event listening) is granted.
+
+    Uses ``IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)`` (macOS 10.15+).
+    Returns True when granted, False when denied, None when undetermined
+    (macOS will prompt on first use) or when the query is unavailable.
+    """
+    if not is_macos():
+        return None
+    try:
+        iokit = ctypes.CDLL("/System/Library/Frameworks/IOKit.framework/IOKit")
+        iokit.IOHIDCheckAccess.restype = ctypes.c_uint32
+        iokit.IOHIDCheckAccess.argtypes = [ctypes.c_uint32]
+        status = iokit.IOHIDCheckAccess(1)  # kIOHIDRequestTypeListenEvent
+        if status == 0:  # kIOHIDAccessTypeGranted
+            return True
+        if status == 1:  # kIOHIDAccessTypeDenied
+            return False
+        return None  # kIOHIDAccessTypeUnknown — not yet requested
+    except Exception:
+        return None
+
+
+def microphone_status() -> Optional[bool]:
+    """Whether Microphone access is granted.
+
+    Requires pyobjc-framework-AVFoundation (not part of our extras), so
+    this commonly returns None; treat None as "will be requested on first
+    recording", not as an error.
+    """
+    if not is_macos():
+        return None
+    try:
+        from AVFoundation import (  # type: ignore
+            AVCaptureDevice,
+            AVMediaTypeAudio,
+        )
+        status = AVCaptureDevice.authorizationStatusForMediaType_(AVMediaTypeAudio)
+        if status == 3:  # AVAuthorizationStatusAuthorized
+            return True
+        if status in (1, 2):  # Restricted / Denied
+            return False
+        return None  # NotDetermined — macOS prompts on first use
+    except Exception:
+        return None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# User-facing guidance
+# ─────────────────────────────────────────────────────────────────────
+
+
+def unsupported_os_message() -> str:
+    """Explain why OpenVoiceFlow cannot run here, and how to remove it."""
+    return (
+        f"OpenVoiceFlow only runs on macOS {MIN_MACOS[0]} or newer — this machine is "
+        f"running {os_label()}.\n"
+        "\n"
+        "The app depends on macOS-only services (the AppKit menu bar, pbcopy/pbpaste,\n"
+        "osascript key events, and the Accessibility APIs), so dictation cannot work\n"
+        "here. Nothing was started and nothing is running in the background.\n"
+        "\n"
+        "To remove OpenVoiceFlow from this machine:\n"
+        "  pip uninstall openvoiceflow\n"
+        "  rm -rf ~/.openvoiceflow\n"
+        "\n"
+        "Diagnostics still work: openvoiceflow --doctor / --show-config\n"
+        "Support matrix: https://github.com/shimoverse/openvoiceflow/blob/main/docs/COMPATIBILITY.md"
+    )
+
+
+def old_macos_warning() -> Optional[str]:
+    """A warning string when this macOS is older than the supported floor."""
+    ver = macos_version()
+    if ver is None or ver >= MIN_MACOS:
+        return None
+    return (
+        f"⚠️  {os_label()} is older than the supported minimum (macOS {MIN_MACOS[0]}). "
+        "OpenVoiceFlow may not work correctly — please upgrade macOS."
+    )

--- a/voiceflow/recorder.py
+++ b/voiceflow/recorder.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 import wave
 
 import numpy as np
-import sounddevice as sd
+
+
+def _import_sounddevice():
+    """Import sounddevice at call time, not module-import time.
+
+    sounddevice loads the PortAudio C library the moment it is imported and
+    raises OSError when it is missing (typical on non-macOS machines). A
+    module-level import would make ``import voiceflow.recorder`` — and with
+    it the whole app — crash before any friendly error handling can run.
+    """
+    import sounddevice as sd
+    return sd
 
 
 class AudioRecorder:
@@ -19,7 +30,13 @@ class AudioRecorder:
         self._stream = None
 
     def start(self):
-        """Start recording audio."""
+        """Start recording audio.
+
+        Raises ImportError/OSError when no audio backend is available;
+        callers (``OpenVoiceFlow.start_recording``) surface that as a
+        user-visible "microphone unavailable" error.
+        """
+        sd = _import_sounddevice()
         self.frames = []
         self.is_recording = True
         self._stream = sd.InputStream(

--- a/voiceflow/system.py
+++ b/voiceflow/system.py
@@ -19,17 +19,24 @@ def paste_text(text: str):
     instead of an invisible stderr line. The user's text is still on
     the clipboard, so a manual ⌘V always works as a fallback.
     """
-    process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
-    process.communicate(text.encode("utf-8"), timeout=5)
-    time.sleep(0.05)
-    # BUG-009 fix: capture return code and report Accessibility errors clearly
-    result = subprocess.run(
-        [
-            "osascript", "-e",
-            'tell application "System Events" to keystroke "v" using command down',
-        ],
-        capture_output=True,
-    )
+    try:
+        process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+        process.communicate(text.encode("utf-8"), timeout=5)
+        time.sleep(0.05)
+        # BUG-009 fix: capture return code and report Accessibility errors clearly
+        result = subprocess.run(
+            [
+                "osascript", "-e",
+                'tell application "System Events" to keystroke "v" using command down',
+            ],
+            capture_output=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        # pbcopy/osascript missing (non-macOS or broken PATH) — never crash
+        # the dictation thread over feedback plumbing.
+        from . import notify
+        notify.error(f"Auto-paste unavailable on this system ({exc}).")
+        return
     if result.returncode != 0:
         play_sound("error")
         # System Events → Privacy_AppleEvents (this is the pane macOS opens
@@ -53,24 +60,27 @@ def insert_recording_indicator(indicator: str = "🎙") -> bool:
 
     Returns True if insertion succeeded.
     """
-    original = subprocess.run(["pbpaste"], capture_output=True, timeout=5)
-    process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
-    process.communicate(indicator.encode("utf-8"), timeout=5)
-    _move_caret_to_end()
-    time.sleep(0.03)
-    result = subprocess.run(
-        [
-            "osascript", "-e",
-            'tell application "System Events" to keystroke "v" using command down',
-        ],
-        capture_output=True,
-    )
-    # Give the target app a moment to service the paste before restoring.
-    time.sleep(0.15)
-    if original.returncode == 0:
-        restore = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
-        restore.communicate(original.stdout, timeout=5)
-    return result.returncode == 0
+    try:
+        original = subprocess.run(["pbpaste"], capture_output=True, timeout=5)
+        process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+        process.communicate(indicator.encode("utf-8"), timeout=5)
+        _move_caret_to_end()
+        time.sleep(0.03)
+        result = subprocess.run(
+            [
+                "osascript", "-e",
+                'tell application "System Events" to keystroke "v" using command down',
+            ],
+            capture_output=True,
+        )
+        # Give the target app a moment to service the paste before restoring.
+        time.sleep(0.15)
+        if original.returncode == 0:
+            restore = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+            restore.communicate(original.stdout, timeout=5)
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
 
 
 def clear_recording_indicator() -> bool:
@@ -78,26 +88,32 @@ def clear_recording_indicator() -> bool:
 
     Returns True if the delete keystroke was sent successfully.
     """
-    _move_caret_to_end()
-    result = subprocess.run(
-        [
-            "osascript", "-e",
-            'tell application "System Events" to key code 51',
-        ],
-        capture_output=True,
-    )
-    return result.returncode == 0
+    try:
+        _move_caret_to_end()
+        result = subprocess.run(
+            [
+                "osascript", "-e",
+                'tell application "System Events" to key code 51',
+            ],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
 
 
 def _move_caret_to_end() -> None:
     """Move insertion point to end of the focused text field (best-effort)."""
-    subprocess.run(
-        [
-            "osascript", "-e",
-            'tell application "System Events" to key code 124 using command down',
-        ],
-        capture_output=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "osascript", "-e",
+                'tell application "System Events" to key code 124 using command down',
+            ],
+            capture_output=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
 
 
 def play_sound(sound_type: str = "start"):
@@ -110,7 +126,10 @@ def play_sound(sound_type: str = "start"):
     }
     path = sounds.get(sound_type)
     if path and os.path.exists(path):
-        subprocess.Popen(["afplay", path])
+        try:
+            subprocess.Popen(["afplay", path])
+        except OSError:
+            pass  # Sound feedback is best-effort
 
 
 def log_transcript(raw: str, cleaned: str, config: dict):

--- a/voiceflow/transcriber.py
+++ b/voiceflow/transcriber.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -31,13 +32,12 @@ def find_whisper_cpp() -> str | None:
     (contains 'ggml' or 'whisper.cpp'), to avoid false detection of the openai-whisper
     Python CLI.
     """
-    # Check explicit whisper.cpp names first (these are never the Python CLI)
+    # Check explicit whisper.cpp names first (these are never the Python CLI).
+    # shutil.which (not a `which` subprocess) so lookup works on any OS.
     for name in ["whisper-cli", "whisper-cpp"]:
-        result = subprocess.run(["which", name], capture_output=True, text=True)
-        if result.returncode == 0:
-            path = result.stdout.strip()
-            if path:
-                return path
+        path = shutil.which(name)
+        if path:
+            return path
 
     # Explicit known paths for whisper.cpp (not Python whisper)
     explicit_paths = [
@@ -53,11 +53,9 @@ def find_whisper_cpp() -> str | None:
             return p
 
     # Fall back to 'whisper' only if it is actually whisper.cpp
-    result = subprocess.run(["which", "whisper"], capture_output=True, text=True)
-    if result.returncode == 0:
-        path = result.stdout.strip()
-        if path and _is_whisper_cpp(path):
-            return path
+    path = shutil.which("whisper")
+    if path and _is_whisper_cpp(path):
+        return path
 
     return None
 


### PR DESCRIPTION
## Problem

The package had **no operating-system detection anywhere in the Python code** — only `install.sh` and `build-dmg.sh` checked `uname`. Users who pip-installed OpenVoiceFlow on Linux or Windows got raw tracebacks:

- **Linux:** `voiceflow/recorder.py` imported `sounddevice` at module level, which loads the PortAudio C library at import time. Without it, `import voiceflow.app` died with `OSError: PortAudio library not found` before any error handling could run. The `pynput` import in `run()` crashed similarly on headless/Wayland hosts.
- **Windows:** `find_whisper_cpp()` spawned a `which` subprocess, which doesn't exist on Windows → uncaught `FileNotFoundError` in `validate_setup()`, `transcribe()`, and `--doctor`.
- Everywhere non-Mac, `--doctor` gave misleading advice (install Homebrew), and `--autostart` wrote a `~/Library/LaunchAgents` folder on Linux.

## What changed

**New `voiceflow/platform_support.py`** — single source of truth for OS, macOS version, architecture (Apple Silicon / Intel / Rosetta translation), and the three TCC permission probes (Microphone, Accessibility, Input Monitoring). Every helper returns an answer, never raises.

**CLI platform gate** (`__main__.py`) — on a non-Mac, `openvoiceflow` prints why dictation can't work there plus uninstall guidance, and exits 1 cleanly. `--doctor`, `--show-config`, and `--version` keep working so users can inspect state first. Launching on macOS older than 12 prints an upgrade warning.

**Crash-proofing**
- `sounddevice` now imports at call time; failure surfaces as the existing "microphone unavailable" flow.
- `pynput` imports are guarded in both CLI and menu-bar modes with clear errors.
- `shutil.which` replaces `which` subprocesses (transcriber + doctor).
- `pbcopy`/`pbpaste`/`osascript`/`afplay` calls no longer propagate `FileNotFoundError`.
- `validate_setup` catches the `OSError` sounddevice actually raises for a missing PortAudio, not just `ImportError`.

**Doctor upgrades** — new checks, all with click-to-fix System Settings deep links where applicable:
- Operating system + version (FAIL below macOS 12; releases newer than the tested range are reported as expected-to-work).
- Architecture: warns when Python runs under Rosetta or when Intel Homebrew (`/usr/local`) is installed on Apple Silicon — both silently cost Metal acceleration.
- Microphone / Accessibility / Input Monitoring permissions.
- On non-macOS, the doctor reports a single accurate OS failure instead of a misleading check list.

**Autostart** — refuses politely off-macOS; prefers the supported `launchctl bootstrap`/`bootout` verbs with automatic fallback to the deprecated `load`/`unload`.

**CI** — new `non-macos-guard` job on `ubuntu-latest` pins the guarantee: every module imports, bare launch exits 1 with guidance and no traceback, `--doctor --json` emits valid JSON, and the full suite passes on Linux.

**Docs** — README requirements section, `docs/COMPATIBILITY.md` (new "Behavior on unsupported operating systems" + doctor sections), CHANGELOG, and two stale AGENTS.md entries (`--doctor` was marked "not yet implemented").

## Verification

- Baseline on Linux before the change: **8 failed, 3 errors** (all rooted in the PortAudio import crash). After: **159 passed**, `ruff check` clean.
- Manually exercised on Linux: bare launch, `--menubar`, `--version`, `--doctor` (pretty + `--json`), `--show-config` — friendly output, correct exit codes, zero tracebacks.
- Forced the full macOS doctor check list to run on a Linux host (worst case): all 12 checks complete without raising.
- Not verifiable from this environment: real-Mac behavior on Sequoia/Tahoe (permission probes, `launchctl bootstrap`, System Settings deep links). The launchctl change falls back to the legacy verbs on any failure, so behavior is unchanged where `bootstrap` misbehaves. Recommend one manual pass on real hardware before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_