### PR TITLE
Make it visible: Input Monitoring check, dead-hotkey watchdog, modal alerts, Dock icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Startup now checks the **Input Monitoring** permission — the one the
+  global hotkey listener actually needs. It was never verified (only the
+  doctor knew about it), so a missing grant produced a "Ready" menu with a
+  hotkey that silently never fired. A denied probe warns loudly with a
+  one-click System Settings link but never blocks startup, because
+  Accessibility trust can also grant listen access.
+- A new dead-listener watchdog catches the same failure by measuring
+  reality: if no key events at all arrive within 15 seconds of the
+  listener starting *and* macOS reports Input Monitoring denied, the menu
+  bar shows a front-and-center alert with the fix. An idle user without
+  the permission problem gets a one-time gentle tip instead. (Previously
+  this self-check existed only for the fn/Globe key, never for the
+  default Right Command hotkey.)
+- Setup failures at launch now surface as a **modal alert** with a
+  one-click settings link instead of only a Notification Center banner —
+  notifications require a permission of their own and the status item can
+  hide behind a MacBook notch, so the old failure path could be entirely
+  invisible.
 - A corrupt or wrong-shaped file in `~/.openvoiceflow/` (snippets, stats,
   profile, dictionary aliases, transcript logs, seen-tips) can no longer make
   every dictation fail with a generic error: all user-data loaders now
@@ -52,8 +70,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   versions ("12") no longer compare below the (12, 0) minimum.
 
 ### Added
+- The menu-bar app now shows a **Dock icon** while running (toggleable via
+  **Advanced → Show in Dock**, default on). A menu-bar-only icon can hide
+  behind a MacBook notch, leaving no visible sign the app is running;
+  clicking the Dock icon opens the native status summary with the active
+  dictation shortcut.
 - 17 regression tests pinning the defensive-loader, learner-threshold,
-  updater, and macOS-version behaviors (`tests/test_defensive_loaders.py`).
+  updater, and macOS-version behaviors (`tests/test_defensive_loaders.py`),
+  plus 12 pinning the Input Monitoring gate, dead-listener watchdog, and
+  Dock default (`tests/test_visibility_and_watchdog.py`).
 
 ### Changed
 - CI lint now covers the entire repository (`ruff check .`), not just

--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ For the simplest signed install, download OpenVoiceFlow from the website. The so
 
 Open the website-hosted DMG, drag OpenVoiceFlow to Applications, then launch it.
 
-OpenVoiceFlow is a **menu-bar app**, so it does not stay in the Dock. Look for
-the monochrome **waveform icon** at the top-right of the screen. Click it for a
-native macOS menu whose first action is **Open OpenVoiceFlow**; the same menu
-lets you pause listening, change the dictation shortcut, select AI cleanup and
-writing styles, open permission settings, and **Check for Updates**.
+OpenVoiceFlow is a **menu-bar app**: look for the monochrome **waveform icon**
+at the top-right of the screen. It also shows a **Dock icon** while running —
+click it to see the app's status and active shortcut (on notched MacBooks the
+menu-bar icon can be hidden, so the Dock icon is your always-visible signal;
+turn it off under **Advanced → Show in Dock** for a lighter footprint). Click
+the waveform for a native macOS menu whose first action is
+**Open OpenVoiceFlow**; the same menu lets you pause listening, change the
+dictation shortcut, select AI cleanup and writing styles, open permission
+settings, and **Check for Updates**.
 
 To dictate, click in any text field, hold the **Right Command (⌘)** key, speak,
 then release it. The transcribed text appears at the cursor. The icon changes

