### PR TITLE
Polish the macOS menu bar and app identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] — 2026-07-10
+
+### Added
+- A polished native menu-bar experience led by **Open OpenVoiceFlow**, with
+  grouped Dictation Shortcut, AI Cleanup, Writing Style, Personalization, and
+  Advanced menus.
+- A user-triggered **Check for Updates…** action that always reports whether a
+  release is available, the app is current, or the service could not be
+  reached.
+- Direct menu links to macOS Microphone and Accessibility settings.
+
+### Changed
+- The status item now uses dark-mode-safe SF Symbols with accessible labels:
+  a waveform while ready, a pause symbol while paused, and a warning symbol
+  when setup needs attention. A visible `OpenVoiceFlow` text label remains as
+  the fallback if symbols are unavailable.
+- Menu selections now use native macOS checkmarks, clean human-readable names,
+  every supported dictation shortcut, standard separators, and **⌘Q** for
+  **Quit OpenVoiceFlow** instead of emoji-prefixed labels.
+- The long-lived Python UI process now stays out of the Dock and uses the
+  bundled OpenVoiceFlow icon for native dialogs. The Current App row refreshes
+  as focus changes without mistaking the UI process for the user's app.
+
+### Fixed
+- The waveform status item is created before backend validation begins, so a
+  slow local backend no longer makes launch look unresponsive.
+- **Edit Profile** now runs its Tk interview in an isolated process instead of
+  risking a native Tk crash in the menu-bar process.
+- The **Download** button in the update alert now recognizes AppKit's native
+  button result and opens the release page correctly.
+
 ## [0.3.3] — 2026-07-10
 
 ### Added
@@ -336,7 +367,8 @@ Initial release.
 
 ## Compare links
 
-[Unreleased]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/shimoverse/openvoiceflow/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ For the simplest signed install, download OpenVoiceFlow from the website. The so
 
 Open the website-hosted DMG, drag OpenVoiceFlow to Applications, then launch it.
 
-OpenVoiceFlow is a **menu-bar app**, so it does not open a normal window or
-stay in the Dock. Look for `🎙️✅` at the top-right of the screen. Click in any
-text field, hold the **Right Command (⌘)** key, speak, then release it; the
-transcribed text appears at the cursor. Click the menu-bar icon to pause
-listening, open **How to Use**, or change the hotkey.
+OpenVoiceFlow is a **menu-bar app**, so it does not stay in the Dock. Look for
+the monochrome **waveform icon** at the top-right of the screen. Click it for a
+native macOS menu whose first action is **Open OpenVoiceFlow**; the same menu
+lets you pause listening, change the dictation shortcut, select AI cleanup and
+writing styles, open permission settings, and **Check for Updates**.
+
+To dictate, click in any text field, hold the **Right Command (⌘)** key, speak,
+then release it. The transcribed text appears at the cursor. The icon changes
+to a pause or warning symbol when listening is paused or setup needs attention.
 
 > First launch installs everything automatically, walks you through setup, and interviews you so it knows your name, your team, and your jargon from day one.
 

--- a/build-dmg.sh
+++ b/build-dmg.sh
@@ -137,6 +137,7 @@ PLIST
 TARGET_ARCH="$LAUNCHER_ARCH"
 APP_DIR="\$(cd "\$(dirname "\$0")/.." && pwd)"
 RESOURCES="\$APP_DIR/Resources"
+export OPENVOICEFLOW_APP_RESOURCES="\$RESOURCES"
 HOME_DIR="\$HOME/.openvoiceflow"
 VENV="\$HOME_DIR/venv"
 LOG_DIR="\$HOME/OpenVoiceFlow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openvoiceflow"
-version = "0.3.3"
+version = "0.3.4"
 description = "Free voice dictation for macOS — local transcription + optional LLM cleanup"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_macos_permissions_packaging.py
+++ b/tests/test_macos_permissions_packaging.py
@@ -64,3 +64,14 @@ def test_tk_onboarding_runs_outside_the_long_lived_menu_process() -> None:
     assert "import subprocess" in build_script
     assert "subprocess.run([sys.executable, '-c', onboarding_code]" in build_script
     assert "Onboarding process exited with status" in build_script
+
+
+def test_python_menu_process_keeps_the_openvoiceflow_app_identity() -> None:
+    """The rumps child must remain a Dock-less app with the bundled icon."""
+    build_script = BUILD_SCRIPT.read_text(encoding="utf-8")
+    menubar = (ROOT / "voiceflow" / "menubar.py").read_text(encoding="utf-8")
+
+    assert 'export OPENVOICEFLOW_APP_RESOURCES="\\$RESOURCES"' in build_script
+    assert "NSApplicationActivationPolicyAccessory" in menubar
+    assert "setActivationPolicy_" in menubar
+    assert "setApplicationIconImage_" in menubar

--- a/tests/test_menubar_initialization.py
+++ b/tests/test_menubar_initialization.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
 
 class FakeMenu:
     def __init__(self, initialized: bool) -> None:
@@ -45,7 +51,7 @@ def test_ready_tip_teaches_menu_bar_hotkey(monkeypatch) -> None:
     assert "menu bar" in calls[0][0]
     assert "Right Command" in calls[0][0]
     assert len(calls[0][0]) <= 72
-    assert calls[0][1]["once_key"] == "menubar_ready_v033"
+    assert calls[0][1]["once_key"] == "menubar_ready_v034"
 
 
 def test_usage_instructions_explain_menu_bar_and_hotkey() -> None:
@@ -57,3 +63,273 @@ def test_usage_instructions_explain_menu_bar_and_hotkey() -> None:
     assert "Right Command (⌘)" in message
     assert "hold" in message.lower()
     assert "release" in message.lower()
