### PR TITLE
Fix short dictation and first-run usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] — 2026-07-10
+
 ### Added
+- The menu-bar menu now includes a persistent **How to Use** guide, and the
+  first-run hotkey tip also appears in the floating HUD instead of relying
+  only on a potentially hidden macOS notification.
 - `voiceflow/platform_support.py`: one place for OS, macOS-version,
   architecture (Apple Silicon / Intel / Rosetta), and permission detection.
 - CLI platform gate: on Linux/Windows, `openvoiceflow` now prints a clear
@@ -30,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Chromium browsers already used architecture hints).
 
 ### Fixed
+- Short streaming dictations no longer lose the final transcript fragment
+  when `whisper-stream` exits without a trailing newline.
+- Fresh installs now use the reliable batch recorder by default. Experimental
+  real-time streaming remains available through the menu bar or
+  `--streaming on`. Existing v0.3.2 installs are reset to batch mode once and
+  can opt back into streaming afterward.
 - `voiceflow.recorder` no longer imports `sounddevice` at module load —
   the import crashed the whole app (`OSError: PortAudio library not found`)
   on machines without PortAudio before any error handling could run.
@@ -325,7 +336,11 @@ Initial release.
 
 ## Compare links
 
-[Unreleased]: https://github.com/shimoverse/openvoiceflow/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/shimoverse/openvoiceflow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/shimoverse/openvoiceflow/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/shimoverse/openvoiceflow/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/shimoverse/openvoiceflow/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Your wallet stays full. Your corrections teach the app. You decide what data lea
   ⌨️  Auto-paste — text appears at your cursor in any app
 ```
 
-**Real-time streaming.** Words appear in the overlay as you speak, not after you stop. Powered by `whisper-stream`.
+**Optional real-time streaming.** Turn on the experimental `whisper-stream` mode to see words in the overlay as you
+speak. The reliable batch recorder is the default.
 
 **Context-aware.** OpenVoiceFlow reads the app you're in, the text you have selected, and your personal profile to produce text that fits perfectly.
 
@@ -94,7 +95,7 @@ OpenVoiceFlow is a **menu-bar app**, so it does not open a normal window or
 stay in the Dock. Look for `🎙️✅` at the top-right of the screen. Click in any
 text field, hold the **Right Command (⌘)** key, speak, then release it; the
 transcribed text appears at the cursor. Click the menu-bar icon to pause
-listening or change the hotkey.
+listening, open **How to Use**, or change the hotkey.
 
 > First launch installs everything automatically, walks you through setup, and interviews you so it knows your name, your team, and your jargon from day one.
 
@@ -162,11 +163,12 @@ openvoiceflow --backend ollama    # fully local, $0
 
 Words appear in the floating overlay **as you speak**. No waiting until you release the key.
 
-Powered by `whisper-stream` (Metal-accelerated on Apple Silicon). Samples audio every 3 seconds, transcribes continuously, shows partial results live. Falls back to batch mode on Intel if needed.
+Powered by `whisper-stream` (Metal-accelerated on Apple Silicon). Samples audio every 3 seconds, transcribes
+continuously, and shows partial results live. This mode is opt-in; the reliable batch recorder is the default.
 
 ```bash