--- a/tests/test_menubar_initialization.py
+++ b/tests/test_menubar_initialization.py
@@ -292,7 +292,12 @@ def test_real_rumps_constructor_builds_the_branded_menu(
     monkeypatch.setattr(context, "get_frontmost_app", lambda: "TextEdit")
     monkeypatch.setattr(context, "get_style_for_app", lambda *_args: "default")
     monkeypatch.setattr(updater, "check_for_updates", lambda **_kwargs: None)
-    monkeypatch.setattr(menubar, "_configure_macos_application", lambda: None)
+    monkeypatch.setattr(
+        menubar, "_configure_macos_application", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        menubar, "_install_dock_activation_handler", lambda _app: None
+    )
     monkeypatch.setattr(menubar, "_frontmost_app_is_current_process", lambda: False)
     monkeypatch.setattr(
         menubar.rumps,

--- a/tests/test_visibility_and_watchdog.py
+++ b/tests/test_visibility_and_watchdog.py
@@ -1,0 +1,215 @@
+"""Visibility & dead-hotkey fixes: the app must never look Ready while dead.
+
+Root cause pinned here: to capture the global hotkey, pynput needs macOS
+Input Monitoring; without it the listener starts cleanly and then receives
+NOTHING — the menu said "Ready — Hold ⌘" while the hotkey was silently
+dead, and validate_setup never checked Input Monitoring at all (the doctor
+did, the startup gate didn't).
+
+Design rules pinned by these tests:
+  - Input Monitoring denied → warn loudly, NEVER block (Accessibility trust
+    often also grants listen access, so a denied probe can be a false
+    negative — a hard gate would strand working setups).
+  - The dead-listener watchdog escalates only when the static probe AND
+    reality agree (no key events at all); an idle user alone gets a gentle
+    one-time tip, not an alarm.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+@pytest.fixture
+def app_module(monkeypatch):
+    """voiceflow.app with a stubbed recorder + happy-path validate inputs."""
+    import sys
+
+    import voiceflow.app as appmod
+
+    monkeypatch.setattr(appmod, "AudioRecorder", lambda *a, **kw: object())
+    monkeypatch.setattr(
+        appmod, "load_config",
+        lambda: {"llm_backend": "none", "whisper_model": "base.en",
+                 "sample_rate": 16000, "channels": 1, "hotkey": "right_cmd"},
+    )
+    monkeypatch.setattr(appmod, "find_whisper_cpp", lambda: "/opt/homebrew/bin/whisper-cli")
+    monkeypatch.setattr(appmod, "get_model_path", lambda name: "/fake/model")
+    monkeypatch.setattr(appmod.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(appmod.os.path, "getsize", lambda p: 142_000_000)
+    monkeypatch.setattr(appmod, "_is_accessibility_trusted", lambda: True)
+    monkeypatch.setitem(sys.modules, "sounddevice", types.ModuleType("sounddevice"))
+    return appmod
+
+
+@pytest.fixture
+def notify_calls(monkeypatch):
+    """Record every notify call as (kind, message, kwargs)."""
+    import voiceflow.notify as notify
+
+    calls: list = []
+    for kind in ("error", "warn", "tip"):
+        monkeypatch.setattr(
+            notify, kind,
+            lambda msg, *, _kind=kind, **kw: calls.append((_kind, msg, kw)),
+        )
+    return calls
+
+
+# ─────────────────────────────────────────────────────────────────────
+# validate_setup: Input Monitoring is checked, loudly, but never blocks
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_input_monitoring_denied_warns_but_does_not_block(
+    app_module, notify_calls, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        app_module.platform_support, "input_monitoring_status", lambda: False
+    )
+    vf = app_module.OpenVoiceFlow()
+    assert vf.validate_setup() is True, "a denied probe must never block startup"
+    assert any(kind == "input_monitoring" for kind, _ in vf.setup_warnings)
+    warns = [c for c in notify_calls if c[0] == "warn"]
+    assert warns, "denied Input Monitoring must produce a visible warning"
+    assert warns[-1][2]["action"] == (
+        "Open Input Monitoring Settings",
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
+    )
+
+
+def test_input_monitoring_unknown_stays_silent(
+    app_module, notify_calls, monkeypatch
+) -> None:
+    """None (cannot probe — e.g. Linux CI) is not a warning."""
+    monkeypatch.setattr(
+        app_module.platform_support, "input_monitoring_status", lambda: None
+    )
+    vf = app_module.OpenVoiceFlow()
+    assert vf.validate_setup() is True
+    assert vf.setup_warnings == []
+    assert not [c for c in notify_calls if c[0] == "warn"]
+
+
+def test_setup_errors_exposed_for_menubar_alert(app_module, notify_calls, monkeypatch) -> None:
+    """The menubar's modal alert needs the error list, not just False."""
+    monkeypatch.setattr(app_module, "_is_accessibility_trusted", lambda: False)
+    monkeypatch.setattr(app_module, "_prompt_accessibility_consent", lambda: None)
+    vf = app_module.OpenVoiceFlow()
+    assert vf.validate_setup() is False
+    assert any("Accessibility permission" in e for e in vf.setup_errors)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Dead-listener watchdog
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_watchdog_silent_when_key_events_seen(app_module, notify_calls) -> None:
+    vf = app_module.OpenVoiceFlow()
+    vf._any_key_event_seen = True
+    vf._check_dead_listener(on_dead_hotkey=lambda msg: notify_calls.append(("cb", msg, {})))
+    assert notify_calls == []
+
+
+def test_watchdog_dead_listener_calls_menubar_callback(
+    app_module, notify_calls, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        app_module.platform_support, "input_monitoring_status", lambda: False
+    )
+    vf = app_module.OpenVoiceFlow()
+    callback_messages: list = []
+    vf._check_dead_listener(on_dead_hotkey=callback_messages.append)
+    assert callback_messages and "Input Monitoring" in callback_messages[0]
+    assert not [c for c in notify_calls if c[0] == "error"], (
+        "when the menubar callback handles it, no duplicate notification"
+    )
+
+
+def test_watchdog_dead_listener_cli_fallback_notifies(
+    app_module, notify_calls, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        app_module.platform_support, "input_monitoring_status", lambda: False
+    )
+    vf = app_module.OpenVoiceFlow()
+    vf._check_dead_listener(on_dead_hotkey=None)
+    errors = [c for c in notify_calls if c[0] == "error"]
+    assert errors and errors[-1][2]["action"] == (
+        "Open Input Monitoring Settings",
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
+    )
+
+
+def test_watchdog_idle_user_gets_gentle_tip_not_alarm(
+    app_module, notify_calls, monkeypatch
+) -> None:
+    """No events but permission looks fine → the user may just be idle."""
+    monkeypatch.setattr(
+        app_module.platform_support, "input_monitoring_status", lambda: True
+    )
+    vf = app_module.OpenVoiceFlow()
+    vf._check_dead_listener(on_dead_hotkey=lambda msg: pytest.fail("must not alarm"))
+    tips = [c for c in notify_calls if c[0] == "tip"]
+    assert tips and tips[-1][2]["once_key"] == "hotkey_no_events"
+    assert not [c for c in notify_calls if c[0] == "error"]
+
+
+def test_any_key_event_flag_set_on_press_and_release(app_module) -> None:
+    vf = app_module.OpenVoiceFlow()
+    assert vf._any_key_event_seen is False
+    vf.on_key_press(object())
+    assert vf._any_key_event_seen is True
+    vf._any_key_event_seen = False
+    vf.on_key_release(object())
+    assert vf._any_key_event_seen is True
+
+
+def test_watchdog_thread_started_for_default_hotkey(app_module, monkeypatch) -> None:
+    """The fn-only probe never covered right_cmd; the watchdog must."""
+    created: list = []
+
+    class _FakeThread:
+        def __init__(self, *a, **kw):
+            created.append(kw)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(app_module.threading, "Thread", _FakeThread)
+    vf = app_module.OpenVoiceFlow()
+    vf.start_hotkey_runtime_checks()
+    assert any(kw.get("name") == "ovf-hotkey-watchdog" for kw in created)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Menubar helpers + Dock config default
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_settings_pane_for_accessibility_error() -> None:
+    from voiceflow.menubar import _settings_pane_for_errors
+
+    pane = _settings_pane_for_errors(
+        ["Accessibility permission not granted. Enable OpenVoiceFlow ..."]
+    )
+    assert pane is not None
+    label, url = pane
+    assert label == "Open Accessibility Settings"
+    assert url.endswith("Privacy_Accessibility")
+
+
+def test_settings_pane_none_for_non_permission_errors() -> None:
+    from voiceflow.menubar import _settings_pane_for_errors
+
+    assert _settings_pane_for_errors(["whisper.cpp not found."]) is None
+    assert _settings_pane_for_errors([]) is None
+
+
+def test_default_config_shows_dock_icon() -> None:
+    """Dock presence defaults on: a notch can hide a menu-bar-only icon."""
+    from voiceflow.config import DEFAULTS
+
+    assert DEFAULTS["show_dock_icon"] is True

--- a/voiceflow/app.py
+++ b/voiceflow/app.py
@@ -77,6 +77,12 @@ def _maybe_voice_command_tutor(text_before: str, text_after: str) -> None:
         )
 
 
+# Same deep link the doctor's Input Monitoring fix uses.
+_INPUT_MONITORING_SETTINGS_URL = (
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+)
+
+
 def _is_accessibility_trusted() -> bool:
     """Return True when the process is trusted for macOS Accessibility APIs."""
     status = platform_support.accessibility_status()
@@ -149,9 +155,20 @@ class OpenVoiceFlow:
         self._fn_event_seen = False
         self._recording_indicator_inserted = False
 
+        # Dead-listener watchdog state: True once ANY key event reaches us.
+        # Without Input Monitoring, pynput's listener starts cleanly and
+        # then receives nothing — this flag is how we tell "Ready" apart
+        # from "silently dead".
+        self._any_key_event_seen = False
+
+        # validate_setup results, exposed for the menubar's alert UI.
+        self.setup_errors: list[str] = []
+        self.setup_warnings: list[tuple[str, str]] = []
+
     def validate_setup(self) -> bool:
         """Check that all dependencies are ready."""
         errors = []
+        self.setup_warnings = []
 
         # whisper.cpp
         whisper_bin = self.config.get("whisper_cpp_path") or find_whisper_cpp()
@@ -205,6 +222,34 @@ class OpenVoiceFlow:
                 "then relaunch the app"
             )
 