+    assert "waveform icon" in message
+    assert "🎙️✅" not in message
+
+
+def test_main_menu_is_branded_and_uses_standard_shortcuts() -> None:
+    from voiceflow.menubar import _MAIN_MENU_LAYOUT, _MENU_ITEM_SPECS
+
+    visible_ids = [item_id for item_id in _MAIN_MENU_LAYOUT if item_id is not None]
+
+    assert visible_ids[0] == "open"
+    assert _MENU_ITEM_SPECS["open"] == ("Open OpenVoiceFlow", None)
+    assert visible_ids[-1] == "quit"
+    assert _MENU_ITEM_SPECS["quit"] == ("Quit OpenVoiceFlow", "q")
+    assert _MAIN_MENU_LAYOUT.count(None) >= 4
+
+
+def test_informational_panels_do_not_use_input_ellipsis() -> None:
+    from voiceflow.menubar import _MENU_ITEM_SPECS
+
+    assert _MENU_ITEM_SPECS["stats"][0] == "Usage Statistics"
+    assert _MENU_ITEM_SPECS["usage"][0] == "How to Use"
+
+
+def test_menu_labels_are_native_text_without_emoji_or_manual_checkmarks() -> None:
+    from voiceflow.menubar import _MENU_ITEM_SPECS
+
+    labels = [title for title, _key in _MENU_ITEM_SPECS.values()]
+    forbidden = ("✓", "🎙", "✅", "❌", "▶", "⏸", "📊", "📖", "📌", "👤", "❓")
+
+    assert all(not any(marker in label for marker in forbidden) for label in labels)
+
+
+def test_hotkey_menu_offers_every_supported_shortcut_with_human_labels() -> None:
+    from voiceflow.config import VALID_HOTKEYS
+    from voiceflow.menubar import _hotkey_choices
+
+    choices = _hotkey_choices("right_cmd")
+
+    assert [choice[0] for choice in choices] == VALID_HOTKEYS
+    assert dict((hotkey, label) for hotkey, label, _checked in choices)["right_cmd"] == "Right Command (⌘)"
+    assert dict((hotkey, label) for hotkey, label, _checked in choices)["f12"] == "F12"
+    assert sum(checked for _hotkey, _label, checked in choices) == 1
+    assert all(not label.startswith("✓") for _hotkey, label, _checked in choices)
+
+
+def test_native_menu_state_is_used_for_checkmarks() -> None:
+    from voiceflow.menubar import _set_checked
+
+    class FakeItem:
+        state = None
+
+    item = FakeItem()
+    _set_checked(item, True)
+    assert item.state == 1
+
+    _set_checked(item, False)
+    assert item.state == 0
+
+
+def test_native_alert_download_button_is_recognized() -> None:
+    from voiceflow.menubar import _alert_confirmed
+
+    assert _alert_confirmed(1000) is True
+    assert _alert_confirmed(1) is True
+    assert _alert_confirmed(1001) is False
+    assert _alert_confirmed(0) is False
+
+
+def test_profile_interview_runs_in_an_isolated_python_process() -> None:
+    from voiceflow.menubar import _profile_interview_command
+
+    command = _profile_interview_command("/test/python")
+
+    assert command[:2] == ["/test/python", "-c"]
+    assert "from voiceflow.interview import run_interview" in command[2]
+    assert "run_interview()" in command[2]
+
+
+def test_packaged_app_icon_is_discovered_from_launcher_environment(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from voiceflow.menubar import _app_icon_path
+
+    icon = tmp_path / "OpenVoiceFlow.icns"
+    icon.write_bytes(b"icon")
+    monkeypatch.setenv("OPENVOICEFLOW_APP_RESOURCES", str(tmp_path))
+
+    assert _app_icon_path() == str(icon)
+
+
+def test_alerts_and_notifications_use_the_branded_app_icon(monkeypatch) -> None:
+    import voiceflow.menubar as menubar
+
+    alerts = []
+    notifications = []
+    fake_rumps = SimpleNamespace(
+        alert=lambda **kwargs: alerts.append(kwargs) or 1000,
+        notification=lambda *args, **kwargs: notifications.append((args, kwargs)),
+    )
+    monkeypatch.setattr(menubar, "rumps", fake_rumps)
+    monkeypatch.setattr(
+        menubar,
+        "_app_icon_path",
+        lambda: "/Applications/OpenVoiceFlow.app/Contents/Resources/OpenVoiceFlow.icns",
+    )
+
+    assert menubar._show_alert(title="OpenVoiceFlow", message="Ready") == 1000
+    menubar._show_notification("OpenVoiceFlow", "Ready", "Listening")
+
+    assert alerts[0]["icon_path"].endswith("OpenVoiceFlow.icns")
+    assert notifications[0][1]["icon"].endswith("OpenVoiceFlow.icns")
+
+
+def test_current_app_status_has_a_lightweight_refresh_interval() -> None:
+    from voiceflow.menubar import (
+        _CONTEXT_REFRESH_SECONDS,
+        _LISTENER_START_DELAY_SECONDS,
+        _is_current_process,
+        _is_openvoiceflow_host,
+    )
+
+    assert 1 <= _CONTEXT_REFRESH_SECONDS <= 5
+    assert 0 < _LISTENER_START_DELAY_SECONDS <= 0.5
+    assert _is_current_process(420, current_process_id=420) is True
+    assert _is_current_process(421, current_process_id=420) is False
+    assert _is_openvoiceflow_host(421, "Python", "com.apple.python3", 420) is True
+    assert _is_openvoiceflow_host(421, "OpenVoiceFlow", "com.openvoiceflow.dictation", 420) is True
+    assert _is_openvoiceflow_host(421, "TextEdit", "com.apple.TextEdit", 420) is False
+
+
+def test_status_line_uses_the_human_shortcut_name() -> None:
+    from voiceflow.menubar import _status_line
+
+    assert _status_line(True, "right_cmd") == "Ready — Hold Right Command (⌘)"
+    assert _status_line(False, "right_cmd") == "Listening Paused"
+
+
+def test_status_bar_states_have_accessible_native_symbol_presentations() -> None:
+    from voiceflow.menubar import _STATUS_PRESENTATIONS
+
+    assert _STATUS_PRESENTATIONS["ready"] == ("waveform", "Ready")
+    assert _STATUS_PRESENTATIONS["paused"][0] == "pause.circle"
+    assert _STATUS_PRESENTATIONS["error"][0] == "exclamationmark.triangle"
+    assert all(label and label.isascii() for _symbol, label in _STATUS_PRESENTATIONS.values())
+
+
+def test_status_bar_uses_native_image_without_duplicate_text(monkeypatch) -> None:
+    import voiceflow.menubar as menubar
+
+    image = object()
+    monkeypatch.setattr(menubar, "_system_symbol_image", lambda *_args: image)
+
+    class FakeApp:
+        pass
+
+    app = FakeApp()
+    menubar._apply_status_bar_state(app, "ready")
+
+    assert app._icon_nsimage is image
+    assert app._title is None
+    assert app._status_bar_state == "ready"
+
+
+def test_status_bar_has_visible_text_fallback_when_symbols_fail(monkeypatch) -> None:
+    import voiceflow.menubar as menubar
+
+    monkeypatch.setattr(menubar, "_system_symbol_image", lambda *_args: None)
+
+    class FakeApp:
+        pass
+
+    app = FakeApp()
+    menubar._apply_status_bar_state(app, "error")
+
+    assert app._icon_nsimage is None
+    assert app._title == "OpenVoiceFlow"
+    assert app._status_bar_state == "error"
+
+
+def test_runtime_no_longer_replaces_the_app_identity_with_status_emoji() -> None:
+    from voiceflow.menubar import run_menubar
+
+    source = inspect.getsource(run_menubar)
+
+    assert "self.title =" not in source
+    assert "🎙️✅" not in source
+    assert "before_start.unregister" not in source
+    assert "_call_on_main_thread_later(" in source
+    assert "self._start_listening_safely" in source
+
+
+def test_readme_explains_the_branded_menu_bar_experience() -> None:
+    readme = (Path(__file__).resolve().parent.parent / "README.md").read_text()
+
+    assert "waveform icon" in readme
+    assert "Open OpenVoiceFlow" in readme
+    assert "Check for Updates" in readme
+    assert "🎙️✅" not in readme
+
+
+def test_real_rumps_constructor_builds_the_branded_menu(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    import voiceflow.app as app_module
+    import voiceflow.autostart as autostart
+    import voiceflow.config as config
+    import voiceflow.context as context
+    import voiceflow.menubar as menubar
+    import voiceflow.updater as updater
+
+    if menubar.rumps is None:
+        pytest.skip("rumps is an optional macOS dependency")
+
+    captured = {}
+    alerts = []
+
+    class FakeVoiceFlow:
+        def __init__(self) -> None:
+            self.config = {}
+
+    monkeypatch.setattr(app_module, "OpenVoiceFlow", FakeVoiceFlow)
+    monkeypatch.setattr(config, "load_config", lambda: dict(config.DEFAULTS))
+    monkeypatch.setattr(config, "save_config", lambda _config: None)
+    monkeypatch.setattr(autostart, "get_autostart_status", lambda: False)
+    monkeypatch.setattr(context, "get_frontmost_app", lambda: "TextEdit")
+    monkeypatch.setattr(context, "get_style_for_app", lambda *_args: "default")
+    monkeypatch.setattr(updater, "check_for_updates", lambda **_kwargs: None)
+    monkeypatch.setattr(menubar, "_configure_macos_application", lambda: None)
+    monkeypatch.setattr(menubar, "_frontmost_app_is_current_process", lambda: False)
+    monkeypatch.setattr(
+        menubar.rumps,
+        "alert",
+        lambda **kwargs: alerts.append(kwargs),
+    )
+    monkeypatch.setattr(menubar.rumps.rumps, "application_support", lambda _name: str(tmp_path))
+    monkeypatch.setattr(
+        menubar.rumps.App,
+        "run",
+        lambda app, **_kwargs: captured.setdefault("app", app),
+    )
+
+    menubar.run_menubar()
+    app = captured["app"]
+    visible_titles = [
+        item.title
+        for item in app.menu.values()
+        if hasattr(item, "title")
+    ]
+
+    assert visible_titles[0] == "Open OpenVoiceFlow"
+    assert visible_titles[-1] == "Quit OpenVoiceFlow"
+    assert app.quit_item.key == "q"
+    assert app.open_item.callback.__self__ is app
+    assert app.quit_item.callback.__self__ is app
+    assert sum(item.state == 1 for item in app.hotkey_menu.values()) == 1
+    assert sum(item.state == 1 for item in app.backend_menu.values()) == 1
+    assert sum(item.state == 1 for item in app.style_menu.values()) == 1
+    assert app.detected_app_item.title == "Current App: TextEdit · Default"
+
+    app._start_listening_safely()
+
+    assert app._status_bar_state == "error"
+    assert app.status_item.title == "Unable to Start"
+    assert app.listening_item.state == 0
+    assert alerts[-1]["title"] == "OpenVoiceFlow Could Not Start"
+    assert alerts[-1]["icon_path"].endswith("OpenVoiceFlow.icns")
+
+    menubar.rumps.events.before_start.unregister(app._finish_status_bar_setup)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -66,3 +66,70 @@ def test_update_check_default_when_no_config(monkeypatch) -> None:
     updater.check_for_updates()
 
     assert fetched.wait(timeout=2.0), "worker thread didn't run with empty config"
+
+
+def test_manual_update_worker_reports_available_release(monkeypatch) -> None:
+    monkeypatch.setattr(
+        updater,
+        "_fetch_latest_release",
+        lambda: {
+            "tag_name": "v99.0.0",
+            "html_url": "https://example.com/openvoiceflow-99",
+        },
+    )
+    results = []
+
+    updater._manual_check_worker(lambda *result: results.append(result))
+
+    assert results == [
+        ("available", "99.0.0", "https://example.com/openvoiceflow-99"),
+    ]
+
+
+def test_manual_update_worker_reports_current_release(monkeypatch) -> None:
+    monkeypatch.setattr(
+        updater,
+        "_fetch_latest_release",
+        lambda: {
+            "tag_name": f"v{updater.__version__}",
+            "html_url": "https://example.com/current",
+        },
+    )
+    results = []
+
+    updater._manual_check_worker(lambda *result: results.append(result))
+
+    assert results == [
+        ("current", updater.__version__, "https://example.com/current"),
+    ]
+
+
+def test_manual_update_worker_reports_network_error(monkeypatch) -> None:
+    monkeypatch.setattr(updater, "_fetch_latest_release", lambda: None)
+    results = []
+
+    updater._manual_check_worker(lambda *result: results.append(result))
+
+    assert results == [
+        (
+            "error",
+            "",
+            "https://github.com/shimoverse/openvoiceflow/releases",
+        ),
+    ]
+
+
+def test_manual_update_check_runs_in_background(monkeypatch) -> None:
+    fetched = threading.Event()
+    completed = threading.Event()
+
+    def fake_fetch() -> dict | None:
+        fetched.set()
+        return None
+
+    monkeypatch.setattr(updater, "_fetch_latest_release", fake_fetch)
+
+    updater.check_for_updates_now(lambda *_result: completed.set())
+
+    assert fetched.wait(timeout=2.0), "manual update worker didn't run"
+    assert completed.wait(timeout=2.0), "manual update result callback didn't run"

--- a/voiceflow/__init__.py
+++ b/voiceflow/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __author__ = "Shimoverse"
 __app_name__ = "OpenVoiceFlow"

--- a/voiceflow/menubar.py
+++ b/voiceflow/menubar.py
@@ -10,11 +10,42 @@ except ImportError:
     rumps = None
 
 
-def _clear_submenu(menu) -> None:
-    """Clear a rumps submenu only after its native NSMenu exists."""
-    if getattr(menu, "_menu", None) is not None:
-        menu.clear()
+_MENU_ITEM_SPECS = {
+    "open": ("Open OpenVoiceFlow", None),
+    "listening": ("Listening", None),
+    "status": ("Starting…", None),
+    "detected_app": ("Current App: —", None),
+    "shortcut": ("Dictation Shortcut", None),
+    "backend": ("AI Cleanup", None),
+    "style": ("Writing Style", None),
+    "personalization": ("Personalization", None),
+    "advanced": ("Advanced", None),
+    "stats": ("Usage Statistics", None),
+    "usage": ("How to Use", None),
+    "updates": ("Check for Updates…", None),
+    "quit": ("Quit OpenVoiceFlow", "q"),
+}
 
+_MAIN_MENU_LAYOUT = (
+    "open",
+    None,
+    "listening",
+    "status",
+    "detected_app",
+    None,
+    "shortcut",
+    "backend",
+    "style",
+    None,
+    "personalization",
+    "advanced",
+    "stats",
+    None,
+    "usage",
+    "updates",
+    None,
+    "quit",
+)
 
 _HOTKEY_LABELS = {
     "right_cmd": "Right Command (⌘)",
@@ -25,13 +56,216 @@ _HOTKEY_LABELS = {
     "right_ctrl": "Right Control (⌃)",
 }
 
+_BACKEND_LABELS = {
+    "openrouter": "OpenRouter",
+    "openai": "OpenAI",
+    "anthropic": "Anthropic Claude",
+    "groq": "Groq",
+    "ollama": "Ollama (Local)",
+    "none": "No AI Cleanup",
+}
+
+_STYLE_MENU_LABELS = {
+    "default": "Default",
+    "casual": "Casual",
+    "formal": "Formal",
+    "code": "Code",
+    "email": "Email",
+}
+
+_STATUS_PRESENTATIONS = {
+    "starting": ("waveform", "Starting"),
+    "ready": ("waveform", "Ready"),
+    "paused": ("pause.circle", "Paused"),
+    "error": ("exclamationmark.triangle", "Needs attention"),
+}
+
+_CONTEXT_REFRESH_SECONDS = 2.0
+_LISTENER_START_DELAY_SECONDS = 0.15
+
+
+def _clear_submenu(menu) -> None:
+    """Clear a rumps submenu only after its native NSMenu exists."""
+    if getattr(menu, "_menu", None) is not None:
+        menu.clear()
+
+
+def _hotkey_label(hotkey: str) -> str:
+    """Return the menu label for a configured dictation shortcut."""
+    return _HOTKEY_LABELS.get(hotkey, hotkey.upper())
+
+
+def _hotkey_choices(current_hotkey: str) -> list[tuple[str, str, bool]]:
+    """Return every supported hotkey with its label and selected state."""
+    from .config import VALID_HOTKEYS
+
+    return [
+        (hotkey, _hotkey_label(hotkey), hotkey == current_hotkey)
+        for hotkey in VALID_HOTKEYS
+    ]
+
+
+def _backend_label(backend: str) -> str:
+    return _BACKEND_LABELS.get(backend, backend.replace("_", " ").title())
+
+
+def _style_label(style: str) -> str:
+    return _STYLE_MENU_LABELS.get(style, style.replace("_", " ").title())
+
+
+def _set_checked(item, enabled: bool) -> None:
+    """Use the native NSMenuItem state instead of a checkmark in its title."""
+    item.state = 1 if enabled else 0
+
+
+def _alert_confirmed(result: int) -> bool:
+    """Accept both native AppKit and legacy rumps first-button results."""
+    try:
+        from AppKit import NSAlertFirstButtonReturn
+
+        first_button = NSAlertFirstButtonReturn
+    except Exception:
+        first_button = 1000
+    return result in (1, first_button)
+
+
+def _profile_interview_command(
+    python_executable: str | None = None,
+) -> list[str]:
+    """Build the isolated command used for the Tk profile interview."""
+    import sys
+
+    executable = python_executable or sys.executable
+    code = "from voiceflow.interview import run_interview; run_interview()"
+    return [executable, "-c", code]
+
+
+def _app_icon_path() -> str | None:
+    """Find the branded app icon in a package or source checkout."""
+    import os
+    from pathlib import Path
+
+    candidates = []
+    resources = os.environ.get("OPENVOICEFLOW_APP_RESOURCES")
+    if resources:
+        candidates.append(Path(resources) / "OpenVoiceFlow.icns")
+    candidates.extend(
+        [
+            Path("/Applications/OpenVoiceFlow.app/Contents/Resources/OpenVoiceFlow.icns"),
+            Path.home()
+            / "Applications"
+            / "OpenVoiceFlow.app"
+            / "Contents"
+            / "Resources"
+            / "OpenVoiceFlow.icns",
+        ]
+    )
+    candidates.append(
+        Path(__file__).resolve().parent.parent / "assets" / "OpenVoiceFlow.icns"
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _show_alert(**kwargs):
+    """Show a native alert with OpenVoiceFlow branding."""
+    icon_path = _app_icon_path()
+    if icon_path:
+        kwargs.setdefault("icon_path", icon_path)
+    return rumps.alert(**kwargs)
+
+
+def _show_notification(title: str, subtitle: str, message: str, **kwargs) -> None:
+    """Show a notification with OpenVoiceFlow branding."""
+    icon_path = _app_icon_path()
+    if icon_path:
+        kwargs.setdefault("icon", icon_path)
+    rumps.notification(title, subtitle, message, **kwargs)
+
+
+def _configure_macos_application() -> None:
+    """Keep the Python UI process Dock-less and give alerts our app icon."""
+    try:
+        from AppKit import (
+            NSApplication,
+            NSApplicationActivationPolicyAccessory,
+            NSImage,
+        )
+
+        application = NSApplication.sharedApplication()
+        application.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+        icon_path = _app_icon_path()
+        if icon_path:
+            icon = NSImage.alloc().initWithContentsOfFile_(icon_path)
+            if icon is not None:
+                application.setApplicationIconImage_(icon)
+    except Exception:
+        pass
+
+
+def _is_current_process(
+    process_id: int,
+    current_process_id: int | None = None,
+) -> bool:
+    """Return whether an AppKit running application is this UI process."""
+    import os
+
+    current = os.getpid() if current_process_id is None else current_process_id
+    return process_id == current
+
+
+def _is_openvoiceflow_host(
+    process_id: int,
+    localized_name: str | None,
+    bundle_id: str | None,
+    current_process_id: int | None = None,
+) -> bool:
+    """Recognize this UI process and its native/Python helper processes."""
+    if _is_current_process(process_id, current_process_id):
+        return True
+    name = (localized_name or "").casefold()
+    identifier = (bundle_id or "").casefold()
+    return name in {"openvoiceflow", "python", "python3"} or identifier in {
+        "com.apple.python3",
+        "com.openvoiceflow.dictation",
+        "org.python.python",
+    }
+
+
+def _frontmost_app_is_current_process() -> bool:
+    """Avoid presenting OpenVoiceFlow helper processes as the current app."""
+    try:
+        from AppKit import NSWorkspace
+
+        app = NSWorkspace.sharedWorkspace().frontmostApplication()
+        return bool(
+            app
+            and _is_openvoiceflow_host(
+                int(app.processIdentifier()),
+                app.localizedName(),
+                app.bundleIdentifier(),
+            )
+        )
+    except Exception:
+        return False
+
+
+def _status_line(running: bool, hotkey: str) -> str:
+    """Return the concise status row shown below the Listening toggle."""
+    if running:
+        return f"Ready — Hold {_hotkey_label(hotkey)}"
+    return "Listening Paused"
+
 
 def _usage_instructions(hotkey: str) -> str:
     """Return concise, user-facing instructions for the active hotkey."""
-    label = _HOTKEY_LABELS.get(hotkey, hotkey.upper())
+    label = _hotkey_label(hotkey)
     return (
         f"Hold {label} in any text field, speak, then release to paste. "
-        "OpenVoiceFlow stays in the menu bar (🎙️✅); click its icon for settings."
+        "OpenVoiceFlow stays in the menu bar as a waveform icon; click it "
+        "for settings and status."
     )
 
 
@@ -40,13 +274,104 @@ def _show_ready_tip(hotkey: str) -> None:
     try:
         from . import notify
 
-        label = _HOTKEY_LABELS.get(hotkey, hotkey.upper())
+        label = _hotkey_label(hotkey)
         notify.tip(
-            f"menu bar 🎙️✅ — hold {label}, speak, release to paste.",
-            once_key="menubar_ready_v033",
+            f"menu bar waveform — hold {label}, speak, release to paste.",
+            once_key="menubar_ready_v034",
         )
     except Exception:
         pass
+
+
+def _system_symbol_image(symbol_name: str, state_label: str):
+    """Create a dark-mode-safe SF Symbol image, or return None as fallback."""
+    try:
+        from AppKit import (
+            NSFontWeightRegular,
+            NSImage,
+            NSImageSymbolConfiguration,
+        )
+
+        description = f"OpenVoiceFlow — {state_label}"
+        image = NSImage.imageWithSystemSymbolName_accessibilityDescription_(
+            symbol_name,
+            description,
+        )
+        if image is None:
+            return None
+        config = NSImageSymbolConfiguration.configurationWithPointSize_weight_(
+            15.0,
+            NSFontWeightRegular,
+        )
+        configured = image.imageWithSymbolConfiguration_(config)
+        if configured is not None:
+            image = configured
+        image.setTemplate_(True)
+        return image
+    except Exception:
+        return None
+
+
+def _apply_status_bar_state(app, state: str) -> None:
+    """Apply a native status icon while keeping a visible text fallback."""
+    symbol_name, state_label = _STATUS_PRESENTATIONS.get(
+        state,
+        _STATUS_PRESENTATIONS["error"],
+    )
+    image = _system_symbol_image(symbol_name, state_label)
+
+    app._status_bar_state = state
+    app._icon_nsimage = image
+    app._title = None if image is not None else "OpenVoiceFlow"
+
+    try:
+        app._nsapp.setStatusBarIcon()
+        app._nsapp.setStatusBarTitle()
+    except Exception:
+        return
+
+    try:
+        status_item = app._nsapp.nsstatusitem
+        button = status_item.button()
+        if button is not None:
+            button.setToolTip_(f"OpenVoiceFlow — {state_label}")
+            button.setAccessibilityLabel_("OpenVoiceFlow")
+            button.setAccessibilityValue_(state_label)
+        else:
+            status_item.setToolTip_(f"OpenVoiceFlow — {state_label}")
+    except Exception:
+        pass
+
+
+def _call_on_main_thread(callback, *args) -> None:
+    """Schedule UI work on AppKit's main thread when PyObjC is available."""
+    try:
+        from PyObjCTools import AppHelper
+
+        AppHelper.callAfter(callback, *args)
+    except Exception:
+        callback(*args)
+
+
+def _call_on_main_thread_later(
+    delay: float,
+    callback,
+    *args,
+) -> None:
+    """Let AppKit paint the status item before potentially slow startup."""
+    try:
+        from PyObjCTools import AppHelper
+
+        AppHelper.callLater(delay, callback, *args)
+    except Exception:
+        callback(*args)
+
+
+def _open_url(url: str) -> None:
+    """Open a web or System Settings URL using the macOS default handler."""
+    import subprocess
+
+    subprocess.Popen(["open", url])
 
 
 def run_menubar():
@@ -55,212 +380,319 @@ def run_menubar():
         print("❌ rumps not installed. Install with: pip install rumps")
         print("   Falling back to CLI mode...")
         from .app import OpenVoiceFlow
+
         OpenVoiceFlow().run()
         return
 
     from .app import OpenVoiceFlow
-    from .config import CONFIG_PATH, VALID_STYLES, load_config, save_config
-    from .llm import BACKENDS
+    from .config import (
+        CONFIG_PATH,
+        VALID_BACKENDS,
+        VALID_STYLES,
+        load_config,
+        save_config,
+    )
     from .stats import load_stats
-    from .styles import get_style_label
+
+    _configure_macos_application()
+
+    def make_item(item_id: str, callback=None):
+        title, key = _MENU_ITEM_SPECS[item_id]
+        return rumps.MenuItem(title, callback=callback, key=key)
 
     class OpenVoiceFlowMenuBar(rumps.App):
         def __init__(self):
-            super().__init__("🎙️", quit_button=None)
+            super().__init__(
+                "OpenVoiceFlow",
+                title="OpenVoiceFlow",
+                quit_button=None,
+            )
             self.vf = None
             self.listener = None
             self.config = load_config()
             self._running = False
+            self._checking_for_updates = False
+            self.context_timer = rumps.Timer(
+                self._refresh_detected_app,
+                _CONTEXT_REFRESH_SECONDS,
+            )
+            _apply_status_bar_state(self, "starting")
+            rumps.events.before_start.register(self._finish_status_bar_setup)
 
-            # Build menu items
-            self.start_stop_item = rumps.MenuItem("▶ Start Listening", callback=self.toggle)
-            self.status_item = rumps.MenuItem("Status: Stopped")
+            self.open_item = make_item("open", self.open_app)
+            self.listening_item = make_item("listening", self.toggle)
+            _set_checked(self.listening_item, False)
+
+            self.status_item = make_item("status")
             self.status_item.set_callback(None)
-            self.usage_item = rumps.MenuItem("❓ How to Use", callback=self.show_usage)
-
-            # Backend submenu
-            self.backend_menu = rumps.MenuItem("LLM Backend")
-
-            # Hotkey submenu
-            self.hotkey_menu = rumps.MenuItem("Hotkey")
-
-            # Style submenu
-            self.style_menu = rumps.MenuItem("Style/Tone")
-
-            # Stats item
-            self.stats_item = rumps.MenuItem("📊 Statistics", callback=self.show_stats)
-
-            # Dictionary item
-            self.dictionary_item = rumps.MenuItem("📖 Dictionary", callback=self.open_dictionary)
-
-            # Snippets item
-            self.snippets_item = rumps.MenuItem("📌 Snippets", callback=self.open_snippets)
-
-            # "Know Me" profile item
-            self.profile_item = rumps.MenuItem("👤 Edit Profile...", callback=self.open_profile)
-
-            # Autostart item
-            self.autostart_item = rumps.MenuItem(
-                self._autostart_label(),
-                callback=self.toggle_autostart,
-            )
-
-            # Streaming toggle (Feature 1)
-            self.streaming_item = rumps.MenuItem(
-                self._streaming_label(),
-                callback=self.toggle_streaming,
-            )
-
-            # Auto-style toggle (Feature 2)
-            self.auto_style_item = rumps.MenuItem(
-                self._auto_style_label(),
-                callback=self.toggle_auto_style,
-            )
-
-            # Auto-learn corrections toggle
-            self.auto_learn_item = rumps.MenuItem(
-                self._auto_learn_label(),
-                callback=self.toggle_auto_learn,
-            )
-
-            # Detected app status (Feature 2) — read-only informational item
-            self.detected_app_item = rumps.MenuItem("App: —")
+            self.detected_app_item = make_item("detected_app")
             self.detected_app_item.set_callback(None)
 
-            self.menu = [
-                self.start_stop_item,
-                self.status_item,
-                self.usage_item,
-                self.detected_app_item,
-                None,  # separator
-                self.backend_menu,
-                self.hotkey_menu,
-                self.style_menu,
+            self.hotkey_menu = make_item("shortcut")
+            self.backend_menu = make_item("backend")
+            self.style_menu = make_item("style")
+
+            self.personalization_menu = make_item("personalization")
+            self.auto_style_item = rumps.MenuItem(
+                "Automatic App Style",
+                callback=self.toggle_auto_style,
+            )
+            _set_checked(
                 self.auto_style_item,
-                self.streaming_item,
+                self.config.get("auto_style", True),
+            )
+            self.auto_learn_item = rumps.MenuItem(
+                "Learn Corrections",
+                callback=self.toggle_auto_learn,
+            )
+            _set_checked(
+                self.auto_learn_item,
+                self.config.get("auto_learn", False),
+            )
+            self.dictionary_item = rumps.MenuItem(
+                "Personal Dictionary",
+                callback=self.open_dictionary,
+            )
+            self.snippets_item = rumps.MenuItem(
+                "Voice Snippets",
+                callback=self.open_snippets,
+            )
+            self.profile_item = rumps.MenuItem(
+                "Edit Profile…",
+                callback=self.open_profile,
+            )
+            for item in (
+                self.auto_style_item,
                 self.auto_learn_item,
                 None,
-                self.stats_item,
                 self.dictionary_item,
                 self.snippets_item,
                 self.profile_item,
-                None,
+            ):
+                self.personalization_menu.add(item)
+
+            self.advanced_menu = make_item("advanced")
+            self.streaming_item = rumps.MenuItem(
+                "Streaming Transcription",
+                callback=self.toggle_streaming,
+            )
+            _set_checked(
+                self.streaming_item,
+                self.config.get("streaming", False),
+            )
+            self.autostart_item = rumps.MenuItem(
+                "Launch at Login",
+                callback=self.toggle_autostart,
+            )
+            _set_checked(self.autostart_item, self._autostart_enabled())
+            advanced_items = (
+                self.streaming_item,
                 self.autostart_item,
-                rumps.MenuItem("Open Config", callback=self.open_config),
-                rumps.MenuItem("View Logs", callback=self.open_logs),
                 None,
-                rumps.MenuItem("Quit", callback=self.quit_app),
+                rumps.MenuItem(
+                    "Microphone Settings…",
+                    callback=self.open_microphone_settings,
+                ),
+                rumps.MenuItem(
+                    "Accessibility Settings…",
+                    callback=self.open_accessibility_settings,
+                ),
+                None,
+                rumps.MenuItem(
+                    "Open Configuration File",
+                    callback=self.open_config,
+                ),
+                rumps.MenuItem(
+                    "Show Logs in Finder",
+                    callback=self.open_logs,
+                ),
+            )
+            for item in advanced_items:
+                self.advanced_menu.add(item)
+
+            self.stats_item = make_item("stats", self.show_stats)
+            self.usage_item = make_item("usage", self.show_usage)
+            self.check_updates_item = make_item(
+                "updates",
+                self.check_for_updates,
+            )
+            self.quit_item = make_item("quit", self.quit_app)
+
+            menu_items = {
+                "open": self.open_item,
+                "listening": self.listening_item,
+                "status": self.status_item,
+                "detected_app": self.detected_app_item,
+                "shortcut": self.hotkey_menu,
+                "backend": self.backend_menu,
+                "style": self.style_menu,
+                "personalization": self.personalization_menu,
+                "advanced": self.advanced_menu,
+                "stats": self.stats_item,
+                "usage": self.usage_item,
+                "updates": self.check_updates_item,
+                "quit": self.quit_item,
+            }
+            self.menu = [
+                None if item_id is None else menu_items[item_id]
+                for item_id in _MAIN_MENU_LAYOUT
             ]
 
-            # Populate the settings submenus (they start empty)
             self._build_backend_menu()
             self._build_hotkey_menu()
             self._build_style_menu()
+            self._update_detected_app()
 
-            # Kick off update check in background
             try:
                 from .updater import check_for_updates
-                check_for_updates(on_update_available=self._on_update_available)
+
+                check_for_updates(
+                    config=self.config,
+                    on_update_available=self._on_update_available,
+                )
             except Exception:
                 pass
 
-            # Auto-start
-            self.start_listening()
+        # ── Native status item ─────────────────────────────────────────────
+
+        def _finish_status_bar_setup(self):
+            """Apply accessibility metadata after rumps creates NSStatusItem."""
+            _apply_status_bar_state(self, self._status_bar_state)
+            if not self.context_timer.is_alive():
+                self.context_timer.start()
+            _call_on_main_thread_later(
+                _LISTENER_START_DELAY_SECONDS,
+                self._start_listening_safely,
+            )
 
         # ── Menu builders ──────────────────────────────────────────────────
 
         def _build_backend_menu(self):
-            """(Re)build backend submenu with current checkmarks."""
+            """Rebuild the AI cleanup submenu with a native selected state."""
             _clear_submenu(self.backend_menu)
             current_backend = self.config.get("llm_backend", "openrouter")
-            for name in list(BACKENDS.keys()) + ["none"]:
+            for name in VALID_BACKENDS:
                 item = rumps.MenuItem(
-                    f"{'✓ ' if name == current_backend else '  '}{name}",
+                    _backend_label(name),
                     callback=lambda sender, n=name: self.set_backend(sender, n),
                 )
+                _set_checked(item, name == current_backend)
                 self.backend_menu.add(item)
 
         def _build_hotkey_menu(self):
-            """(Re)build hotkey submenu with current checkmarks."""
+            """Rebuild the shortcut submenu with every supported hotkey."""
             _clear_submenu(self.hotkey_menu)
             current_hotkey = self.config.get("hotkey", "right_cmd")
-            for hk in ["left_fn", "right_cmd", "right_alt", "left_alt", "f5", "f6", "f7", "f8"]:
+            for hotkey, label, checked in _hotkey_choices(current_hotkey):
                 item = rumps.MenuItem(
-                    f"{'✓ ' if hk == current_hotkey else '  '}{hk}",
-                    callback=lambda sender, h=hk: self.set_hotkey(sender, h),
+                    label,
+                    callback=lambda sender, h=hotkey: self.set_hotkey(sender, h),
                 )
+                _set_checked(item, checked)
                 self.hotkey_menu.add(item)
 
         def _build_style_menu(self):
-            """(Re)build style submenu with current checkmarks."""
+            """Rebuild the writing-style submenu with native checkmarks."""
             _clear_submenu(self.style_menu)
             current_style = self.config.get("style", "default")
             for style_id in VALID_STYLES:
-                label = get_style_label(style_id)
                 item = rumps.MenuItem(
-                    f"{'✓ ' if style_id == current_style else '  '}{label}",
+                    _style_label(style_id),
                     callback=lambda sender, s=style_id: self.set_style(sender, s),
                 )
+                _set_checked(item, style_id == current_style)
                 self.style_menu.add(item)
 
-        def _autostart_label(self) -> str:
+        def _autostart_enabled(self) -> bool:
             try:
                 from .autostart import get_autostart_status
-                enabled = get_autostart_status()
+
+                return get_autostart_status()
             except Exception:
-                enabled = self.config.get("launch_at_login", False)
-            return "✓ Launch at Login" if enabled else "  Launch at Login"
-
-        def _streaming_label(self) -> str:
-            enabled = self.config.get("streaming", False)
-            return "✓ Streaming Transcription" if enabled else "  Streaming Transcription"
-
-        def _auto_style_label(self) -> str:
-            enabled = self.config.get("auto_style", True)
-            return "✓ Auto-Style (per app)" if enabled else "  Auto-Style (per app)"
-
-        def _auto_learn_label(self) -> str:
-            # Default mirrors DEFAULTS["auto_learn"] (False in v0.3+; opt-in only).
-            enabled = self.config.get("auto_learn", False)
-            return "✓ Auto-Learn Corrections" if enabled else "  Auto-Learn Corrections"
+                return self.config.get("launch_at_login", False)
 
         def _update_detected_app(self):
-            """Refresh the detected-app status item (called after start_listening)."""
+            """Refresh the current-app status item after starting listening."""
+            if _frontmost_app_is_current_process():
+                return
             try:
                 from .context import get_frontmost_app, get_style_for_app
+
                 app = get_frontmost_app()
                 if app:
                     style = get_style_for_app(app, self.config)
-                    self.detected_app_item.title = f"App: {app} [{style}]"
+                    self.detected_app_item.title = (
+                        f"Current App: {app} · {_style_label(style)}"
+                    )
                 else:
-                    self.detected_app_item.title = "App: —"
+                    self.detected_app_item.title = "Current App: —"
             except Exception:
-                self.detected_app_item.title = "App: —"
+                self.detected_app_item.title = "Current App: —"
 
-        # ── Listeners ──────────────────────────────────────────────────────
+        def _refresh_detected_app(self, _timer):
+            """Keep the displayed app/style current as the user switches apps."""
+            self._update_detected_app()
+
+        # ── Listener lifecycle ─────────────────────────────────────────────
+
+        def _start_listening_safely(self):
+            """Start the listener without leaving the menu stuck on Starting."""
+            if self._running:
+                return
+            try:
+                self.start_listening()
+            except Exception as exc:
+                import sys
+
+                try:
+                    if self.listener:
+                        self.listener.stop()
+                except Exception:
+                    pass
+                self.listener = None
+                self._abort_active_dictation()
+                self._running = False
+                _set_checked(self.listening_item, False)
+                _apply_status_bar_state(self, "error")
+                self.status_item.title = "Unable to Start"
+                sys.stderr.write(f"OpenVoiceFlow menu startup failed: {exc}\n")
+                _show_alert(
+                    title="OpenVoiceFlow Could Not Start",
+                    message=(
+                        "The listening service could not start. Open the "
+                        f"Advanced menu to review settings and logs.\n\n{exc}"
+                    ),
+                    ok="OK",
+                )
 
         def start_listening(self):
             self.vf = OpenVoiceFlow()
             if not self.vf.validate_setup():
-                self.title = "🎙️❌"
-                self.status_item.title = "Status: Setup error"
-                rumps.notification(
-                    "OpenVoiceFlow", "Setup Error",
-                    "Check config. Click menu bar icon for details.",
+                self._running = False
+                _set_checked(self.listening_item, False)
+                _apply_status_bar_state(self, "error")
+                self.status_item.title = "Setup Required"
+                _show_notification(
+                    "OpenVoiceFlow",
+                    "Setup Required",
+                    "Open the menu for settings and setup help.",
                 )
                 return
 
             try:
                 from pynput.keyboard import Listener
-            except Exception as e:
-                self.title = "🎙️❌"
-                self.status_item.title = "Status: Keyboard listener unavailable"
-                rumps.notification(
-                    "OpenVoiceFlow", "Keyboard Listener Error",
-                    f"Could not start the hotkey listener ({e}). "
-                    "Reinstall with: pip install pynput",
+            except Exception as exc:
+                self._running = False
+                _set_checked(self.listening_item, False)
+                _apply_status_bar_state(self, "error")
+                self.status_item.title = "Keyboard Listener Unavailable"
+                _show_notification(
+                    "OpenVoiceFlow",
+                    "Keyboard Listener Error",
+                    f"Could not start the shortcut listener ({exc}). Reinstall pynput.",
                 )
                 return
+
             self.listener = Listener(
                 on_press=self.vf.on_key_press,
                 on_release=self.vf.on_key_release,
@@ -268,14 +700,13 @@ def run_menubar():
             self.listener.start()
             self.vf.start_hotkey_runtime_checks()
             self._running = True
-            self.title = "🎙️✅"
+            _set_checked(self.listening_item, True)
+            _apply_status_bar_state(self, "ready")
             if self.config.get("sound_feedback", True):
                 play_sound("done")
             hotkey = self.config.get("hotkey", "right_cmd")
-            self.start_stop_item.title = "⏸ Stop Listening"
-            self.status_item.title = f"Status: Ready — hold [{hotkey}]"
+            self.status_item.title = _status_line(True, hotkey)
             _show_ready_tip(hotkey)
-            # Refresh detected app label
             self._update_detected_app()
 
         def _abort_active_dictation(self):
@@ -296,7 +727,7 @@ def run_menubar():
                     watcher.stop()
                     vf._watcher = None
             except Exception:
-                pass  # Best-effort cleanup; never block stop/quit
+                pass
 
         def stop_listening(self):
             if self.listener:
@@ -304,195 +735,322 @@ def run_menubar():
                 self.listener = None
             self._abort_active_dictation()
             self._running = False
-            self.title = "🎙️💤"
-            self.start_stop_item.title = "▶ Start Listening"
-            self.status_item.title = "Status: Paused"
+            _set_checked(self.listening_item, False)
+            _apply_status_bar_state(self, "paused")
+            hotkey = self.config.get("hotkey", "right_cmd")
+            self.status_item.title = _status_line(False, hotkey)
 
         def toggle(self, _):
             if self._running:
                 self.stop_listening()
             else:
-                self.start_listening()
+                self._start_listening_safely()
 
         # ── Settings handlers ──────────────────────────────────────────────
 
-        def set_backend(self, sender, name):
+        def set_backend(self, _sender, name):
             self.config["llm_backend"] = name
             save_config(self.config)
             self._build_backend_menu()
             if self._running:
                 self.stop_listening()
-                self.start_listening()
-            rumps.notification("OpenVoiceFlow", "Backend Changed", f"Now using: {name}")
+                self._start_listening_safely()
+            _show_notification(
+                "OpenVoiceFlow",
+                "AI Cleanup Changed",
+                f"Now using {_backend_label(name)}.",
+            )
 
-        def set_hotkey(self, sender, hotkey):
+        def set_hotkey(self, _sender, hotkey):
             self.config["hotkey"] = hotkey
             save_config(self.config)
             self._build_hotkey_menu()
             if self._running:
                 self.stop_listening()
-                self.start_listening()
-            rumps.notification("OpenVoiceFlow", "Hotkey Changed", f"Now using: {hotkey}")
+                self._start_listening_safely()
+            _show_notification(
+                "OpenVoiceFlow",
+                "Dictation Shortcut Changed",
+                f"Now using {_hotkey_label(hotkey)}.",
+            )
 
-        def set_style(self, sender, style_id):
+        def set_style(self, _sender, style_id):
             self.config["style"] = style_id
             save_config(self.config)
             self._build_style_menu()
-            # Rebuild VoiceFlow instance so LLM backend picks up new style prompt
             if self._running:
                 self.stop_listening()
-                self.start_listening()
-            label = get_style_label(style_id)
-            rumps.notification("OpenVoiceFlow", "Style Changed", f"Now using: {label}")
+                self._start_listening_safely()
+            _show_notification(
+                "OpenVoiceFlow",
+                "Writing Style Changed",
+                f"Now using {_style_label(style_id)}.",
+            )
 
         def _set_config_flag(self, key: str, value: bool):
-            """Persist a config flag and propagate it to the live instance.
-
-            The running OpenVoiceFlow instance holds its own config dict
-            loaded at start_listening; without this, toggles only take
-            effect after an app restart.
-            """
+            """Persist a config flag and propagate it to the live instance."""
             self.config[key] = value
             save_config(self.config)
             if self.vf:
                 self.vf.config[key] = value
 
         def toggle_streaming(self, _):
-            """Toggle streaming transcription on/off."""
             current = self.config.get("streaming", False)
-            self._set_config_flag("streaming", not current)
-            self.streaming_item.title = self._streaming_label()
-            state_str = "enabled" if not current else "disabled"
-            rumps.notification("OpenVoiceFlow", "Streaming", f"Streaming transcription {state_str}")
+            enabled = not current
+            self._set_config_flag("streaming", enabled)
+            _set_checked(self.streaming_item, enabled)
+            state = "enabled" if enabled else "disabled"
+            _show_notification(
+                "OpenVoiceFlow",
+                "Streaming Transcription",
+                f"Streaming transcription {state}.",
+            )
 
         def toggle_auto_style(self, _):
-            """Toggle automatic per-app style detection."""
             current = self.config.get("auto_style", True)
-            self._set_config_flag("auto_style", not current)
-            self.auto_style_item.title = self._auto_style_label()
-            state_str = "enabled" if not current else "disabled"
-            rumps.notification("OpenVoiceFlow", "Auto-Style", f"Per-app auto style {state_str}")
+            enabled = not current
+            self._set_config_flag("auto_style", enabled)
+            _set_checked(self.auto_style_item, enabled)
+            state = "enabled" if enabled else "disabled"
+            _show_notification(
+                "OpenVoiceFlow",
+                "Automatic App Style",
+                f"Automatic per-app style {state}.",
+            )
 
         def toggle_auto_learn(self, _):
-            """Toggle auto-learning corrections from post-paste edits."""
-            # Default mirrors DEFAULTS["auto_learn"] (False; opt-in only).
             current = self.config.get("auto_learn", False)
-            self._set_config_flag("auto_learn", not current)
-            self.auto_learn_item.title = self._auto_learn_label()
-            state_str = "enabled" if not current else "disabled"
-            rumps.notification("OpenVoiceFlow", "Auto-Learn", f"Correction learning {state_str}")
+            enabled = not current
+            self._set_config_flag("auto_learn", enabled)
+            _set_checked(self.auto_learn_item, enabled)
+            state = "enabled" if enabled else "disabled"
+            _show_notification(
+                "OpenVoiceFlow",
+                "Learn Corrections",
+                f"Correction learning {state}.",
+            )
 
-        # ── Feature handlers ───────────────────────────────────────────────
+        # ── User-facing panels ─────────────────────────────────────────────
+
+        def open_app(self, _):
+            """Open a native status summary for the otherwise windowless app."""
+            from . import __version__
+
+            hotkey = self.config.get("hotkey", "right_cmd")
+            backend = self.config.get("llm_backend", "openrouter")
+            style = self.config.get("style", "default")
+            message = (
+                f"{self.status_item.title}\n\n"
+                f"Dictation Shortcut: {_hotkey_label(hotkey)}\n"
+                f"AI Cleanup: {_backend_label(backend)}\n"
+                f"Writing Style: {_style_label(style)}\n\n"
+                f"{_usage_instructions(hotkey)}"
+            )
+            _show_alert(
+                title=f"OpenVoiceFlow {__version__}",
+                message=message,
+                ok="Done",
+            )
 
         def show_usage(self, _):
-            """Show persistent instructions when the user asks for help."""
             hotkey = self.config.get("hotkey", "right_cmd")
-            rumps.alert(
+            _show_alert(
                 title="How to Use OpenVoiceFlow",
                 message=_usage_instructions(hotkey),
             )
 
         def show_stats(self, _):
-            """Show statistics in a rumps alert dialog."""
             stats = load_stats()
             total = stats["total_dictations"]
             words = stats["total_words"]
             seconds = stats["total_seconds_recorded"]
             typing_min_saved = words / 40.0 if words else 0
-
-            msg = (
+            message = (
                 f"Dictations: {total}\n"
-                f"Words:       {words:,}\n"
-                f"Recorded:    {seconds / 60:.1f} min\n"
-                f"Time saved:  ~{typing_min_saved:.0f} min"
+                f"Words: {words:,}\n"
+                f"Recorded: {seconds / 60:.1f} min\n"
+                f"Time saved: about {typing_min_saved:.0f} min"
             )
-            rumps.alert(title="📊 OpenVoiceFlow Stats", message=msg)
+            _show_alert(title="OpenVoiceFlow Statistics", message=message)
 
         def open_dictionary(self, _):
-            """Open a window to view dictionary words, or open config dir."""
             try:
                 from .dictionary import list_words
+
                 words = list_words()
             except Exception:
                 words = []
 
             if words:
-                msg = "\n".join(f"  • {w}" for w in words)
-                msg += "\n\nAdd words: openvoiceflow --add-word \"MyWord\""
+                message = "\n".join(f"• {word}" for word in words)
+                message += "\n\nAdd words with: openvoiceflow --add-word MyWord"
             else:
-                msg = "No words yet.\n\nAdd with:\nopenvoiceflow --add-word \"MyWord\""
-            rumps.alert(title="📖 Personal Dictionary", message=msg)
+                message = "No words yet.\n\nAdd with: openvoiceflow --add-word MyWord"
+            _show_alert(title="Personal Dictionary", message=message)
 
         def open_snippets(self, _):
-            """Show snippet list in a rumps alert dialog."""
             try:
                 from .snippets import list_snippets
-                snips = list_snippets()
-            except Exception:
-                snips = {}
 
-            if snips:
-                lines = [f"  \"{t}\" → \"{e[:40]}{'...' if len(e)>40 else ''}\"" for t, e in snips.items()]
-                msg = "\n".join(lines)
-                msg += "\n\nAdd: openvoiceflow --add-snippet \"trigger\" \"expansion\""
+                snippets = list_snippets()
+            except Exception:
+                snippets = {}
+
+            if snippets:
+                lines = [
+                    f"\"{trigger}\" → \"{expansion[:40]}"
+                    f"{'...' if len(expansion) > 40 else ''}\""
+                    for trigger, expansion in snippets.items()
+                ]
+                message = "\n".join(lines)
+                message += (
+                    "\n\nAdd with: openvoiceflow --add-snippet "
+                    "\"trigger\" \"expansion\""
+                )
             else:
-                msg = "No snippets yet.\n\nAdd with:\nopenvoiceflow --add-snippet \"insert sig\" \"Best regards, Name\""
-            rumps.alert(title="📌 Voice Snippets", message=msg)
+                message = (
+                    "No snippets yet.\n\nAdd with: openvoiceflow --add-snippet "
+                    "\"insert signature\" \"Best regards\""
+                )
+            _show_alert(title="Voice Snippets", message=message)
 
         def open_profile(self, _):
-            """Open the Know Me interview wizard so the user can update their profile."""
             try:
-                import threading
+                import subprocess
 
-                from .interview import run_interview
-                # Run in a separate thread to avoid blocking the rumps event loop
-                threading.Thread(target=run_interview, daemon=True).start()
-            except Exception as e:
-                rumps.alert(title="Profile Error", message=str(e))
+                subprocess.Popen(_profile_interview_command())
+            except Exception as exc:
+                _show_alert(title="Profile Error", message=str(exc))
 
         def toggle_autostart(self, _):
-            """Toggle launch at login."""
             try:
                 from .autostart import get_autostart_status, set_autostart
+
                 current = get_autostart_status()
-                success, msg = set_autostart(not current)
+                success, message = set_autostart(not current)
                 if success:
-                    new_state = not current
-                    self.config["launch_at_login"] = new_state
+                    enabled = not current
+                    self.config["launch_at_login"] = enabled
                     save_config(self.config)
-                    self.autostart_item.title = self._autostart_label()
-                    state_str = "enabled" if new_state else "disabled"
-                    rumps.notification("OpenVoiceFlow", "Launch at Login", f"Autostart {state_str}")
+                    _set_checked(self.autostart_item, enabled)
+                    state = "enabled" if enabled else "disabled"
+                    _show_notification(
+                        "OpenVoiceFlow",
+                        "Launch at Login",
+                        f"Launch at Login {state}.",
+                    )
                 else:
-                    rumps.alert(title="Autostart Error", message=msg)
-            except Exception as e:
-                rumps.alert(title="Autostart Error", message=str(e))
+                    _show_alert(title="Launch at Login Error", message=message)
+            except Exception as exc:
+                _show_alert(title="Launch at Login Error", message=str(exc))
 
-        # ── File openers ───────────────────────────────────────────────────
+        # ── File and settings openers ──────────────────────────────────────
 
-        def open_config(self, _):
-            import subprocess
-            subprocess.Popen(["open", str(CONFIG_PATH)])
-
-        def open_logs(self, _):
-            import subprocess
-
-            from .config import LOG_DIR
-            LOG_DIR.mkdir(parents=True, exist_ok=True)
-            subprocess.Popen(["open", str(LOG_DIR)])
-
-        # ── Update handler ─────────────────────────────────────────────────
-
-        def _on_update_available(self, latest_version: str, release_url: str):
-            """Called from updater thread when a new version is found."""
-            from . import __version__
-            rumps.notification(
-                "OpenVoiceFlow Update Available",
-                f"v{latest_version} is available (you have v{__version__})",
-                f"Visit: {release_url}",
+        def open_microphone_settings(self, _):
+            _open_url(
+                "x-apple.systempreferences:com.apple.preference.security?"
+                "Privacy_Microphone"
             )
 
+        def open_accessibility_settings(self, _):
+            _open_url(
+                "x-apple.systempreferences:com.apple.preference.security?"
+                "Privacy_Accessibility"
+            )
+
+        def open_config(self, _):
+            _open_url(str(CONFIG_PATH))
+
+        def open_logs(self, _):
+            from .config import LOG_DIR
+
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
+            _open_url(str(LOG_DIR))
+
+        # ── Update handlers ────────────────────────────────────────────────
+
+        def _on_update_available(self, latest_version: str, release_url: str):
+            _call_on_main_thread(
+                self._show_update_notification,
+                latest_version,
+                release_url,
+            )
+
+        def _show_update_notification(self, latest_version: str, release_url: str):
+            from . import __version__
+
+            _show_notification(
+                "OpenVoiceFlow Update Available",
+                f"Version {latest_version} is available; you have {__version__}.",
+                release_url,
+            )
+
+        def check_for_updates(self, _):
+            if self._checking_for_updates:
+                return
+            self._checking_for_updates = True
+            self.check_updates_item.title = "Checking for Updates…"
+            try:
+                from .updater import check_for_updates_now
+
+                check_for_updates_now(self._on_manual_update_result)
+            except Exception:
+                self._show_manual_update_result("error", "", "")
+
+        def _on_manual_update_result(
+            self,
+            status: str,
+            latest_version: str,
+            release_url: str,
+        ):
+            _call_on_main_thread(
+                self._show_manual_update_result,
+                status,
+                latest_version,
+                release_url,
+            )
+
+        def _show_manual_update_result(
+            self,
+            status: str,
+            latest_version: str,
+            release_url: str,
+        ):
+            from . import __version__
+
+            self._checking_for_updates = False
+            self.check_updates_item.title = _MENU_ITEM_SPECS["updates"][0]
+            if status == "available":
+                result = _show_alert(
+                    title="OpenVoiceFlow Update Available",
+                    message=(
+                        f"Version {latest_version} is available. "
+                        f"You currently have version {__version__}."
+                    ),
+                    ok="Download",
+                    cancel="Later",
+                )
+                if _alert_confirmed(result):
+                    _open_url(release_url)
+            elif status == "current":
+                _show_alert(
+                    title="OpenVoiceFlow Is Up to Date",
+                    message=f"You have the latest version ({__version__}).",
+                    ok="OK",
+                )
+            else:
+                _show_alert(
+                    title="Unable to Check for Updates",
+                    message=(
+                        "OpenVoiceFlow could not reach the update service. "
+                        "Please check your internet connection and try again."
+                    ),
+                    ok="OK",
+                )
+
         def quit_app(self, _):
+            if self.context_timer.is_alive():
+                self.context_timer.stop()
             self.stop_listening()
             rumps.quit_application()
 

--- a/voiceflow/updater.py
+++ b/voiceflow/updater.py
@@ -16,7 +16,10 @@ from typing import Callable
 from . import __version__
 
 GITHUB_RELEASES_API = "https://api.github.com/repos/shimoverse/openvoiceflow/releases/latest"
+GITHUB_RELEASES_URL = "https://github.com/shimoverse/openvoiceflow/releases"
 CHECK_TIMEOUT = 8  # seconds
+
+ManualUpdateCallback = Callable[[str, str, str], None]
 
 
 def _parse_version(version_str: str) -> tuple[int, ...]:
@@ -85,6 +88,22 @@ def check_for_updates(
     thread.start()
 
 
+def check_for_updates_now(on_result: ManualUpdateCallback) -> None:
+    """Run a user-requested update check without blocking the menu bar.
+
+    Unlike the quiet startup check, this always calls ``on_result`` with one
+    of ``"available"``, ``"current"``, or ``"error"`` so the menu can give
+    the user a definitive answer.
+    """
+    thread = threading.Thread(
+        target=_manual_check_worker,
+        args=(on_result,),
+        daemon=True,
+        name="openvoiceflow-manual-updater",
+    )
+    thread.start()
+
+
 def _check_worker(on_update_available: Callable | None) -> None:
     """Background worker: fetch release and compare versions."""
     release = _fetch_latest_release()
@@ -108,6 +127,22 @@ def _check_worker(on_update_available: Callable | None) -> None:
         print(f"\n🆕 Update available: v{latest_str} (you have v{__version__})")
         print(f"   Download: {release_url}\n")
         _send_notification(latest_str, release_url)
+
+
+def _manual_check_worker(on_result: ManualUpdateCallback) -> None:
+    """Fetch and classify the latest release for an explicit menu action."""
+    release = _fetch_latest_release()
+    if not release:
+        on_result("error", "", GITHUB_RELEASES_URL)
+        return
+
+    latest_tag = release.get("tag_name", "")
+    release_url = release.get("html_url", GITHUB_RELEASES_URL)
+    latest_str = latest_tag.lstrip("vV")
+    if _parse_version(latest_tag) > _parse_version(__version__):
+        on_result("available", latest_str, release_url)
+    else:
+        on_result("current", latest_str or __version__, release_url)
 
 
 def _send_notification(latest_version: str, release_url: str) -> None:


### PR DESCRIPTION
## What changed

- Replaces the changing microphone emoji title with native, dark-mode-safe SF Symbols for starting, ready, paused, and error states.
- Adds a clear **Open OpenVoiceFlow** first action, clean Apple-style groups and submenus, native checkmarks, human-readable shortcuts, and **Quit OpenVoiceFlow** with Command-Q.
- Adds direct Microphone and Accessibility settings links plus a user-triggered **Check for Updates…** flow.
- Keeps the Python UI process out of the Dock, gives native dialogs and notifications the bundled OpenVoiceFlow artwork, and filters helper processes from Current App.
- Defers listener setup until the status item is visible, surfaces unexpected startup failures, isolates the Tk profile editor, and refreshes Current App safely.
- Bumps the release candidate to 0.3.4 and updates the README/changelog.

## Why

The downloaded app is intentionally menu-bar-only, but the current build exposes it as changing microphone/status emojis and has no branded first menu action. That makes the app easy to miss and makes clicking it feel unfinished. The Python child process can also leak Python branding into the Dock and native dialogs.

## User impact

OpenVoiceFlow is immediately identifiable as a native macOS menu-bar app. Its state, primary action, shortcut, settings, permissions, updates, and quit command are discoverable from one polished menu without exposing Python implementation details.

## Validation

- 190 pytest tests passed.
- `ruff check voiceflow/` passed.
- Changed test files pass Ruff.
- `bash -n build-dmg.sh` and `git diff --check` passed.
- Live rumps/AppKit probe verified Starting → Ready, Accessory activation policy, branded alerts/notifications, SF Symbol aspect ratios, accessibility labels, submenus, native selections, Current App filtering, and Command-Q.
- Built, mounted, and smoke-tested a local arm64 0.3.4 DMG.

After merge and green CI, the release follow-up will create signed/notarized 0.3.4 DMGs and update the website only after those assets exist.