-openvoiceflow --streaming on     # default
-openvoiceflow --streaming off    # classic batch mode
+openvoiceflow --streaming on     # opt in to experimental live results
+openvoiceflow --streaming off    # default, reliable batch mode
 ```
 
 ---
@@ -465,7 +467,7 @@ Everything lives in `~/.openvoiceflow/`:
   "auto_paste": true,
   "language": "en",
   "style": "default",
-  "streaming": true,
+  "streaming": false,
   "streaming_step_ms": 3000,
   "auto_style": true,
   "auto_learn": true,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ The 28 modules under `voiceflow/`, grouped by role.
 ### Configuration & migration
 | Module | Purpose | Public symbols |
 |---|---|---|
-| `config.py` | `DEFAULTS`, validation, load/save with one-time `cleanup_prompt` → `llm_prompt` and retired Gemini → OpenRouter migrations. | `DEFAULTS`, `VALID_HOTKEYS`, `VALID_MODELS`, `VALID_BACKENDS`, `VALID_STYLES`, `load_config()`, `save_config()`, `validate_config()`, `get_api_key()`, `CONFIG_DIR`, `CONFIG_PATH`, `LOG_DIR`, `MODELS_DIR` |
+| `config.py` | `DEFAULTS`, validation, load/save, schema versioning, and one-time migrations (`cleanup_prompt` → `llm_prompt`, retired Gemini → OpenRouter, v0.3.2 streaming default → batch). | `DEFAULTS`, `CONFIG_SCHEMA_VERSION`, `VALID_HOTKEYS`, `VALID_MODELS`, `VALID_BACKENDS`, `VALID_STYLES`, `load_config()`, `save_config()`, `validate_config()`, `get_api_key()`, `CONFIG_DIR`, `CONFIG_PATH`, `LOG_DIR`, `MODELS_DIR` |
 | `_secure_io.py` | Centralized chmod-600 + JSON write helpers for every file under `~/.openvoiceflow/`. | `secure_chmod()`, `secure_write_json()` |
 
 ### Telemetry / lifecycle
@@ -246,11 +246,15 @@ Preserve these — most have explicit tests, the rest are load-bearing for trust
 
 1. **Audio never leaves the Mac.** Only `transcriber.py` and `streamer.py` touch audio, and both call local subprocess binaries. No HTTP client takes audio bytes anywhere.
 2. **Every file under `~/.openvoiceflow/` is mode 600.** New persistence sites must go through `_secure_io.secure_write_json` / `secure_chmod`. Enforced by `tests/test_chmod_600.py`.
-3. **Config migrations run at most once.** `config._migrate_cleanup_to_llm_prompt` and `config._migrate_gemini_to_openrouter` mutate and persist the stored dict; tests in `tests/test_config_migration.py` pin this.
+3. **Config migrations run at most once.** The cleanup-prompt, retired-Gemini,
+   and v0.3.2 streaming-default migrations mutate and persist the stored dict.
+   The streaming reset is fixed to schema v1 so future schema bumps do not
+   override a later user opt-in. Tests in `tests/test_config_migration.py`,
+   `tests/test_privacy_defaults.py`, and `tests/test_onboarding.py` pin this.
 4. **`LLMBackend.cleanup` signature is fixed:** `cleanup(raw_text, context=None, app_context=None, override_style=None) -> str`. All backends conform; the orchestrator passes all four args. Don't break this.
 5. **Voice commands run BEFORE LLM cleanup.** That's how `"new line"` becomes an actual newline at zero added latency, and the LLM sees the formatted text as input.
 6. **Snippets run AFTER cleanup (well, instead of it) and BEFORE paste.** A matched snippet short-circuits the LLM call. Don't move that check.
-7. **Privacy defaults are opt-in.** `log_transcripts` is `False` for fresh installs; `auto_learn` is `False` by default. `tests/test_privacy_defaults.py` pins this. Existing users keep their current setting because `load_config` merges DEFAULTS *under* stored config.
+7. **Privacy defaults are opt-in.** `log_transcripts` is `False` for fresh installs; `auto_learn` is `False` by default. `tests/test_privacy_defaults.py` pins this. Existing stored settings override DEFAULTS, except for explicitly documented one-time migrations such as the v0.3.3 reset of v0.3.2's unreliable streaming default.
 8. **`from __future__ import annotations`** is present in every module so `str | None` annotations don't break Python 3.9. `tests/test_python39_compat.py` asserts this.
 
 ## 9. Build, ship, and CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openvoiceflow"
-version = "0.3.2"
+version = "0.3.3"
 description = "Free voice dictation for macOS — local transcription + optional LLM cleanup"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_menubar_initialization.py
+++ b/tests/test_menubar_initialization.py
@@ -43,5 +43,17 @@ def test_ready_tip_teaches_menu_bar_hotkey(monkeypatch) -> None:
 
     assert len(calls) == 1
     assert "menu bar" in calls[0][0]
-    assert "right_cmd" in calls[0][0]
-    assert calls[0][1]["once_key"] == "menubar_ready"
+    assert "Right Command" in calls[0][0]
+    assert len(calls[0][0]) <= 72
+    assert calls[0][1]["once_key"] == "menubar_ready_v033"
+
+
+def test_usage_instructions_explain_menu_bar_and_hotkey() -> None:
+    from voiceflow.menubar import _usage_instructions
+
+    message = _usage_instructions("right_cmd")
+
+    assert "menu bar" in message
+    assert "Right Command (⌘)" in message
+    assert "hold" in message.lower()
+    assert "release" in message.lower()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -100,7 +100,7 @@ def test_success_emits(silent_emitters) -> None:
 
 
 def test_tip_with_once_key_fires_only_once(isolated_seen_tips, silent_emitters) -> None:
-    notif, _ = silent_emitters
+    notif, overlay = silent_emitters
     from voiceflow import notify
 
     notify.tip("Try saying 'comma' for ,", once_key="voice_commands_intro")
@@ -109,6 +109,7 @@ def test_tip_with_once_key_fires_only_once(isolated_seen_tips, silent_emitters) 
 
     # Only the first call should have hit the emitter.
     assert len(notif) == 1
+    assert [call[0] for call in overlay] == ["show_info"]
 
 
 def test_tip_without_once_key_fires_every_time(isolated_seen_tips, silent_emitters) -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -13,6 +13,8 @@ visible to the user via stderr and (when tkinter is available)
 from __future__ import annotations
 
 import importlib
+import json
+from pathlib import Path
 
 
 def test_interview_error_is_surfaced_to_stderr(monkeypatch, capsys) -> None:
@@ -70,3 +72,39 @@ def test_silent_pass_pattern_is_gone() -> None:
         "launch_interview_then_close still uses `except Exception: pass`. "
         "Surface the error instead (stderr + messagebox)."
     )
+
+
+class _Value:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def get(self) -> str:
+        return self.value
+
+
+def test_finish_setup_applies_legacy_streaming_migration(monkeypatch, tmp_path: Path) -> None:
+    """Onboarding must not stamp schema v1 while retaining v0.3.2 streaming."""
+    import voiceflow.onboarding as ob
+
+    config_dir = tmp_path / ".openvoiceflow"
+    config_dir.mkdir()
+    config_path = config_dir / "config.json"
+    config_path.write_text(json.dumps({"streaming": True, "style": "formal"}))
+    monkeypatch.setattr(ob, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(ob, "CONFIG_PATH", config_path)
+
+    wizard = object.__new__(ob.OnboardingWizard)
+    wizard.config = {}
+    wizard.selected_backend = _Value("none")
+    wizard.selected_hotkey = _Value("right_cmd")
+    wizard.api_key = _Value("")
+    wizard._prefill_key = ""
+    wizard._prefill_backend = ""
+    wizard.show_success = lambda: None
+
+    wizard.save_and_finish()
+
+    saved = json.loads(config_path.read_text())
+    assert saved["streaming"] is False
+    assert saved["_config_version"] == 1
+    assert saved["style"] == "formal"

--- a/tests/test_overlay_layout.py
+++ b/tests/test_overlay_layout.py
@@ -1,0 +1,50 @@
+"""Layout regressions for the floating HUD."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class _Window:
+    def __init__(self) -> None:
+        self.frame = None
+
+    def setFrame_display_(self, frame, display) -> None:
+        self.frame = (frame, display)
+
+
+class _Label:
+    def __init__(self) -> None:
+        self.frame = None
+
+    def setFrame_(self, frame) -> None:
+        self.frame = frame
+
+
+def test_resize_updates_window_and_label(monkeypatch) -> None:
+    import voiceflow.overlay as overlay_module
+
+    screen = SimpleNamespace(
+        frame=lambda: SimpleNamespace(size=SimpleNamespace(width=1000)),
+    )
+    monkeypatch.setattr(
+        overlay_module,
+        "NSScreen",
+        SimpleNamespace(mainScreen=lambda: screen),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        overlay_module,
+        "NSMakeRect",
+        lambda x, y, width, height: (x, y, width, height),
+        raising=False,
+    )
+
+    hud = object.__new__(overlay_module.FloatingOverlay)
+    hud._window = _Window()
+    hud._label = _Label()
+
+    hud._resize(650)
+
+    assert hud._window.frame == ((175, 80, 650, 40), True)
+    assert hud._label.frame == (10, 5, 630, 30)

--- a/tests/test_privacy_defaults.py
+++ b/tests/test_privacy_defaults.py
@@ -73,7 +73,45 @@ def test_auto_learn_existing_true_is_preserved(isolated_config: Path) -> None:
     assert config["auto_learn"] is True
 
 
+def test_streaming_default_off_for_fresh_install(isolated_config: Path) -> None:
+    """Fresh installs use the reliable batch recorder until streaming is enabled."""
+    config = cfg.load_config()
+    assert config["streaming"] is False
+
+
+def test_streaming_old_default_true_migrates_off(isolated_config: Path) -> None:
+    """v0.3.2's persisted-on default is reset to the reliable recorder once."""
+    _write(isolated_config, {"streaming": True})
+    config = cfg.load_config()
+    assert config["streaming"] is False
+
+    on_disk = json.loads(isolated_config.read_text())
+    assert on_disk["streaming"] is False
+    assert on_disk["_config_version"] == cfg.CONFIG_SCHEMA_VERSION
+
+
+def test_streaming_reenabled_after_migration_is_preserved(isolated_config: Path) -> None:
+    """After the one-time reset, a user can opt back into streaming."""
+    _write(
+        isolated_config,
+        {"streaming": True, "_config_version": cfg.CONFIG_SCHEMA_VERSION},
+    )
+    config = cfg.load_config()
+    assert config["streaming"] is True
+
+
+def test_streaming_reset_does_not_rerun_after_future_schema_bump(monkeypatch) -> None:
+    """The v1 reset stays one-time when unrelated schema versions are added."""
+    stored = {"streaming": True, "_config_version": 1}
+    monkeypatch.setattr(cfg, "CONFIG_SCHEMA_VERSION", 2)
+
+    assert cfg._migrate_streaming_default(stored) is False
+    assert stored["streaming"] is True
+
+
 def test_default_dict_reflects_privacy_defaults() -> None:
     """``DEFAULTS`` itself encodes the privacy posture; no leakage via direct read."""
     assert cfg.DEFAULTS["log_transcripts"] is False
     assert cfg.DEFAULTS["auto_learn"] is False
+    assert cfg.DEFAULTS["streaming"] is False
+    assert cfg.DEFAULTS["_config_version"] == cfg.CONFIG_SCHEMA_VERSION

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,0 +1,60 @@
+"""Regression tests for the whisper-stream subprocess wrapper."""
+
+from __future__ import annotations
+
+import threading
+
+from voiceflow.streamer import StreamingTranscriber
+
+
+class _TrailingStdout:
+    """Yield one final non-newline transcript only after process shutdown."""
+
+    def __init__(self) -> None:
+        self.released = threading.Event()
+        self.emitted = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> str:
+        if not self.released.wait(timeout=1.0):
+            raise StopIteration
+        if self.emitted:
+            raise StopIteration
+        self.emitted = True
+        return " final words"
+
+    def close(self) -> None:
+        pass
+
+
+class _ProcessWithTrailingStdout:
+    def __init__(self) -> None:
+        self.stdout = _TrailingStdout()
+        self.stopped = False
+
+    def poll(self):
+        return 0 if self.stopped else None
+
+    def send_signal(self, _signal) -> None:
+        self.stopped = True
+        self.stdout.released.set()
+
+    def wait(self, timeout=None) -> int:
+        return 0
+
+    def kill(self) -> None:
+        self.stopped = True
+        self.stdout.released.set()
+
+
+def test_stop_drains_unterminated_final_transcript() -> None:
+    """Text flushed without a newline must survive a normal stop."""
+    streamer = StreamingTranscriber("model.bin")
+    streamer._proc = _ProcessWithTrailingStdout()
+    streamer._running = True
+    streamer._reader_thread = threading.Thread(target=streamer._read_output)
+    streamer._reader_thread.start()
+
+    assert streamer.stop() == "final words"

--- a/voiceflow/__init__.py
+++ b/voiceflow/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __author__ = "Shimoverse"
 __app_name__ = "OpenVoiceFlow"

--- a/voiceflow/app.py
+++ b/voiceflow/app.py
@@ -309,7 +309,7 @@ class OpenVoiceFlow:
 
     def _streaming_enabled(self) -> bool:
         """Return True if streaming mode is configured and the binary is available."""
-        if not self.config.get("streaming", True):
+        if not self.config.get("streaming", False):
             return False
         from .streamer import find_whisper_stream
         if find_whisper_stream():

--- a/voiceflow/config.py
+++ b/voiceflow/config.py
@@ -13,7 +13,11 @@ CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
 LOG_DIR = Path(CONFIG_DIR) / "logs"
 MODELS_DIR = Path(CONFIG_DIR) / "models"
 
+CONFIG_SCHEMA_VERSION = 1
+_STREAMING_DEFAULT_MIGRATION_VERSION = 1
+
 DEFAULTS = {
+    "_config_version": CONFIG_SCHEMA_VERSION,
     "hotkey": "right_cmd",
     "whisper_model": "base.en",
     "whisper_cpp_path": None,
@@ -79,7 +83,8 @@ DEFAULTS = {
     # Selected text context capture (Feature 4)
     "selected_text_context": True,  # Capture selected text as LLM context on hotkey press
     # Real-time streaming transcription (Feature 1)
-    "streaming": True,             # Use whisper-stream for real-time transcription
+    # Opt-in until whisper-stream can reliably finalize sub-step dictations.
+    "streaming": False,            # Use whisper-stream for real-time transcription
     "streaming_step_ms": 3000,     # Audio step size in milliseconds for streaming
     # Auto-learn corrections from user edits after paste.
     # Strong privilege (reads focused text field via Accessibility API for
@@ -138,6 +143,22 @@ def _migrate_gemini_to_openrouter(stored: dict) -> bool:
     return migrated
 
 
+def _migrate_streaming_default(stored: dict) -> bool:
+    """Reset v0.3.2's persisted streaming default to reliable batch mode.
+
+    v0.3.2 wrote the entire defaults dictionary on first launch, so nearly
+    every existing config contains ``streaming: true`` even when the user did
+    not opt in. Stamp the first schema version and reset streaming once. A
+    later explicit opt-in is preserved because the schema marker is present.
+    """
+    version = stored.get("_config_version")
+    if isinstance(version, int) and version >= _STREAMING_DEFAULT_MIGRATION_VERSION:
+        return False
+    stored["streaming"] = False
+    stored["_config_version"] = CONFIG_SCHEMA_VERSION
+    return True
+
+
 def load_config() -> dict:
     os.makedirs(CONFIG_DIR, exist_ok=True)
     from ._secure_io import secure_dir
@@ -170,7 +191,8 @@ def load_config() -> dict:
         return dict(DEFAULTS)
     prompt_migrated = _migrate_cleanup_to_llm_prompt(stored)
     backend_migrated = _migrate_gemini_to_openrouter(stored)
-    migrated = prompt_migrated or backend_migrated
+    streaming_migrated = _migrate_streaming_default(stored)
+    migrated = prompt_migrated or backend_migrated or streaming_migrated
     # Merge with defaults so new fields are always present
     config = dict(DEFAULTS)
     config.update(stored)
@@ -186,6 +208,11 @@ def load_config() -> dict:
             print(
                 "ℹ️  Migrated retired Gemini backend config to OpenRouter. "
                 "Set `openrouter_api_key` or OPENROUTER_API_KEY before using cloud cleanup."
+            )
+        if streaming_migrated:
+            print(
+                "ℹ️  Reset experimental streaming to the reliable batch recorder "
+                "for v0.3.3. Re-enable it from the menu bar if you prefer live results."
             )
     return config
 

--- a/voiceflow/menubar.py
+++ b/voiceflow/menubar.py
@@ -16,15 +16,34 @@ def _clear_submenu(menu) -> None:
         menu.clear()
 
 
+_HOTKEY_LABELS = {
+    "right_cmd": "Right Command (⌘)",
+    "left_cmd": "Left Command (⌘)",
+    "left_fn": "Fn",
+    "right_alt": "Right Option (⌥)",
+    "left_alt": "Left Option (⌥)",
+    "right_ctrl": "Right Control (⌃)",
+}
+
+
+def _usage_instructions(hotkey: str) -> str:
+    """Return concise, user-facing instructions for the active hotkey."""
+    label = _HOTKEY_LABELS.get(hotkey, hotkey.upper())
+    return (
+        f"Hold {label} in any text field, speak, then release to paste. "
+        "OpenVoiceFlow stays in the menu bar (🎙️✅); click its icon for settings."
+    )
+
+
 def _show_ready_tip(hotkey: str) -> None:
     """Teach first-time users where the app lives and how to dictate."""
     try:
         from . import notify
 
+        label = _HOTKEY_LABELS.get(hotkey, hotkey.upper())
         notify.tip(
-            "OpenVoiceFlow is ready in the menu bar. Click in any text field, "
-            f"hold [{hotkey}], speak, then release to paste.",
-            once_key="menubar_ready",
+            f"menu bar 🎙️✅ — hold {label}, speak, release to paste.",
+            once_key="menubar_ready_v033",
         )
     except Exception:
         pass
@@ -57,6 +76,7 @@ def run_menubar():
             self.start_stop_item = rumps.MenuItem("▶ Start Listening", callback=self.toggle)
             self.status_item = rumps.MenuItem("Status: Stopped")
             self.status_item.set_callback(None)
+            self.usage_item = rumps.MenuItem("❓ How to Use", callback=self.show_usage)
 
             # Backend submenu
             self.backend_menu = rumps.MenuItem("LLM Backend")
@@ -110,6 +130,7 @@ def run_menubar():
             self.menu = [
                 self.start_stop_item,
                 self.status_item,
+                self.usage_item,
                 self.detected_app_item,
                 None,  # separator
                 self.backend_menu,
@@ -191,7 +212,7 @@ def run_menubar():
             return "✓ Launch at Login" if enabled else "  Launch at Login"
 
         def _streaming_label(self) -> str:
-            enabled = self.config.get("streaming", True)
+            enabled = self.config.get("streaming", False)
             return "✓ Streaming Transcription" if enabled else "  Streaming Transcription"
 
         def _auto_style_label(self) -> str:
@@ -338,7 +359,7 @@ def run_menubar():
 
         def toggle_streaming(self, _):
             """Toggle streaming transcription on/off."""
-            current = self.config.get("streaming", True)
+            current = self.config.get("streaming", False)
             self._set_config_flag("streaming", not current)
             self.streaming_item.title = self._streaming_label()
             state_str = "enabled" if not current else "disabled"
@@ -362,6 +383,14 @@ def run_menubar():
             rumps.notification("OpenVoiceFlow", "Auto-Learn", f"Correction learning {state_str}")
 
         # ── Feature handlers ───────────────────────────────────────────────
+
+        def show_usage(self, _):
+            """Show persistent instructions when the user asks for help."""
+            hotkey = self.config.get("hotkey", "right_cmd")
+            rumps.alert(
+                title="How to Use OpenVoiceFlow",
+                message=_usage_instructions(hotkey),
+            )
 
         def show_stats(self, _):
             """Show statistics in a rumps alert dialog."""

--- a/voiceflow/notify.py
+++ b/voiceflow/notify.py
@@ -221,3 +221,4 @@ def tip(
         seen.add(once_key)
         _save_seen_tips(seen)
     _post_macos_notification(title, message)
+    _overlay_show("show_info", message)

--- a/voiceflow/onboarding.py
+++ b/voiceflow/onboarding.py
@@ -494,6 +494,9 @@ class OnboardingWizard:
         # reason `log_transcripts` quietly stayed True for fresh wizard
         # users even after the DEFAULTS-level flip in v0.3).
         from .config import DEFAULTS as _CONFIG_DEFAULTS
+        from .config import _migrate_streaming_default
+
+        _migrate_streaming_default(self.config)
         for k, v in _CONFIG_DEFAULTS.items():
             if k not in self.config:
                 self.config[k] = v

--- a/voiceflow/overlay.py
+++ b/voiceflow/overlay.py
@@ -185,6 +185,7 @@ class FloatingOverlay:
             self._label.setTextColor_(NSColor.whiteColor())
             self._label.setFont_(NSFont.systemFontOfSize_weight_(13, 0.3))
             self._label.setAlignment_(NSTextAlignmentCenter)
+            self._label.setAutoresizingMask_(NSViewWidthSizable)
             self._label.setStringValue_("")
             content.addSubview_(self._label)
 
@@ -197,6 +198,19 @@ class FloatingOverlay:
             print(f"⚠️  Overlay init failed: {e}")
             self._initialized = False
 
+    def _resize(self, width: float, height: float | None = None, y: float | None = None):
+        """Resize the HUD and its label, keeping the window centered."""
+        height = self.HEIGHT if height is None else height
+        y = self.MARGIN_BOTTOM if y is None else y
+        screen = NSScreen.mainScreen()
+        if not screen:
+            return
+        screen_frame = screen.frame()
+        x = (screen_frame.size.width - width) / 2
+        frame = NSMakeRect(x, y, width, height)
+        self._window.setFrame_display_(frame, True)
+        self._label.setFrame_(NSMakeRect(10, 5, width - 20, height - 10))
+
     def show_recording(self, style_label: str | None = None, with_context: bool = False):
         """Show recording indicator (red dot + "Recording...").
 
@@ -208,6 +222,31 @@ class FloatingOverlay:
             return
         self._perform_on_main(self._show_recording, style_label, with_context)
 
+    def show_info(self, message: str, duration: float = 6.0):
+        """Show a brief informational tip in the floating HUD."""
+        if not HAS_APPKIT:
+            return
+        self._perform_on_main(self._show_info, message, duration)
+
+    def _show_info(self, message, duration):
+        if not self._initialized:
+            self._setup()
+        if not self._initialized:
+            return
+        self._cancel_hide_timer()
+        self._animator.stopAnimation()
+        display = message if len(message) <= 72 else message[:69] + "..."
+        self._label.setStringValue_(f"💡 {display}")
+        self._label.setTextColor_(NSColor.whiteColor())
+        self._label.setFont_(NSFont.systemFontOfSize_weight_(13, 0.3))
+
+        text_width = max(self.WIDTH, min(650, len(display) * 8 + 40))
+        self._resize(text_width)
+
+        if self._window.alphaValue() < 0.5:
+            self._fade_in()
+        self._schedule_hide(duration)
+
     def _show_recording(self, style_label=None, with_context=False):
         if not self._initialized:
             self._setup()
@@ -215,6 +254,7 @@ class FloatingOverlay:
             return
         self._cancel_hide_timer()
         self._animator.stopAnimation()
+        self._resize(self.WIDTH)
         label = "🔴 Recording"
         if style_label:
             label += f" [{style_label}]"
@@ -237,6 +277,7 @@ class FloatingOverlay:
         self._cancel_hide_timer()
         self._animator.stopAnimation()
         display = text if len(text) <= 35 else "…" + text[-32:]
+        self._resize(max(self.WIDTH, min(400, len(display) * 8 + 40)))
         self._label.setStringValue_(f"🎙 {display}")
         self._label.setTextColor_(NSColor.colorWithWhite_alpha_(0.9, 1.0))
         if self._window.alphaValue() < 0.5:
@@ -252,6 +293,7 @@ class FloatingOverlay:
         if not self._initialized:
             return
         self._cancel_hide_timer()
+        self._resize(self.WIDTH)
         self._label.setStringValue_("Processing...")
         self._label.setTextColor_(NSColor.colorWithWhite_alpha_(0.9, 1.0))
         self._animator.startProcessingAnimation()
@@ -284,12 +326,7 @@ class FloatingOverlay:
 
         # Auto-resize window width for longer text
         text_width = max(self.WIDTH, min(400, len(display) * 9 + 40))
-        screen = NSScreen.mainScreen()
-        if screen:
-            screen_frame = screen.frame()
-            x = (screen_frame.size.width - text_width) / 2
-            frame = NSMakeRect(x, self.MARGIN_BOTTOM, text_width, self.HEIGHT)
-            self._window.setFrame_display_(frame, True)
+        self._resize(text_width)
 
         if self._window.alphaValue() < 0.5:
             self._fade_in()
@@ -322,13 +359,7 @@ class FloatingOverlay:
 
         # Compact pill width
         text_width = max(160, min(350, len(display) * 8 + 40))
-        screen = NSScreen.mainScreen()
-        if screen:
-            screen_frame = screen.frame()
-            x = (screen_frame.size.width - text_width) / 2
-            # Position slightly lower than main overlay
-            frame = NSMakeRect(x, self.MARGIN_BOTTOM - 10, text_width, 32)
-            self._window.setFrame_display_(frame, True)
+        self._resize(text_width, height=32, y=self.MARGIN_BOTTOM - 10)
 
         if self._window.alphaValue() < 0.5:
             self._fade_in()
@@ -346,6 +377,7 @@ class FloatingOverlay:
             return
         self._animator.stopAnimation()
         display = message if len(message) <= 35 else message[:32] + "..."
+        self._resize(max(self.WIDTH, min(400, len(display) * 8 + 40)))
         self._label.setStringValue_(f"❌ {display}")
         self._label.setTextColor_(NSColor.colorWithRed_green_blue_alpha_(1.0, 0.4, 0.4, 1.0))
         if self._window.alphaValue() < 0.5:

--- a/voiceflow/streamer.py
+++ b/voiceflow/streamer.py
@@ -189,8 +189,6 @@ class StreamingTranscriber:
         """Background thread: read whisper-stream stdout line by line."""
         try:
             for raw_line in self._proc.stdout:
-                if not self._running:
-                    break
                 cleaned = _clean_line(raw_line)
                 if not cleaned:
                     continue


### PR DESCRIPTION
## Summary

- fix the streaming shutdown race that discarded the final unterminated transcript
- reset v0.3.2 installs to the reliable batch recorder once and make batch the fresh-install default
- preserve a later user opt-in to experimental streaming through a versioned config migration
- add a visible first-run HUD tip and a persistent **How to Use** menu item
- prepare version 0.3.3 and document the behavior change

## Root cause

`whisper-stream` flushes partial text without always adding a newline. On hotkey release, OpenVoiceFlow marked its reader stopped before terminating the subprocess. The final buffered fragment arrived at EOF and was discarded, so normal short dictations often ended as “No speech detected.”

Version 0.3.2 also persisted `streaming: true` into every fresh config, so changing only the default would not repair existing installs. The v0.3.3 schema migration resets that old default once; a subsequent explicit opt-in is preserved.

## Verification

- `pytest -q` — 167 passed
- `ruff check voiceflow/` — passed
- `python -m build` — passed
- `twine check dist/*.whl dist/*.tar.gz` — passed
- local arm64 DMG — version/architecture/source payload verified; launcher smoke test passed
- installed v0.3.2 reproduction — batch dictation transcribed the spoken test accurately and pasted it into TextEdit

## Release follow-up

After this PR is green and merged, tag `v0.3.3`, wait for the signed/notarized release DMGs, verify both artifacts, then update the website-hosted downloads and checksums in a separate PR.