+        # Input Monitoring — what the global hotkey listener actually needs.
+        # TCC nuance: Accessibility trust often also grants listen access,
+        # so a denied probe does not always mean a dead hotkey. Warn loudly
+        # but never block — a false block would strand working setups. The
+        # dead-listener watchdog escalates if key events genuinely never
+        # arrive.
+        input_monitoring = platform_support.input_monitoring_status()
+        if input_monitoring is True:
+            print("✅ Input Monitoring permission granted")
+        elif input_monitoring is False:
+            warning = (
+                "Input Monitoring permission not granted — the dictation "
+                "hotkey may not respond. Enable OpenVoiceFlow in System "
+                "Settings -> Privacy & Security -> Input Monitoring, then "
+                "relaunch the app."
+            )
+            print(f"⚠️  {warning}")
+            self.setup_warnings.append(("input_monitoring", warning))
+            from . import notify
+            notify.warn(
+                warning,
+                action=(
+                    "Open Input Monitoring Settings",
+                    _INPUT_MONITORING_SETTINGS_URL,
+                ),
+            )
+
+        self.setup_errors = errors
         if errors:
             print("\n❌ Setup issues:")
             for e in errors:
@@ -255,6 +300,7 @@ class OpenVoiceFlow:
 
     def on_key_press(self, key):
         try:
+            self._any_key_event_seen = True
             hotkey = self.config["hotkey"]
             target = self._get_key_map().get(hotkey)
             if hotkey == "left_fn" and target and key == target:
@@ -264,11 +310,72 @@ class OpenVoiceFlow:
         except Exception:
             pass
 
-    def start_hotkey_runtime_checks(self):
-        """Start non-blocking runtime checks for fn hotkey reliability."""
+    # Seconds to wait for the first key event before concluding the listener
+    # is receiving nothing. Long enough that a normal launch-then-type flow
+    # registers an event first; short enough that a dead setup surfaces
+    # while the user is still paying attention.
+    _DEAD_LISTENER_WINDOW = 15
+
+    def _check_dead_listener(self, on_dead_hotkey=None):
+        """Escalate when the listener is up but macOS delivers no events.
+
+        Fires the modal path only when the static Input Monitoring probe
+        agrees the permission is denied — an idle user alone must not
+        trigger the alarm (they get a one-time gentle tip instead).
+        """
+        if self._any_key_event_seen:
+            return
+        from . import notify
+        if platform_support.input_monitoring_status() is False:
+            message = (
+                "OpenVoiceFlow isn't receiving keyboard events, and macOS "
+                "reports Input Monitoring is not granted — the dictation "
+                "hotkey will not work. Enable OpenVoiceFlow in System "
+                "Settings > Privacy & Security > Input Monitoring, then "
+                "relaunch the app."
+            )
+            if on_dead_hotkey is not None:
+                try:
+                    on_dead_hotkey(message)
+                    return
+                except Exception:
+                    pass
+            notify.error(
+                message,
+                action=(
+                    "Open Input Monitoring Settings",
+                    _INPUT_MONITORING_SETTINGS_URL,
+                ),
+            )
+        else:
+            notify.tip(
+                "No key events seen yet. If the dictation hotkey doesn't "
+                "respond, check System Settings > Privacy & Security > "
+                "Input Monitoring and relaunch the app.",
+                once_key="hotkey_no_events",
+            )
+
+    def start_hotkey_runtime_checks(self, on_dead_hotkey=None):
+        """Start non-blocking runtime checks for hotkey reliability.
+
+        ``on_dead_hotkey`` receives a message (from a daemon thread) when
+        the listener has been up for the watch window without a single key
+        event AND Input Monitoring is denied — the signature of a silently
+        dead listener. Menubar mode passes a modal-alert callback; CLI mode
+        falls back to a Notification Center error.
+        """
         if self._fn_probe_started:
             return
         self._fn_probe_started = True
+
+        def _watch_key_events():
+            time.sleep(self._DEAD_LISTENER_WINDOW)
+            self._check_dead_listener(on_dead_hotkey)
+
+        watchdog = threading.Thread(
+            target=_watch_key_events, daemon=True, name="ovf-hotkey-watchdog"
+        )
+        watchdog.start()
 
         if self.config.get("hotkey") != "left_fn":
             return
@@ -301,6 +408,7 @@ class OpenVoiceFlow:
 
     def on_key_release(self, key):
         try:
+            self._any_key_event_seen = True
             hotkey = self.config["hotkey"]
             target = self._get_key_map().get(hotkey)
             if target and key == target and self.is_recording:

--- a/voiceflow/config.py
+++ b/voiceflow/config.py
@@ -38,6 +38,11 @@ DEFAULTS = {
     "language": "en",  # Transcription language (en, es, de, ja, auto, etc.)
     "style": "default",  # Output style: default, casual, formal, code, email
     "launch_at_login": False,  # Auto-start on macOS login
+    # Dock presence for the menu-bar app. A menu-bar-only icon can hide
+    # behind a MacBook notch, leaving no visible sign the app is running;
+    # default on, with "Show in Dock" in the Advanced menu to return to
+    # the lightweight Dock-less mode.
+    "show_dock_icon": True,
     # Per-app automatic style detection (Feature 2)
     "auto_style": True,  # Automatically switch style based on the frontmost app
     "app_styles": {

--- a/voiceflow/menubar.py
+++ b/voiceflow/menubar.py
@@ -169,12 +169,23 @@ def _app_icon_path() -> str | None:
     return None
 
 
+# True while a _show_alert dialog is on screen. NSAlert activates the app,
+# which would otherwise make the Dock-activation handler pop the status
+# panel on top of every alert this app shows.
+_alert_active = False
+
+
 def _show_alert(**kwargs):
     """Show a native alert with OpenVoiceFlow branding."""
+    global _alert_active
     icon_path = _app_icon_path()
     if icon_path:
         kwargs.setdefault("icon_path", icon_path)
-    return rumps.alert(**kwargs)
+    _alert_active = True
+    try:
+        return rumps.alert(**kwargs)
+    finally:
+        _alert_active = False
 
 
 def _show_notification(title: str, subtitle: str, message: str, **kwargs) -> None:
@@ -200,17 +211,39 @@ def _show_notification(title: str, subtitle: str, message: str, **kwargs) -> Non
             print(f"{title}: {subtitle} {message}".strip(), file=sys.stderr)
 
 
-def _configure_macos_application() -> None:
-    """Keep the Python UI process Dock-less and give alerts our app icon."""
+def _apply_activation_policy(show_dock_icon: bool) -> None:
+    """Show or hide the Dock icon for this UI process.
+
+    Regular puts the app in the Dock and the Cmd-Tab switcher — an
+    always-visible sign it is running (a menu-bar-only icon can hide
+    behind a MacBook notch). Accessory is the pre-0.3.5 Dock-less mode.
+    The bundle plist keeps LSUIElement=true, so the runtime policy is the
+    single source of truth for Dock presence.
+    """
     try:
         from AppKit import (
             NSApplication,
             NSApplicationActivationPolicyAccessory,
-            NSImage,
+            NSApplicationActivationPolicyRegular,
         )
 
+        policy = (
+            NSApplicationActivationPolicyRegular
+            if show_dock_icon
+            else NSApplicationActivationPolicyAccessory
+        )
+        NSApplication.sharedApplication().setActivationPolicy_(policy)
+    except Exception:
+        pass
+
+
+def _configure_macos_application(show_dock_icon: bool = False) -> None:
+    """Set the UI process's Dock presence and give alerts our app icon."""
+    _apply_activation_policy(show_dock_icon)
+    try:
+        from AppKit import NSApplication, NSImage
+
         application = NSApplication.sharedApplication()
-        application.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
         icon_path = _app_icon_path()
         if icon_path:
             icon = NSImage.alloc().initWithContentsOfFile_(icon_path)
@@ -218,6 +251,55 @@ def _configure_macos_application() -> None:
                 application.setApplicationIconImage_(icon)
     except Exception:
         pass
+
+
+# Ignore app activations this soon after launch: macOS may activate the
+# process once as it starts, and that must not pop the status panel.
+_DOCK_ACTIVATION_GRACE_SECONDS = 5.0
+
+
+def _install_dock_activation_handler(app) -> None:
+    """Open the status panel when the user activates us from the Dock.
+
+    A Dock icon that does nothing when clicked is worse than none. The app
+    has no windows, so activation (Dock click or Cmd-Tab) routes to the
+    same native status summary as the "Open OpenVoiceFlow" menu item.
+    Registered once; the handler itself re-checks the config so toggling
+    the Dock icon off also disables it.
+    """
+    if getattr(app, "_dock_activation_observer", None) is not None:
+        return
+    try:
+        import time
+
+        from AppKit import NSNotificationCenter, NSOperationQueue
+
+        started = time.monotonic()
+
+        def _on_did_become_active(_notification):
+            if time.monotonic() - started < _DOCK_ACTIVATION_GRACE_SECONDS:
+                return
+            if not bool(app.config.get("show_dock_icon", True)):
+                return
+            if _alert_active or getattr(app, "_dock_activation_busy", False):
+                return
+            app._dock_activation_busy = True
+            try:
+                app.open_app(None)
+            finally:
+                app._dock_activation_busy = False
+
+        app._dock_activation_observer = (
+            NSNotificationCenter.defaultCenter()
+            .addObserverForName_object_queue_usingBlock_(
+                "NSApplicationDidBecomeActiveNotification",
+                None,
+                NSOperationQueue.mainQueue(),
+                _on_did_become_active,
+            )
+        )
+    except Exception:
+        app._dock_activation_observer = None
 
 
 def _is_current_process(
@@ -265,6 +347,17 @@ def _frontmost_app_is_current_process() -> bool:
         )
     except Exception:
         return False
+
+
+def _settings_pane_for_errors(errors: list[str]) -> tuple[str, str] | None:
+    """Pick the one-click System Settings target for a failed validation."""
+    joined = " ".join(errors)
+    if "Accessibility permission" in joined:
+        return (
+            "Open Accessibility Settings",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+        )
+    return None
 
 
 def _status_line(running: bool, hotkey: str) -> str:
@@ -409,7 +502,9 @@ def run_menubar():
     )
     from .stats import load_stats
 
-    _configure_macos_application()
+    _configure_macos_application(
+        bool(load_config().get("show_dock_icon", True))
+    )
 
     def make_item(item_id: str, callback=None):
         title, key = _MENU_ITEM_SPECS[item_id]
@@ -500,9 +595,18 @@ def run_menubar():
                 callback=self.toggle_autostart,
             )
             _set_checked(self.autostart_item, self._autostart_enabled())
+            self.dock_icon_item = rumps.MenuItem(
+                "Show in Dock",
+                callback=self.toggle_dock_icon,
+            )
+            _set_checked(
+                self.dock_icon_item,
+                bool(self.config.get("show_dock_icon", True)),
+            )
             advanced_items = (
                 self.streaming_item,
                 self.autostart_item,
+                self.dock_icon_item,
                 None,
                 rumps.MenuItem(
                     "Microphone Settings…",
@@ -680,6 +784,54 @@ def run_menubar():
                     ok="OK",
                 )
 
+        def _present_setup_errors(self):
+            """Surface validation failures front-and-center.
+
+            Notifications need a permission of their own and the status
+            item can hide behind a MacBook notch, so a failed setup uses a
+            modal alert — the one channel that is always visible.
+            """
+            errors = list(getattr(self.vf, "setup_errors", None) or [])
+            details = "\n".join(f"• {e}" for e in errors) or (
+                "Run `openvoiceflow --doctor` in Terminal for a full report."
+            )
+            pane = _settings_pane_for_errors(errors)
+            if pane is None:
+                _show_alert(
+                    title="OpenVoiceFlow — Setup Required",
+                    message=f"Dictation can't start yet:\n\n{details}",
+                    ok="OK",
+                )
+                return
+            pane_label, pane_url = pane
+            result = _show_alert(
+                title="OpenVoiceFlow — Setup Required",
+                message=f"Dictation can't start yet:\n\n{details}",
+                ok=pane_label,
+                cancel="Later",
+            )
+            if _alert_confirmed(result):
+                _open_url(pane_url)
+
+        def _present_dead_hotkey_alert(self, message):
+            """Modal alert from the dead-listener watchdog (daemon thread)."""
+            def _show():
+                _apply_status_bar_state(self, "error")
+                self.status_item.title = "Check Input Monitoring"
+                result = _show_alert(
+                    title="OpenVoiceFlow — Hotkey Not Working",
+                    message=message,
+                    ok="Open Input Monitoring Settings",
+                    cancel="Later",
+                )
+                if _alert_confirmed(result):
+                    _open_url(
+                        "x-apple.systempreferences:com.apple.preference."
+                        "security?Privacy_ListenEvent"
+                    )
+
+            _call_on_main_thread(_show)
+
         def start_listening(self):
             self.vf = OpenVoiceFlow()
             if not self.vf.validate_setup():
@@ -687,11 +839,7 @@ def run_menubar():
                 _set_checked(self.listening_item, False)
                 _apply_status_bar_state(self, "error")
                 self.status_item.title = "Setup Required"
-                _show_notification(
-                    "OpenVoiceFlow",
-                    "Setup Required",
-                    "Open the menu for settings and setup help.",
-                )
+                self._present_setup_errors()
                 return
 
             try:
@@ -713,7 +861,9 @@ def run_menubar():
                 on_release=self.vf.on_key_release,
             )
             self.listener.start()
-            self.vf.start_hotkey_runtime_checks()
+            self.vf.start_hotkey_runtime_checks(
+                on_dead_hotkey=self._present_dead_hotkey_alert,
+            )
             self._running = True
             _set_checked(self.listening_item, True)
             _apply_status_bar_state(self, "ready")
@@ -937,6 +1087,15 @@ def run_menubar():
             except Exception as exc:
                 _show_alert(title="Profile Error", message=str(exc))
 
+        def toggle_dock_icon(self, _):
+            enabled = not bool(self.config.get("show_dock_icon", True))
+            self.config["show_dock_icon"] = enabled
+            save_config(self.config)
+            _set_checked(self.dock_icon_item, enabled)
+            _apply_activation_policy(enabled)
+            if enabled:
+                _install_dock_activation_handler(self)
+
         def toggle_autostart(self, _):
             try:
                 from .autostart import get_autostart_status, set_autostart
@@ -1069,4 +1228,7 @@ def run_menubar():
             self.stop_listening()
             rumps.quit_application()
 
-    OpenVoiceFlowMenuBar().run()
+    app = OpenVoiceFlowMenuBar()
+    if bool(app.config.get("show_dock_icon", True)):
+        _install_dock_activation_handler(app)
+    app.run()


### PR DESCRIPTION
## Problem

Real-user report (M3 Pro MacBook Pro, Sequoia 15.7.4, notched 14" + 34" external display): *"I have no idea whether it's running or not. I can't see it in the Dock, I don't know what the hotkey is, I don't see it in the menu bar — and pressing the hotkey does nothing."*

Root causes found:

1. **`validate_setup` never checked Input Monitoring** — the permission the global hotkey listener actually needs. The doctor knew (*"Denied — the hotkey will never fire"*, `doctor.py`), the startup gate didn't. Result: a "Ready — Hold ⌘" menu with a silently dead hotkey.
2. **Every failure signal routed through invisible channels**: Notification Center (needs its own permission) and a status item that a MacBook notch can hide entirely. The app is deliberately Dock-less (`LSUIElement=true`), so there was no visible sign it was even running.
3. The existing dead-hotkey self-check covered **only the fn/Globe key**, never the default `right_cmd`.

## What changed

- **`validate_setup` probes Input Monitoring** — denied → loud warning with a one-click `Privacy_ListenEvent` settings deep link, but **never blocks**: TCC often grants listen access via Accessibility trust alone, so a denied probe can be a false negative and a hard gate would strand working setups. `setup_errors`/`setup_warnings` are exposed on the instance for the menubar UI.
- **Dead-listener watchdog (all hotkeys)** — if zero key events arrive within 15s of the listener starting *and* the probe reports denied, escalate: menubar shows a modal "Hotkey Not Working" alert with the settings button and flips the status item to "Check Input Monitoring"; CLI falls back to `notify.error`. Probe fine but silent → one-time gentle tip (an idle user must never see an alarm).
- **Setup failures are now modal** — a native alert listing the exact errors with a one-click Accessibility settings button, replacing the notification-only path.
- **Dock icon while running (default on)** — Regular activation policy; clicking the Dock icon (or ⌘-Tab) opens the existing "Open OpenVoiceFlow" native status summary showing state + active shortcut. Toggle: **Advanced → Show in Dock** (`show_dock_icon` config key). The bundle plist keeps `LSUIElement=true` so runtime policy is the single source of truth. Guards: `_alert_active` flag (our own alerts activate the app) + 5s launch grace period + re-entrancy flag.
- README updated; website install guide intentionally untouched (it documents the shipped 0.3.4 DMG; updates land in the next release PR per the release flow). CHANGELOG under `[Unreleased]`. No version bump.

## Verification

- `pytest -q` — **220 passed, 1 skipped** (rumps optional-dep skip): 208 pre-existing + 12 new in `tests/test_visibility_and_watchdog.py`
- `ruff check .` — clean; `compileall` — clean; Python 3.9 compat suite passes (`from __future__ import annotations` throughout, no runtime unions)

## ⚠️ Needs real-Mac verification before release

I cannot exercise AppKit from this environment. Before cutting the next DMG, please verify on your Mac:
1. Dock icon appears on launch and clicking it opens the status panel (and doesn't double-fire on top of other alerts).
2. "Show in Dock" toggle hides/shows the icon live.
3. With Input Monitoring revoked: the watchdog alert appears ~15s after launch; granting + relaunching makes the hotkey work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSz3HajTkyKP6UPYJjpZ83

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSz3HajTkyKP6UPYJjpZ83)_