### PR TITLE
harden: runtime, data-loss, security, and packaging fixes from end-to-end audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — production-hardening pass (end-to-end audit follow-up)
+- **Hotkey can't be wedged by a consent dialog.** The microphone is now armed
+  on the event-tap thread and the ~150 ms of `osascript` context capture runs
+  on a worker, so a stalled Automation/Accessibility dialog can no longer block
+  (and let macOS disable) the global hotkey.
+- **Runaway recordings self-terminate.** A max-duration watchdog force-stops a
+  dictation whose key-release was lost, instead of leaving the mic and
+  `whisper-stream` running indefinitely.
+- **No PortAudio stream leak.** `recorder.stop()` always releases the audio
+  stream even when the input device is unplugged mid-recording; that failure is
+  now surfaced instead of silently freezing the overlay.
+- **Clipboard data-loss fixed.** Selected-text capture no longer overwrites a
+  non-text clipboard (image/file) and never restores empty text over the
+  selection.
+- **Security defense-in-depth.** Secrets are written with `O_EXCL|O_NOFOLLOW`
+  (symlink-swap safe); `~/.openvoiceflow/logs/` is `0700`; LLM/Ollama responses
+  are read with a 16 MB cap; `ollama_url` rejects non-HTTP schemes and warns
+  when it points off-box. Hung `pbcopy` children are reaped, not orphaned.
+- **Upgrades actually reinstall dependencies.** The DMG venv marker is now
+  version-stamped, so a release that adds or bumps a dependency reinstalls for
+  existing upgraders instead of breaking on import.
+- **Overlay polish.** HUD timers run in the common run-loop mode (no freeze
+  during menu tracking), fades honor Reduce Motion, and the window is ordered
+  out after fading so it doesn't linger in every Space.
+- **Know-Me interview no longer self-destructs** when Escape is pressed while a
+  text field is focused.
+
+See [`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md) for the full audit and
+the remaining roadmap (native onboarding, self-contained bundle, Sparkle, etc.).
+
 ## [0.3.5] — 2026-07-13
 
 ### Fixed — first launch could silently do nothing (no menu bar icon, no wizard)

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -1,0 +1,139 @@
+# Production readiness — audit findings & roadmap
+
+An end-to-end audit (runtime/concurrency, macOS UX vs. Apple HIG, packaging/
+first-run, security/privacy) was run against the codebase. This file records
+**what was fixed** and — more importantly — **what remains**, so the path to a
+genuinely Apple-grade, "award-winning" experience is explicit and nothing is
+lost.
+
+## Done in this pass (tested, in `voiceflow/` + `build-dmg.sh`)
+
+Runtime robustness
+- Mic is armed on the event-tap thread; the ~150 ms of `osascript` context
+  capture moved to a worker so a stalled consent dialog can't disable the
+  global hotkey (**H1**).
+- Max-duration watchdog force-stops a recording whose key-release was lost,
+  instead of leaving the mic + `whisper-stream` running forever (**H2**).
+- `recorder.stop()` always releases the PortAudio stream even if the device
+  was unplugged mid-recording; the guarded stop path surfaces the error
+  instead of freezing the overlay (**H3**).
+- A failed processing-thread start rolls back the `processing` flag (no wedged
+  hotkey); `transcribe()` reports the whisper binary vanishing distinctly.
+- Hung `pbcopy`/`osascript` children are reaped on timeout, not orphaned.
+
+Data-loss & privacy
+- Selected-text capture no longer destroys a non-text clipboard (image/file)
+  and never restores empty text over the user's selection.
+- `~/.openvoiceflow/logs/` is created `0700`; the secrets writer uses
+  `O_EXCL|O_NOFOLLOW` so a symlink swap can't redirect it.
+- LLM/Ollama responses are read with a 16 MB cap; `ollama_url` is validated
+  (non-HTTP schemes rejected, off-loopback warns).
+
+Packaging
+- The venv marker is **version-stamped**, so a release that bumps a dependency
+  actually reinstalls for existing upgraders instead of silently breaking on
+  import.
+
+UX polish (safe, standard AppKit — verify visually on device)
+- Overlay timers run in `NSRunLoopCommonModes` (no freeze during menu
+  tracking); fades honor **Reduce Motion**; the window is `orderOut`-ed after
+  fade so it doesn't linger in every Space.
+- The Know-Me interview no longer abandons itself (data loss) when Escape is
+  pressed while typing in a field.
+
+---
+
+## Remaining — ranked by leverage
+
+### Tier A — the "award-winning native" investments (re-architecture)
+
+**A1. Native SwiftUI onboarding + Know-Me interview.** The first thing every
+user sees is a tkinter wizard with a hardcoded dark theme and fonts
+(`"SF Pro Display"`, `"SF Mono"`) that Tk can't resolve, so it silently renders
+Helvetica fallback with non-native buttons and no focus rings. This is the
+single highest-impact polish surface. *Rewrite in SwiftUI/AppKit.* (Cheap
+interim already partially addressed: the destructive-Escape bug is fixed.)
+
+**A2. Self-contained bundle — no Homebrew, no Terminal, no pip-at-runtime.**
+First launch currently installs the Command Line Tools, runs the Homebrew
+installer in Terminal, `brew install whisper-cpp`, builds a venv, pip-installs
+unpinned deps, and downloads a 142 MB model — a multi-minute, network-dependent,
+non-Apple experience. Ship instead: a code-signed `whisper-cli` per arch in
+`Resources/` (add the bundle path to `transcriber.py`'s probe — low risk); the
+`ggml-base.en.bin` model in the DMG (or a checksum-pinned download); and a
+relocatable interpreter (python-build-standalone) or `py2app`/PyInstaller bundle
+with wheels pre-installed and pinned at build time, code-signed and notarized as
+nested code. Payoff: true drag-to-Applications, launch-and-go, fully offline.
+
+**A3. SF Symbols + real progress in the HUD.** The recording HUD communicates
+with emoji (🔴✅❌📚) inside an `NSTextField` and a fake text-dot "spinner."
+Replace with tinted `NSImage.imageWithSystemSymbolName_` glyphs and an
+`NSProgressIndicator` (or a live mic-RMS level meter). Highest polish-per-hour;
+can be done within the current stack.
+
+**A4. In-app updates (Sparkle).** Today the app only *checks* GitHub Releases
+and sends the user to a web page to re-download and re-run the whole bootstrap.
+Integrate Sparkle with a signed (EdDSA) appcast for one-click, verified,
+auto-relaunch updates.
+
+### Tier B — packaging correctness (do before a real launch; mostly incremental)
+
+**B1. Couple the served DMG to the signing pipeline (audit C1).** Users
+download hand-committed blobs in `docs/downloads/`; the "refuse unsigned" guard
+only protects the GitHub Release asset nobody clicks. A local unsigned
+`build-dmg.sh` run can reach the website while the page claims "notarized." Fix:
+have the release workflow copy the just-notarized `dist/*.dmg` into
+`docs/downloads/`, regenerate the checksums, and gate on `spctl --assess` +
+`stapler validate` before deploy.
+
+**B2. Staple the `.app`, not just the DMG (audit H1).** Only the DMG is
+stapled; the dragged-out app carries no ticket, so an offline first launch can
+be Gatekeeper-blocked — contradicting the download page. Notarize + staple the
+`.app`, then build the DMG from the stapled app.
+
+**B3. Pin + checksum the supply chain (audit H4).** The model is fetched from a
+mutable `…/main/ggml-base.en.bin` with no checksum; pip/brew are unpinned. Pin
+the model by immutable commit SHA + verify SHA256; pin pip deps
+(`--require-hashes`); pin or drop the brew formula.
+
+**B4. Version-drift gate (audit M1) & Intel execution (M2) & CLT-Python matrix
+(M3).** Have `verify-version` also assert `download.html`/`site.js`/README match
+the tag; exercise the x86_64 launcher under Rosetta in CI; extend the CI Python
+matrix to the versions current CLT actually ships (3.12/3.13).
+
+**B5. App Translocation guard (audit M5).** Detect launch from `/Volumes/` or a
+translocated path and prompt "move to Applications."
+
+### Tier C — UX correctness within the current stack (cheap, but verify on device)
+
+- **Permission priming (audit UX #3):** three scary TCC prompts fire back-to-
+  back at first launch with no explanation and before the user knows what the
+  app does. Add a per-capability priming screen; request each in-context; defer
+  Input Monitoring until listening starts.
+- **CGEventPost paste (audit UX #5):** replace the AppleScript `System Events`
+  keystroke (a 4th Automation prompt + a subprocess on every dictation's hot
+  path) with `CGEventPost` — needs only Accessibility, no dialog, sub-ms.
+- **Screen-aware HUD (audit UX #4):** position on the display containing the
+  mouse/active window, within its `visibleFrame` (not primary-only, full frame).
+- **Menu HIG (audit UX #9):** ellipsis on dialog-opening items; clearer
+  Listening toggle; unify the hotkey label source between menu and onboarding.
+- **Measure HUD text** with `NSAttributedString.size()` instead of `chars×8px`;
+  visible radio selection in the wizards (`selectcolor=ACCENT`).
+
+### Tier D — privacy/product decisions (need a human call)
+
+- **Profile PII default (audit security M1):** completing the Know-Me interview
+  sends home/work names (incl. children's names) into the system prompt of every
+  cloud cleanup call by default (default backend is OpenRouter, which fans out to
+  sub-providers). Consider: gate the profile fragment behind explicit transmit
+  consent; prefer a local backend when a profile exists; show which fields leave
+  the machine.
+- **`--set-key KEY` (security M3):** the plaintext-arg form leaks the key into
+  `ps`/shell history; the `-` stdin form is the documented default. Consider
+  warning on, or removing, the literal-arg form.
+
+---
+
+*Effort orientation: Tier A is weeks (A2 is the biggest single lift); Tier B is
+days and gates a real public launch; Tier C is hours each but needs on-device
+visual verification; Tier D is a product/privacy decision, not just code.*

--- a/build-dmg.sh
+++ b/build-dmg.sh
@@ -128,6 +128,7 @@ PLIST
 
     # Capture vars before heredoc
     local LAUNCHER_ARCH="$ARCH"
+    local LAUNCHER_VERSION="$VERSION"
 
     local BOOTSTRAP="$APP_DIR/Contents/Resources/launcher.sh"
     cat > "$BOOTSTRAP" << LAUNCHER
@@ -135,6 +136,7 @@ PLIST
 # OpenVoiceFlow bootstrap — installs deps natively, then launches
 
 TARGET_ARCH="$LAUNCHER_ARCH"
+BUNDLE_VERSION="$LAUNCHER_VERSION"
 APP_DIR="\$(cd "\$(dirname "\$0")/.." && pwd)"
 RESOURCES="\$APP_DIR/Resources"
 export OPENVOICEFLOW_APP_RESOURCES="\$RESOURCES"
@@ -243,15 +245,26 @@ fi
 DEPS_MARKER="\$VENV/.ovf-deps-installed"
 MODEL="\$HOME_DIR/models/ggml-base.en.bin"
 
-# The marker alone is not proof of health: a macOS or Command Line Tools
-# update can break the venv's python link or its native wheels, after which
-# every launch died silently. Verify the interpreter and imports actually
-# work; rebuild from scratch when they don't.
+# The marker is version-stamped, not a bare touch: without the stamp an
+# existing user who upgrades keeps their old venv forever (the marker
+# already exists, so pip never re-runs) and a release that adds or bumps a
+# dependency breaks on import for exactly the users who upgraded. A stamp
+# mismatch forces a reinstall so the DMG's deps track the bundle version.
+DEPS_OK=""
 if [[ -f "\$PY" && -f "\$DEPS_MARKER" ]]; then
+    DEPS_OK=1
+    # (a) interpreter + native wheels still import? A macOS/CLT update can
+    # break the venv's python link or its compiled wheels.
     if ! "\$PY" -c "import numpy, sounddevice, pynput, rumps, objc" >/dev/null 2>&1; then
         echo "[\$(date)] venv failed its health check - rebuilding"
         notify "Repairing OpenVoiceFlow installation..."
         rm -rf "\$VENV"
+        DEPS_OK=""
+    # (b) marker version matches this bundle? Otherwise reinstall for the upgrade.
+    elif [[ "\$(cat "\$DEPS_MARKER" 2>/dev/null)" != "\$BUNDLE_VERSION" ]]; then
+        echo "[\$(date)] deps installed for a different version - reinstalling for \$BUNDLE_VERSION"
+        notify "Updating OpenVoiceFlow components..."
+        DEPS_OK=""
     fi
 fi
 
@@ -261,7 +274,7 @@ fi
 # guaranteed to see is this dialog.
 FIRST_RUN_WORK=""
 command -v whisper-cli &>/dev/null || command -v whisper-cpp &>/dev/null || FIRST_RUN_WORK=1
-[[ -f "\$PY" && -f "\$DEPS_MARKER" ]] || FIRST_RUN_WORK=1
+[[ -n "\$DEPS_OK" ]] || FIRST_RUN_WORK=1
 [[ -f "\$MODEL" ]] || FIRST_RUN_WORK=1
 if [[ -n "\$FIRST_RUN_WORK" ]]; then
     alert "First-time setup: OpenVoiceFlow will now install its speech engine and download the speech model. This takes about 5 minutes and needs internet.\n\nThere is no window while this runs. When it finishes, look for the microphone icon at the TOP-RIGHT of the menu bar.\n\nTip: on 14-inch and 16-inch MacBooks a full menu bar hides new icons behind the notch - close a few menu bar apps if you do not see it."
@@ -272,12 +285,13 @@ if ! command -v whisper-cli &>/dev/null && ! command -v whisper-cpp &>/dev/null;
     brew install whisper-cpp || fatal "whisper-cpp install failed. Try: brew install whisper-cpp\nLog: \$LOG"
 fi
 
-if [[ ! -f "\$PY" || ! -f "\$DEPS_MARKER" ]]; then
+if [[ -z "\$DEPS_OK" ]]; then
     notify "First run setup (~1 min)..."
-    python3 -m venv "\$VENV" || fatal "Could not create the Python environment. If macOS just asked to install the Command Line Tools, finish that install and open OpenVoiceFlow again.\n\nLog: \$LOG"
+    [[ -d "\$VENV" ]] || python3 -m venv "\$VENV" || fatal "Could not create the Python environment. If macOS just asked to install the Command Line Tools, finish that install and open OpenVoiceFlow again.\n\nLog: \$LOG"
     "\$VENV/bin/pip" install -q --upgrade pip || fatal "Python package tooling failed to update. Check your internet connection and open OpenVoiceFlow again.\n\nLog: \$LOG"
     "\$VENV/bin/pip" install -q sounddevice numpy pynput rumps pyobjc-framework-Cocoa || fatal "Package install failed. Relaunch OpenVoiceFlow to retry. Log: \$LOG"
-    touch "\$DEPS_MARKER"
+    # Stamp the marker with the bundle version so the next upgrade reinstalls.
+    printf '%s' "\$BUNDLE_VERSION" > "\$DEPS_MARKER"
 fi
 
 notify "OpenVoiceFlow is launching..."

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -188,7 +188,7 @@ def test_system_prompt_backends_apply_app_context_and_style(backend_name, monkey
         def __exit__(self, *a):
             return False
 
-        def read(self):
+        def read(self, *args):
             if backend_name == "anthropic":
                 return json.dumps({"content": [{"text": "cleaned"}]}).encode()
             return json.dumps(

--- a/tests/test_defensive_loaders.py
+++ b/tests/test_defensive_loaders.py
@@ -246,7 +246,7 @@ def test_updater_fetch_tolerates_exotic_failures(monkeypatch) -> None:
 
     class _FakeResp:
         status = 200
-        def read(self):
+        def read(self, *args):
             return b"\xff\xfe garbage"  # not UTF-8
         def __enter__(self):
             return self
@@ -257,7 +257,7 @@ def test_updater_fetch_tolerates_exotic_failures(monkeypatch) -> None:
     assert upd._fetch_latest_release() is None  # must not raise
 
     class _ListResp(_FakeResp):
-        def read(self):
+        def read(self, *args):
             return b'["not", "a", "dict"]'
 
     monkeypatch.setattr(upd.urllib.request, "urlopen", lambda *a, **kw: _ListResp())

--- a/tests/test_fn_hotkey.py
+++ b/tests/test_fn_hotkey.py
@@ -1,0 +1,58 @@
+"""The Fn / Globe key can't be a hotkey (pynput has no fn on macOS), so the
+app must (a) surface that immediately via the modal path, not a slow
+suppressible tip, and (b) not offer fn in the picker unless it's already set.
+"""
+from __future__ import annotations
+
+from voiceflow.config import DEFAULTS
+
+
+def _make_app(monkeypatch):
+    import voiceflow.app as appmod
+
+    monkeypatch.setattr(appmod, "AudioRecorder", lambda *a, **k: object())
+    monkeypatch.setattr(appmod, "load_config", lambda: dict(DEFAULTS))
+    return appmod.OpenVoiceFlow(use_overlay=False)
+
+
+def test_fn_hotkey_surfaces_immediately_through_modal(monkeypatch) -> None:
+    app = _make_app(monkeypatch)
+    app.config["hotkey"] = "left_fn"
+    app._fn_probe_started = False
+
+    modal_messages: list = []
+    app.start_hotkey_runtime_checks(on_dead_hotkey=lambda m: modal_messages.append(m))
+
+    assert modal_messages, "fn hotkey must be surfaced synchronously, not after a 12s watch"
+    assert "Right Command" in modal_messages[0]
+    assert "Fn" in modal_messages[0] or "Globe" in modal_messages[0]
+
+
+def test_non_fn_hotkey_does_not_fire_the_fn_modal(monkeypatch) -> None:
+    app = _make_app(monkeypatch)
+    app.config["hotkey"] = "right_cmd"
+    app._fn_probe_started = False
+
+    modal_messages: list = []
+    app.start_hotkey_runtime_checks(on_dead_hotkey=lambda m: modal_messages.append(m))
+    assert modal_messages == []
+
+
+def test_hotkey_picker_hides_fn_unless_it_is_current() -> None:
+    from voiceflow.menubar import _hotkey_choices
+
+    ids = [h for h, _, _ in _hotkey_choices("right_cmd")]
+    assert "left_fn" not in ids, "fn must not be offered as a fresh choice"
+
+    ids_when_set = [h for h, _, _ in _hotkey_choices("left_fn")]
+    assert "left_fn" in ids_when_set, "must still show fn (marked) so a stuck user can switch off it"
+
+
+def test_onboarding_does_not_offer_fn() -> None:
+    import inspect
+
+    from voiceflow import onboarding
+
+    src = inspect.getsource(onboarding)
+    # The selectable onboarding hotkey list must not include the fn option.
+    assert '("left_fn"' not in src

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,344 @@
+"""Production-hardening regression tests (audit follow-up).
+
+Covers the runtime, data-loss, and security fixes from the end-to-end audit:
+recorder stream-leak, max-duration watchdog, guarded stop, transcribe error
+path, clipboard non-text preservation, orphan-kill, secure-write symlink
+refusal, capped HTTP reads, and local-URL validation. All hermetic — no
+macOS, no real subprocess, no network.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from voiceflow.config import DEFAULTS
+
+# ─────────────────────────────────────────────────────────────────────
+# recorder.stop() — leak-proof (H3)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_recorder_stop_releases_stream_even_when_close_raises() -> None:
+    from voiceflow.recorder import AudioRecorder
+
+    class BadStream:
+        def __init__(self) -> None:
+            self.stopped = False
+            self.closed = False
+
+        def stop(self):
+            self.stopped = True
+            raise OSError("device unplugged")
+
+        def close(self):
+            self.closed = True
+
+    rec = AudioRecorder()
+    stream = BadStream()
+    rec._stream = stream
+    rec.is_recording = True
+
+    rec.stop()  # must not raise
+
+    assert rec._stream is None, "stream reference must be cleared (no leak on next start)"
+    assert stream.closed is True, "close() must still run after stop() raised"
+    assert rec.is_recording is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# transcribe() — binary vanished (L2)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_transcribe_returns_none_when_binary_missing(monkeypatch) -> None:
+    from voiceflow import transcriber
+
+    monkeypatch.setattr(transcriber, "find_whisper_cpp", lambda: "/opt/homebrew/bin/whisper-cli")
+    monkeypatch.setattr(transcriber, "get_model_path", lambda m: "/models/x.bin")
+    monkeypatch.setattr(transcriber.os.path, "exists", lambda p: True)
+
+    def gone(*a, **k):
+        raise FileNotFoundError("no such binary")
+
+    monkeypatch.setattr(transcriber.subprocess, "run", gone)
+    out = transcriber.transcribe("/tmp/a.wav", {"whisper_model": "base.en", "language": "en"})
+    assert out is None  # not a raised exception
+
+
+# ─────────────────────────────────────────────────────────────────────
+# clipboard — non-text preservation + no empty-clobber (security M2, M3)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_pasteboard_nontext_probe_false_without_appkit(monkeypatch) -> None:
+    from voiceflow import clipboard
+    monkeypatch.setitem(sys.modules, "AppKit", None)  # import → ImportError
+    assert clipboard._pasteboard_has_nontext_only() is False
+
+
+def test_capture_skips_entirely_when_clipboard_is_nontext(monkeypatch) -> None:
+    from voiceflow import clipboard
+    monkeypatch.setattr(clipboard, "_pasteboard_has_nontext_only", lambda: True)
+
+    def forbid(*a, **k):
+        raise AssertionError("must not touch the clipboard when it holds non-text")
+
+    monkeypatch.setattr(clipboard.subprocess, "run", forbid)
+    assert clipboard.capture_selected_text() is None
+
+
+def test_capture_never_restores_empty_clipboard(monkeypatch) -> None:
+    """Original was empty/non-text → must NOT pbcopy "" over the selection."""
+    from voiceflow import clipboard
+    monkeypatch.setattr(clipboard, "_pasteboard_has_nontext_only", lambda: False)
+
+    reads = iter(["", "the selected text"])  # original empty, then post-copy
+    monkeypatch.setattr(clipboard, "_read_clipboard", lambda: next(reads))
+    monkeypatch.setattr(clipboard.time, "sleep", lambda s: None)
+
+    class OK:
+        returncode = 0
+
+    monkeypatch.setattr(clipboard.subprocess, "run", lambda *a, **k: OK())
+    writes: list = []
+    monkeypatch.setattr(clipboard, "_write_clipboard", lambda t: writes.append(t))
+
+    result = clipboard.capture_selected_text()
+    assert result == "the selected text"
+    assert writes == [], "must not write empty text back over the clipboard"
+
+
+def test_capture_restores_genuine_prior_text(monkeypatch) -> None:
+    from voiceflow import clipboard
+    monkeypatch.setattr(clipboard, "_pasteboard_has_nontext_only", lambda: False)
+    reads = iter(["important note", "selection"])
+    monkeypatch.setattr(clipboard, "_read_clipboard", lambda: next(reads))
+    monkeypatch.setattr(clipboard.time, "sleep", lambda s: None)
+
+    class OK:
+        returncode = 0
+
+    monkeypatch.setattr(clipboard.subprocess, "run", lambda *a, **k: OK())
+    writes: list = []
+    monkeypatch.setattr(clipboard, "_write_clipboard", lambda t: writes.append(t))
+
+    assert clipboard.capture_selected_text() == "selection"
+    assert writes == ["important note"], "genuine prior text must be restored"
+
+
+def test_write_clipboard_kills_child_on_timeout(monkeypatch) -> None:
+    from voiceflow import clipboard
+
+    class HangingProc:
+        def __init__(self) -> None:
+            self.killed = False
+
+        def communicate(self, data, timeout):
+            raise subprocess.TimeoutExpired("pbcopy", timeout)
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self, *a, **k):
+            return 0
+
+    proc = HangingProc()
+    monkeypatch.setattr(clipboard.subprocess, "Popen", lambda *a, **k: proc)
+    clipboard._write_clipboard("x")  # must not raise
+    assert proc.killed is True, "a hung pbcopy must be reaped, not orphaned"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# _secure_io — symlink-safe secrets write (security L3)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_secure_write_json_roundtrip_mode_600(tmp_path) -> None:
+    import json
+    import os
+
+    from voiceflow._secure_io import secure_write_json
+
+    p = tmp_path / "config.json"
+    secure_write_json(str(p), {"a": 1, "b": "two"})
+    assert json.loads(p.read_text()) == {"a": 1, "b": "two"}
+    assert (os.stat(p).st_mode & 0o777) == 0o600
+
+
+def test_secure_write_json_refuses_symlinked_temp(tmp_path) -> None:
+    """A pre-planted symlink at the temp path must not be followed and
+    clobber its target; the write still succeeds at the real path."""
+    import json
+    import os
+
+    from voiceflow._secure_io import secure_write_json
+
+    target = tmp_path / "config.json"
+    victim = tmp_path / "victim.txt"
+    victim.write_text("do not overwrite me")
+
+    tmp_link = f"{target}.tmp{os.getpid()}"
+    os.symlink(str(victim), tmp_link)
+
+    secure_write_json(str(target), {"ok": True})
+
+    assert victim.read_text() == "do not overwrite me", "symlink target must be untouched"
+    assert json.loads(target.read_text()) == {"ok": True}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# llm.base — capped reads + local-url validation (security L1, L2)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_read_json_capped_accepts_small_body() -> None:
+    from voiceflow.llm.base import read_json_capped
+
+    class Resp:
+        def read(self, n):
+            return b'{"response": "hi"}'
+
+    assert read_json_capped(Resp(), max_bytes=1000) == {"response": "hi"}
+
+
+def test_read_json_capped_rejects_oversized_body() -> None:
+    from voiceflow.llm.base import read_json_capped
+
+    class Flood:
+        def read(self, n):
+            return b"x" * n  # always returns exactly the requested cap+1
+
+    with pytest.raises(ValueError):
+        read_json_capped(Flood(), max_bytes=8)
+
+
+def test_sanitize_local_url_rejects_non_http_scheme() -> None:
+    from voiceflow.llm.base import sanitize_local_url
+
+    default = "http://localhost:11434"
+    assert sanitize_local_url("file:///etc/passwd", default) == default
+    assert sanitize_local_url("ftp://host/x", default) == default
+    assert sanitize_local_url("not a url", default) == default
+
+
+def test_sanitize_local_url_allows_loopback_and_passes_off_box() -> None:
+    from voiceflow.llm.base import sanitize_local_url
+
+    default = "http://localhost:11434"
+    assert sanitize_local_url("http://127.0.0.1:11434", default) == "http://127.0.0.1:11434"
+    # Off-box is allowed (user may intend it) but returned unchanged.
+    assert sanitize_local_url("http://10.0.0.9:11434", default) == "http://10.0.0.9:11434"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# app controller — watchdog, guarded stop, thread-start rollback (H1/H2/H3/L1)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def vf(monkeypatch):
+    import voiceflow.app as appmod
+
+    class FakeRecorder:
+        def __init__(self, *a, **k) -> None:
+            self.started = False
+            self.stopped = False
+            self.is_recording = False
+            self.duration = 1.0
+
+        def start(self):
+            self.started = True
+            self.is_recording = True
+
+        def stop(self):
+            self.stopped = True
+            self.is_recording = False
+
+    monkeypatch.setattr(appmod, "AudioRecorder", FakeRecorder)
+    monkeypatch.setattr(appmod, "load_config", lambda: dict(DEFAULTS))
+    monkeypatch.setattr(appmod, "play_sound", lambda *a, **k: None)
+    return appmod.OpenVoiceFlow(use_overlay=False)
+
+
+def test_max_duration_watchdog_forces_stop_only_while_recording(vf, monkeypatch) -> None:
+    calls: list = []
+    monkeypatch.setattr(vf, "stop_and_process", lambda: calls.append(1))
+
+    vf.is_recording = False
+    vf._on_max_duration()
+    assert calls == []  # nothing to stop
+
+    vf.is_recording = True
+    vf._on_max_duration()
+    assert calls == [1]  # a runaway recording is force-stopped
+
+
+def test_stop_and_process_is_idempotent(vf) -> None:
+    """Only one caller (release / watchdog / abort) may drive the stop."""
+    vf.is_recording = False
+    vf.stop_and_process()  # must return immediately, touch nothing
+    assert vf.recorder.stopped is False
+    assert vf.processing is False
+
+
+def test_start_processing_rolls_back_when_thread_cannot_start(vf, monkeypatch) -> None:
+    import voiceflow.app as appmod
+
+    def no_threads(*a, **k):
+        raise RuntimeError("can't start thread")
+
+    monkeypatch.setattr(appmod.threading, "Thread", no_threads)
+    vf._start_processing(lambda: None, ())
+    assert vf.processing is False, "a failed thread-start must not wedge the hotkey"
+
+
+def test_stop_and_process_surfaces_recorder_stop_failure(vf, monkeypatch) -> None:
+    import voiceflow.notify as notify
+
+    errors: list = []
+    monkeypatch.setattr(notify, "error", lambda m, **k: errors.append(m))
+    spawned: list = []
+    monkeypatch.setattr(vf, "_start_processing", lambda *a: spawned.append(a))
+
+    vf.is_recording = True
+    vf._streaming_active = False
+
+    def device_gone():
+        vf.recorder.is_recording = False
+        raise OSError("device gone")
+
+    vf.recorder.stop = device_gone
+    vf.stop_and_process()
+
+    assert errors and "unexpectedly" in errors[0]
+    assert spawned == [], "must not spawn processing when the recorder failed to stop"
+    assert vf.processing is False
+
+
+def test_start_recording_arms_mic_before_context_capture(vf, monkeypatch) -> None:
+    """H1: the mic is armed on the event-tap thread; the ~150ms osascript
+    context capture is moved to a worker so it can't wedge the tap."""
+    import voiceflow.app as appmod
+
+    monkeypatch.setattr(vf, "_start_max_duration_timer", lambda: None)
+    captured: list = []
+    monkeypatch.setattr(vf, "_capture_context", lambda: captured.append("ran"))
+
+    threads: list = []
+    real_thread = appmod.threading.Thread
+
+    def track_thread(*a, **k):
+        t = real_thread(*a, **k)
+        threads.append(k.get("name", ""))
+        return t
+
+    monkeypatch.setattr(appmod.threading, "Thread", track_thread)
+
+    vf._last_press_time = 0
+    vf.start_recording()
+
+    assert vf.recorder.started is True, "mic must be armed synchronously"
+    assert vf.is_recording is True
+    assert "ovf-context-capture" in threads, "context capture must run on a worker thread"

--- a/tests/test_launcher_flows.py
+++ b/tests/test_launcher_flows.py
@@ -22,6 +22,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 BUILD_SCRIPT = ROOT / "build-dmg.sh"
 
+# The version the rendered test launcher is stamped with (BUNDLE_VERSION).
+TEST_BUNDLE_VERSION = "9.9.9-test"
+
 
 # ─────────────────────────────────────────────────────────────────────
 # Rendering + sandbox harness
@@ -36,7 +39,10 @@ def render_launcher() -> str:
     body = m.group(1)
     # Reproduce heredoc expansion ($VAR expands, \$ stays literal) with the
     # same build-time variable build-dmg.sh sets.
-    script = "LAUNCHER_ARCH=arm64\ncat <<LAUNCHER\n" + body + "\nLAUNCHER\n"
+    script = (
+        f"LAUNCHER_ARCH=arm64\nLAUNCHER_VERSION={TEST_BUNDLE_VERSION}\n"
+        "cat <<LAUNCHER\n" + body + "\nLAUNCHER\n"
+    )
     rendered = subprocess.run(
         ["bash", "-c", script], capture_output=True, text=True, check=True,
     ).stdout
@@ -239,7 +245,8 @@ def test_repeat_launch_with_healthy_state_shows_no_setup_dialog(sandbox) -> None
     )
     (venv / "lib").mkdir(exist_ok=True)
     write_shim(venv / "bin", "pip", "exit 0")
-    (venv / ".ovf-deps-installed").write_text("", encoding="utf-8")
+    # Marker must match the bundle version or the launcher reinstalls.
+    (venv / ".ovf-deps-installed").write_text(TEST_BUNDLE_VERSION, encoding="utf-8")
     (sandbox.state_dir / "models").mkdir(parents=True, exist_ok=True)
     (sandbox.state_dir / "models" / "ggml-base.en.bin").write_text("x", encoding="utf-8")
 
@@ -247,3 +254,30 @@ def test_repeat_launch_with_healthy_state_shows_no_setup_dialog(sandbox) -> None
     assert "First-time setup" not in sandbox.shown_dialogs
     # The final stage ran the venv python (our stub's exit code proves it).
     assert result.returncode == 42
+
+
+def test_upgrade_reinstalls_when_marker_version_differs(sandbox) -> None:
+    """A venv from an OLDER app version must trigger a reinstall — otherwise
+    a release that bumps a dependency breaks on import for upgraders."""
+    venv = sandbox.state_dir / "venv"
+    (venv / "bin").mkdir(parents=True)
+    # Interpreter + native imports are healthy (so it's NOT the health-check
+    # path); only the version stamp is stale.
+    write_shim(venv / "bin", "python3", '[[ "$*" == *"import numpy"* ]] && exit 0; exit 0')
+    (venv / ".ovf-deps-installed").write_text("0.0.1-old", encoding="utf-8")
+
+    # Stop at the reinstall's venv/pip step so the test stays hermetic.
+    write_shim(sandbox.bin, "python3", "exit 0")
+    write_shim(
+        sandbox.bin, "pip",
+        'exit 1',  # pip --upgrade fails → fatal, run stops loudly
+    )
+    # pip is invoked as "$VENV/bin/pip"; shim that path too.
+    write_shim(venv / "bin", "pip", "exit 1")
+
+    result = sandbox.run()
+    assert "reinstalling for" in sandbox.log
+    # It went into the install branch (announced first-run work) rather than
+    # launching straight through on the stale marker.
+    assert "First-time setup" in sandbox.shown_dialogs
+    assert result.returncode == 1

--- a/tests/test_menubar_initialization.py
+++ b/tests/test_menubar_initialization.py
@@ -101,7 +101,12 @@ def test_hotkey_menu_offers_every_supported_shortcut_with_human_labels() -> None
 
     choices = _hotkey_choices("right_cmd")
 
-    assert [choice[0] for choice in choices] == VALID_HOTKEYS
+    # Every valid hotkey EXCEPT fn (macOS doesn't expose it to apps, so it
+    # can't work as a hotkey — it's hidden from the picker unless it's the
+    # current setting; see test_fn_hotkey.py).
+    expected = [hk for hk in VALID_HOTKEYS if hk != "left_fn"]
+    assert [choice[0] for choice in choices] == expected
+    assert "left_fn" not in [choice[0] for choice in choices]
     assert dict((hotkey, label) for hotkey, label, _checked in choices)["right_cmd"] == "Right Command (⌘)"
     assert dict((hotkey, label) for hotkey, label, _checked in choices)["f12"] == "F12"
     assert sum(checked for _hotkey, _label, checked in choices) == 1

--- a/tests/test_openrouter_backend.py
+++ b/tests/test_openrouter_backend.py
@@ -42,7 +42,7 @@ def test_openrouter_cleanup_posts_openai_compatible_payload(monkeypatch) -> None
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *args):
             return json.dumps({"choices": [{"message": {"content": " cleaned text "}}]}).encode()
 
     def fake_urlopen(req, timeout):

--- a/voiceflow/_secure_io.py
+++ b/voiceflow/_secure_io.py
@@ -44,7 +44,19 @@ def secure_write_json(path: str | os.PathLike[str], data: Any, *, indent: int = 
     path = os.fspath(path)
     payload = json.dumps(data, indent=indent)
     tmp_path = f"{path}.tmp{os.getpid()}"
-    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # O_EXCL: refuse to open through an attacker-pre-planted temp file.
+    # O_NOFOLLOW: never follow a symlink at the temp path. Together these
+    # stop a same-directory symlink swap from redirecting a secrets write.
+    # (O_NOFOLLOW may be absent on exotic platforms — degrade gracefully.)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(tmp_path, flags, 0o600)
+    except FileExistsError:
+        # A stale temp file from a crashed write (same pid reused) — remove
+        # it and retry once. A real symlink here is refused by O_EXCL above.
+        os.unlink(tmp_path)
+        fd = os.open(tmp_path, flags, 0o600)
     try:
         with os.fdopen(fd, "w") as f:
             f.write(payload)

--- a/voiceflow/app.py
+++ b/voiceflow/app.py
@@ -161,6 +161,15 @@ class OpenVoiceFlow:
         # from "silently dead".
         self._any_key_event_seen = False
 
+        # Serializes the recording start/stop transition so the pynput
+        # callback thread, the max-duration watchdog, and the menubar's
+        # abort path can't drive a dictation into a half-stopped state.
+        self._lifecycle_lock = threading.Lock()
+        # Force-stops a recording if the key-release event is ever missed
+        # (a stalled consent dialog can disable the event tap and swallow it),
+        # which would otherwise leave the mic + whisper-stream running forever.
+        self._max_record_timer: threading.Timer | None = None
+
         # validate_setup results, exposed for the menubar's alert UI.
         self.setup_errors: list[str] = []
         self.setup_warnings: list[tuple[str, str]] = []
@@ -450,11 +459,23 @@ class OpenVoiceFlow:
             "Check the microphone and Input Monitoring permissions."
         )
 
+    # Hard ceiling on a single dictation. Long enough for a genuine
+    # multi-minute dictation, short enough that a lost key-release doesn't
+    # strand the mic + whisper-stream indefinitely.
+    _MAX_RECORDING_SECONDS = 300
+
     def start_recording(self):
         """Start recording — debounced to prevent duplicate key events.
 
         The window is short (0.2 s) so a genuine immediate retry after a
         too-short attempt still works; it only filters event bounce.
+
+        This runs on the pynput event-tap callback thread, which macOS
+        disables if it blocks too long. So the microphone is armed *first*
+        (fast), and the ~150 ms of ``osascript`` context capture (selected
+        text, frontmost app) is moved to a short-lived worker thread — a
+        stalled ``osascript`` (e.g. a consent dialog) can no longer wedge
+        the event tap or delay the key-release handler.
         """
         now = time.time()
         if now - self._last_press_time < 0.2:
@@ -466,35 +487,15 @@ class OpenVoiceFlow:
             self._watcher.stop()
             self._watcher = None
 
-        # ── Feature: Selected text context (Feature 4) ─────────────────────
-        # Capture selected text BEFORE starting audio (Cmd+C takes ~150ms).
-        # Done first so the clipboard is restored before we begin recording.
+        # Reset per-dictation context; the worker below fills it in. Snapshot
+        # readers (stop_and_process) tolerate it still being empty on an
+        # ultra-short dictation, which is below the 0.3 s floor anyway.
         self._selected_text_context = None
-        if self.config.get("selected_text_context", True):
-            try:
-                from .clipboard import capture_selected_text
-                self._selected_text_context = capture_selected_text()
-            except Exception:
-                pass  # Never let clipboard capture block recording
-
-        # ── Feature: Per-app context detection (Feature 2) ─────────────────
         self._current_app = ""
         self._current_style = self.config.get("style", "default")
-        if self.config.get("auto_style", True):
-            try:
-                from .context import get_frontmost_app, get_style_for_app
-                self._current_app = get_frontmost_app()
-                self._current_style = get_style_for_app(self._current_app, self.config)
-            except Exception:
-                pass  # Never let app detection block recording
+        self._recording_indicator_inserted = False
 
         self.is_recording = True
-        # Typed 🎙 indicator is opt-in: it edits the user's document and can
-        # misfire if focus changes mid-dictation. The overlay HUD is the
-        # default recording feedback.
-        self._recording_indicator_inserted = False
-        if self.config.get("recording_indicator", False):
-            self._recording_indicator_inserted = insert_recording_indicator("🎙")
 
         if self._streaming_enabled():
             # ── Feature: Streaming transcription (Feature 1) ────────────────
@@ -542,14 +543,85 @@ class OpenVoiceFlow:
         if self.config["sound_feedback"]:
             play_sound("start")
         if self._overlay:
-            self._overlay.show_recording(
-                style_label=self._current_style if self._current_app else None,
-                with_context=bool(self._selected_text_context),
+            self._overlay.show_recording()
+
+        # Force-stop if the key-release is ever missed.
+        self._start_max_duration_timer()
+
+        # Capture selected-text + app context OFF the event-tap thread.
+        threading.Thread(
+            target=self._capture_context, daemon=True, name="ovf-context-capture",
+        ).start()
+
+    def _capture_context(self):
+        """Best-effort selected-text + frontmost-app capture (worker thread).
+
+        Runs the ~150 ms of osascript/Accessibility work off the pynput
+        callback thread. Results land in instance attributes that
+        stop_and_process snapshots at key-release.
+        """
+        if self.config.get("selected_text_context", True):
+            try:
+                from .clipboard import capture_selected_text
+                self._selected_text_context = capture_selected_text()
+            except Exception:
+                pass
+        if self.config.get("auto_style", True):
+            try:
+                from .context import get_frontmost_app, get_style_for_app
+                app = get_frontmost_app()
+                self._current_app = app
+                self._current_style = get_style_for_app(app, self.config)
+            except Exception:
+                pass
+        # Typed 🎙 indicator is opt-in: it edits the user's document, so it
+        # also stays off the event-tap thread.
+        if self.config.get("recording_indicator", False):
+            try:
+                self._recording_indicator_inserted = insert_recording_indicator("🎙")
+            except Exception:
+                pass
+
+    def _start_max_duration_timer(self):
+        self._cancel_max_duration_timer()
+        timer = threading.Timer(self._MAX_RECORDING_SECONDS, self._on_max_duration)
+        timer.daemon = True
+        timer.name = "ovf-max-record"
+        self._max_record_timer = timer
+        timer.start()
+
+    def _cancel_max_duration_timer(self):
+        timer = self._max_record_timer
+        self._max_record_timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _on_max_duration(self):
+        """Watchdog: a recording that outran the ceiling lost its key-release."""
+        if not self.is_recording:
+            return
+        print(f"⏱️  Recording hit the {self._MAX_RECORDING_SECONDS}s ceiling — stopping.")
+        try:
+            from . import notify
+            notify.warn(
+                "Dictation reached the maximum length and was stopped "
+                "automatically. Processing what was captured."
             )
+        except Exception:
+            pass
+        self.stop_and_process()
 
     def stop_and_process(self):
-        """Stop recording and process — no debounce, use press timestamp for duration check."""
-        self.is_recording = False
+        """Stop recording and process.
+
+        Guarded so only one caller (the key-release, the max-duration
+        watchdog, or an abort) drives the stop transition; the rest return.
+        """
+        with self._lifecycle_lock:
+            if not self.is_recording:
+                return
+            self.is_recording = False
+        self._cancel_max_duration_timer()
         if self._recording_indicator_inserted:
             clear_recording_indicator()
             self._recording_indicator_inserted = False
@@ -587,16 +659,26 @@ class OpenVoiceFlow:
                     play_sound("error")
                 return
 
-            self.processing = True
-            thread = threading.Thread(
-                target=self._process_streaming_result,
-                args=(raw_text, duration, current_app, current_style, selected_context),
-                daemon=True,
+            self._start_processing(
+                self._process_streaming_result,
+                (raw_text, duration, current_app, current_style, selected_context),
             )
-            thread.start()
         else:
             # ── Batch stop path ─────────────────────────────────────────────
-            self.recorder.stop()
+            try:
+                self.recorder.stop()
+            except Exception as e:
+                # Device unplugged mid-recording, etc. Surface it instead of
+                # dropping the dictation silently and leaving the overlay
+                # stuck on the "Recording" pill.
+                print(f"❌ Failed to stop recorder: {e}")
+                if self._overlay:
+                    self._overlay.show_error("Recording error")
+                if self.config["sound_feedback"]:
+                    play_sound("error")
+                from . import notify
+                notify.error(f"Recording stopped unexpectedly ({e}).")
+                return
             if self.config["sound_feedback"]:
                 play_sound("stop")
 
@@ -610,13 +692,22 @@ class OpenVoiceFlow:
                     self._overlay.hide()
                 return
 
-            self.processing = True
-            thread = threading.Thread(
-                target=self._process_audio,
-                args=(current_app, current_style, selected_context),
-                daemon=True,
+            self._start_processing(
+                self._process_audio,
+                (current_app, current_style, selected_context),
             )
-            thread.start()
+
+    def _start_processing(self, target, args):
+        """Spawn a processing worker, rolling back ``processing`` if the
+        thread can't start (otherwise the hotkey is wedged forever)."""
+        self.processing = True
+        try:
+            threading.Thread(target=target, args=args, daemon=True).start()
+        except Exception as e:
+            self.processing = False
+            print(f"❌ Could not start processing thread: {e}")
+            if self._overlay:
+                self._overlay.hide()
 
     def _process_streaming_result(
         self,

--- a/voiceflow/app.py
+++ b/voiceflow/app.py
@@ -389,31 +389,26 @@ class OpenVoiceFlow:
         if self.config.get("hotkey") != "left_fn":
             return
 
-        key_map = self._get_key_map()
-        if "left_fn" not in key_map:
-            from . import notify
-            notify.tip(
-                "OpenVoiceFlow cannot detect the fn/globe key on this setup. "
-                "Switch hotkey to right option with: openvoiceflow --hotkey right_alt",
-                once_key="fn_hotkey_not_supported",
-            )
-            return
-
-        def _watch_fn_events():
-            # Give the user a short window to press fn once after activation.
-            time.sleep(12)
-            if self._fn_event_seen:
+        # The Fn / 🌐 Globe key cannot be a hotkey with the current engine:
+        # pynput's macOS backend has no fn key at all (no Key.fn, and no
+        # entry in its modifier-flag table), so a fn hotkey NEVER fires. This
+        # is deterministic — not a per-machine "may not respond" — so surface
+        # it immediately and loudly (the old 12 s Notification Center tip was
+        # both slow and easy to miss) and steer the user to a working key.
+        message = (
+            "The Fn / 🌐 Globe key can't be used as the dictation hotkey — "
+            "macOS doesn't expose it to apps. Switch to Right Command (the "
+            "default) from the menu bar under Dictation Shortcut, or run: "
+            "openvoiceflow --hotkey right_cmd"
+        )
+        from . import notify
+        if on_dead_hotkey is not None:
+            try:
+                on_dead_hotkey(message)  # menubar → modal alert
                 return
-            from . import notify
-            notify.tip(
-                "No fn key events detected yet. macOS may reserve Globe/fn shortcuts. "
-                "Try System Settings > Keyboard > Press Globe key, or switch hotkey: "
-                "openvoiceflow --hotkey right_alt",
-                once_key="fn_hotkey_no_events",
-            )
-
-        thread = threading.Thread(target=_watch_fn_events, daemon=True, name="ovf-fn-watchdog")
-        thread.start()
+            except Exception:
+                pass
+        notify.error(message)
 
     def on_key_release(self, key):
         try:

--- a/voiceflow/clipboard.py
+++ b/voiceflow/clipboard.py
@@ -28,11 +28,39 @@ def _read_clipboard() -> str:
 
 def _write_clipboard(text: str) -> None:
     """Write text to clipboard via pbcopy."""
+    process = None
     try:
         process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
         process.communicate(text.encode("utf-8"), timeout=3)
+    except subprocess.TimeoutExpired:
+        # communicate() does NOT reap the child on timeout — kill it so a
+        # hung pbcopy doesn't leak a process + pipe fds.
+        if process is not None:
+            process.kill()
+            process.wait()
     except Exception:
         pass
+
+
+def _pasteboard_has_nontext_only() -> bool:
+    """True when the clipboard holds non-text data (image/file) and no string.
+
+    ``pbpaste`` can only render text, so a copy+restore round-trip silently
+    destroys an image or file on the clipboard. When PyObjC is available we
+    detect that case and skip capture entirely. Returns False (proceed) when
+    PyObjC is absent or the clipboard is empty/has text.
+    """
+    try:
+        from AppKit import NSPasteboard, NSPasteboardTypeString
+    except Exception:
+        return False
+    try:
+        pb = NSPasteboard.generalPasteboard()
+        if pb.availableTypeFromArray_([NSPasteboardTypeString]) is not None:
+            return False  # a string is present → safe to round-trip
+        return bool(pb.pasteboardItems())  # items but no string → non-text
+    except Exception:
+        return False
 
 
 def capture_selected_text() -> str | None:
@@ -45,6 +73,12 @@ def capture_selected_text() -> str | None:
     The total time cost of this function is roughly 150-200ms.
     """
     try:
+        # 0. Preserve non-text clipboard contents. If the clipboard holds an
+        # image or file (no text), the Cmd+C round-trip below would destroy
+        # it — skip capture entirely and leave it untouched.
+        if _pasteboard_has_nontext_only():
+            return None
+
         # 1. Save original clipboard
         original_clipboard = _read_clipboard()
 
@@ -75,11 +109,12 @@ def capture_selected_text() -> str | None:
         selected_text: str | None = None
         if new_clipboard != original_clipboard and new_clipboard.strip():
             selected_text = new_clipboard[:MAX_CONTEXT_CHARS]
-            # 6. Restore the original clipboard. Only done when Cmd+C actually
-            # replaced it: pbpaste can't represent non-text contents (images,
-            # files), so writing back when nothing changed would overwrite
-            # them with empty text.
-            _write_clipboard(original_clipboard)
+            # 6. Restore the original clipboard — but only if it was genuine
+            # prior text. Never `pbcopy ""`: an empty original means it was
+            # either empty already or non-text, and writing empty would
+            # replace the user's selection (now on the clipboard) with nothing.
+            if original_clipboard:
+                _write_clipboard(original_clipboard)
 
         return selected_text
 

--- a/voiceflow/interview.py
+++ b/voiceflow/interview.py
@@ -80,8 +80,10 @@ class InterviewWizard:
         y = (sy - h) // 3
         self.root.geometry(f"{w}x{h}+{x}+{y}")
 
-        # Bind Escape to skip/cancel
-        self.root.bind("<Escape>", lambda e: self._skip())
+        # Bind Escape to skip/cancel — but NOT while the user is typing in a
+        # text field. A global Escape-destroys-everything binding turned an
+        # ordinary "clear the field" keypress into total data loss.
+        self.root.bind("<Escape>", self._on_escape)
 
         # Interview state
         self._name_var         = tk.StringVar()
@@ -698,6 +700,29 @@ class InterviewWizard:
         self._primary_button("Start Dictating 🎙️", self._finish)
 
     # ── Skip / Finish ──────────────────────────────────────────────────────
+
+    # Tk widget classes that accept text entry — Escape must not abandon the
+    # wizard while focus is in one of these.
+    _TEXT_ENTRY_WIDGETS = ("Entry", "TEntry", "Text", "TText")
+
+    def _on_escape(self, event=None):
+        """Skip the interview, unless a text field is focused.
+
+        When typing, Escape is a field-level gesture (clear/blur), not
+        "throw away everything I entered". In that case we drop focus back to
+        the window instead of destroying the wizard.
+        """
+        try:
+            focused = self.root.focus_get()
+        except Exception:
+            focused = None
+        if focused is not None and focused.winfo_class() in self._TEXT_ENTRY_WIDGETS:
+            try:
+                self.root.focus_set()  # blur the field; keep the wizard open
+            except Exception:
+                pass
+            return
+        self._skip()
 
     def _skip(self):
         """Close the window.

--- a/voiceflow/llm/anthropic_backend.py
+++ b/voiceflow/llm/anthropic_backend.py
@@ -7,7 +7,7 @@ import os
 import urllib.error
 import urllib.request
 
-from .base import LLMBackend
+from .base import LLMBackend, read_json_capped
 
 
 class AnthropicBackend(LLMBackend):
@@ -66,7 +66,7 @@ class AnthropicBackend(LLMBackend):
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                data = json.loads(resp.read().decode())
+                data = read_json_capped(resp)
                 return data["content"][0]["text"].strip()
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8", errors="replace")

--- a/voiceflow/llm/base.py
+++ b/voiceflow/llm/base.py
@@ -2,7 +2,56 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from abc import ABC, abstractmethod
+from urllib.parse import urlparse
+
+# Ceiling on a single LLM/Ollama HTTP response. A cleanup reply is a few KB;
+# 16 MB is orders of magnitude of headroom while still bounding a hostile or
+# buggy endpoint (most realistically a non-TLS local Ollama port answered by
+# another process) that would otherwise stream unbounded bytes into memory
+# on the dictation thread.
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+
+
+def read_json_capped(resp, max_bytes: int = MAX_RESPONSE_BYTES):
+    """``json.loads`` an HTTP response, refusing bodies larger than max_bytes."""
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ValueError(f"response exceeded {max_bytes} bytes")
+    return json.loads(raw.decode("utf-8"))
+
+
+def sanitize_local_url(url: str, default: str) -> str:
+    """Validate a user-supplied local-service base URL (e.g. ``ollama_url``).
+
+    Rejects non-HTTP(S) schemes (``file:``/``ftp:`` would let a config edit
+    redirect private prompts through urllib), falling back to *default*.
+    Warns once on stderr when the host isn't loopback, since the whole
+    transcript + profile would then leave the machine in the clear.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return default
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        print(
+            f"⚠️  Ignoring invalid ollama_url {url!r} (must be http(s)://host). "
+            f"Using {default}.",
+            file=sys.stderr,
+        )
+        return default
+    if parsed.hostname not in _LOOPBACK_HOSTS:
+        print(
+            f"⚠️  ollama_url points off-box ({parsed.hostname}); your transcript "
+            "and profile will be sent there in the clear. Use a loopback address "
+            "to keep dictation fully local.",
+            file=sys.stderr,
+        )
+    return url
 
 DEFAULT_PROMPT = (
     "You are a voice dictation cleanup assistant. "

--- a/voiceflow/llm/groq_backend.py
+++ b/voiceflow/llm/groq_backend.py
@@ -7,7 +7,7 @@ import os
 import urllib.error
 import urllib.request
 
-from .base import LLMBackend
+from .base import LLMBackend, read_json_capped
 
 
 class GroqBackend(LLMBackend):
@@ -71,7 +71,7 @@ class GroqBackend(LLMBackend):
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                data = json.loads(resp.read().decode())
+                data = read_json_capped(resp)
                 return data["choices"][0]["message"]["content"].strip()
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8", errors="replace")

--- a/voiceflow/llm/ollama_backend.py
+++ b/voiceflow/llm/ollama_backend.py
@@ -6,16 +6,19 @@ import json
 import urllib.error
 import urllib.request
 
-from .base import LLMBackend
+from .base import LLMBackend, read_json_capped, sanitize_local_url
 
 
 class OllamaBackend(LLMBackend):
     name = "ollama"
     default_model = "llama3.2"
+    _DEFAULT_URL = "http://localhost:11434"
 
     def __init__(self, config: dict):
         super().__init__(config)
-        self.base_url = config.get("ollama_url", "http://localhost:11434")
+        self.base_url = sanitize_local_url(
+            config.get("ollama_url", self._DEFAULT_URL), self._DEFAULT_URL
+        )
         # ollama uses ollama_model key specifically; override base class model
         self.model = config.get("ollama_model", self.default_model)
 
@@ -23,7 +26,7 @@ class OllamaBackend(LLMBackend):
         try:
             req = urllib.request.Request(f"{self.base_url}/api/tags")
             with urllib.request.urlopen(req, timeout=3) as resp:
-                data = json.loads(resp.read().decode())
+                data = read_json_capped(resp)
                 models = [m["name"] for m in data.get("models", [])]
                 if not models:
                     return False, "Ollama running but no models. Run: ollama pull llama3.2"
@@ -62,7 +65,7 @@ class OllamaBackend(LLMBackend):
             # generation completes, and a cold model load alone can take
             # longer than 30 s.
             with urllib.request.urlopen(req, timeout=120) as resp:
-                data = json.loads(resp.read().decode())
+                data = read_json_capped(resp)
                 return data.get("response", raw_text).strip()
         except Exception as e:
             print(f"❌ Ollama error: {e}")

--- a/voiceflow/llm/openai_backend.py
+++ b/voiceflow/llm/openai_backend.py
@@ -7,7 +7,7 @@ import os
 import urllib.error
 import urllib.request
 
-from .base import LLMBackend
+from .base import LLMBackend, read_json_capped
 
 
 class OpenAIBackend(LLMBackend):
@@ -71,7 +71,7 @@ class OpenAIBackend(LLMBackend):
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                data = json.loads(resp.read().decode())
+                data = read_json_capped(resp)
                 return data["choices"][0]["message"]["content"].strip()
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8", errors="replace")

--- a/voiceflow/llm/openrouter.py
+++ b/voiceflow/llm/openrouter.py
@@ -7,7 +7,7 @@ import os
 import urllib.error
 import urllib.request
 
-from .base import LLMBackend
+from .base import LLMBackend, read_json_capped
 
 OPENROUTER_DEFAULT_MODEL = "google/gemma-4-31b-it"
 
@@ -71,7 +71,7 @@ class OpenRouterBackend(LLMBackend):
         )
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                data = json.loads(resp.read().decode())
+                data = read_json_capped(resp)
                 return data["choices"][0]["message"]["content"].strip()
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8", errors="replace")

--- a/voiceflow/menubar.py
+++ b/voiceflow/menubar.py
@@ -50,7 +50,7 @@ _MAIN_MENU_LAYOUT = (
 _HOTKEY_LABELS = {
     "right_cmd": "Right Command (⌘)",
     "left_cmd": "Left Command (⌘)",
-    "left_fn": "Fn",
+    "left_fn": "Fn (not supported)",
     "right_alt": "Right Option (⌥)",
     "left_alt": "Left Option (⌥)",
     "right_ctrl": "Right Control (⌃)",
@@ -96,12 +96,19 @@ def _hotkey_label(hotkey: str) -> str:
 
 
 def _hotkey_choices(current_hotkey: str) -> list[tuple[str, str, bool]]:
-    """Return every supported hotkey with its label and selected state."""
+    """Return selectable hotkeys with label and selected state.
+
+    fn / Globe is excluded from the picker: macOS doesn't expose it to apps,
+    so it can't work as a hotkey. It stays in VALID_HOTKEYS for back-compat,
+    and if it happens to be the *current* setting we still show it (marked)
+    so the user can see what's set and switch away from it.
+    """
     from .config import VALID_HOTKEYS
 
     return [
         (hotkey, _hotkey_label(hotkey), hotkey == current_hotkey)
         for hotkey in VALID_HOTKEYS
+        if hotkey != "left_fn" or current_hotkey == "left_fn"
     ]
 
 

--- a/voiceflow/onboarding.py
+++ b/voiceflow/onboarding.py
@@ -425,11 +425,13 @@ class OnboardingWizard:
         self._title("Choose Your Hotkey")
         self._subtitle("Hold this key to start dictating. Release to stop and paste.")
 
+        # NB: fn / Globe is intentionally omitted — macOS doesn't expose that
+        # key to apps, so it can't be used as a push-to-talk hotkey here.
         hotkeys = [
             ("right_cmd", "Right ⌘ Command", "Recommended — default hotkey"),
             ("right_alt", "Right ⌥ Option", "Good alternative"),
-            ("left_fn", "Left fn / Globe", "Optional — may be reserved by macOS"),
             ("left_alt", "Left ⌥ Option", "If right side is awkward"),
+            ("right_ctrl", "Right ⌃ Control", "Another modifier option"),
             ("f5", "F5", "Traditional push-to-talk"),
             ("f6", "F6", "Alternative function key"),
         ]

--- a/voiceflow/overlay.py
+++ b/voiceflow/overlay.py
@@ -31,11 +31,28 @@ try:
         NSWindowCollectionBehaviorStationary,
         NSWindowLevelFloating,
         NSWindowStyleMaskBorderless,
+        NSWorkspace,
     )
-    from Foundation import NSDefaultRunLoopMode, NSObject, NSRunLoop, NSTimer
+    from Foundation import NSObject, NSRunLoop, NSRunLoopCommonModes, NSTimer
     HAS_APPKIT = True
 except ImportError:
     HAS_APPKIT = False
+
+
+def _reduce_motion() -> bool:
+    """True when the user has enabled Accessibility → Reduce Motion.
+
+    HIG requires honoring it; the HUD then snaps instead of fading. Best
+    effort — any failure falls back to animating (the current behavior).
+    """
+    if not HAS_APPKIT:
+        return False
+    try:
+        return bool(
+            NSWorkspace.sharedWorkspace().accessibilityDisplayShouldReduceMotion()
+        )
+    except Exception:
+        return False
 
 
 class OverlayState:
@@ -73,7 +90,7 @@ if HAS_APPKIT:
             self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
                 0.4, self, b"animateDots:", None, True
             )
-            NSRunLoop.currentRunLoop().addTimer_forMode_(self._timer, NSDefaultRunLoopMode)
+            NSRunLoop.currentRunLoop().addTimer_forMode_(self._timer, NSRunLoopCommonModes)
 
         def stopAnimation(self):
             if self._timer:
@@ -412,18 +429,34 @@ class FloatingOverlay:
         self._fade_out()
 
     def _fade_in(self):
-        """Animate fade in."""
+        """Fade the HUD in (snap if Reduce Motion is on)."""
         self._window.orderFront_(None)
+        if _reduce_motion():
+            self._window.setAlphaValue_(0.95)
+            return
         NSAnimationContext.beginGrouping()
         NSAnimationContext.currentContext().setDuration_(0.2)
         self._window.animator().setAlphaValue_(0.95)
         NSAnimationContext.endGrouping()
 
     def _fade_out(self):
-        """Animate fade out."""
+        """Fade the HUD out, then order it out of every Space's window list.
+
+        Leaving an alpha-0 window on screen keeps it in the window list of
+        every Space (CanJoinAllSpaces|Stationary). ``orderOut_`` after the
+        fade removes it. Snaps when Reduce Motion is on.
+        """
+        window = self._window
+        if _reduce_motion():
+            window.setAlphaValue_(0.0)
+            window.orderOut_(None)
+            return
         NSAnimationContext.beginGrouping()
         NSAnimationContext.currentContext().setDuration_(0.3)
-        self._window.animator().setAlphaValue_(0.0)
+        NSAnimationContext.currentContext().setCompletionHandler_(
+            lambda: window.orderOut_(None)
+        )
+        window.animator().setAlphaValue_(0.0)
         NSAnimationContext.endGrouping()
 
     def _schedule_hide(self, delay: float):
@@ -434,7 +467,7 @@ class FloatingOverlay:
         )
         # Monkey-patch the animator to call our hide
         self._animator._overlay = self
-        NSRunLoop.currentRunLoop().addTimer_forMode_(self._hide_timer, NSDefaultRunLoopMode)
+        NSRunLoop.currentRunLoop().addTimer_forMode_(self._hide_timer, NSRunLoopCommonModes)
 
     def _cancel_hide_timer(self):
         if self._hide_timer:

--- a/voiceflow/recorder.py
+++ b/voiceflow/recorder.py
@@ -53,12 +53,25 @@ class AudioRecorder:
             self.frames.append(indata.copy())
 
     def stop(self):
-        """Stop recording audio."""
+        """Stop recording audio.
+
+        Always releases the PortAudio stream, even if ``stop()``/``close()``
+        raise — which they do when the input device is unplugged mid-recording.
+        A leaked stream keeps the microphone busy and the next ``start()``
+        would overwrite ``self._stream`` without closing the old one.
+        """
         self.is_recording = False
-        if self._stream:
-            self._stream.stop()
-            self._stream.close()
-            self._stream = None
+        stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        try:
+            stream.stop()
+        except Exception:
+            pass
+        try:
+            stream.close()
+        except Exception:
+            pass
 
     def save_wav(self, filepath: str) -> bool:
         """Save recorded audio to a WAV file."""

--- a/voiceflow/system.py
+++ b/voiceflow/system.py
@@ -11,6 +11,21 @@ from datetime import datetime
 from .config import LOG_DIR
 
 
+def _kill_quietly(proc) -> None:
+    """Reap a Popen child that outlived its timeout.
+
+    ``Popen.communicate(timeout=…)`` raises but does NOT terminate the child,
+    so without this a hung pbcopy leaks a process and its pipe fds.
+    """
+    if proc is None:
+        return
+    try:
+        proc.kill()
+        proc.wait(timeout=1)
+    except Exception:
+        pass
+
+
 def paste_text(text: str):
     """Copy text to clipboard and paste at cursor (macOS).
 
@@ -19,6 +34,7 @@ def paste_text(text: str):
     instead of an invisible stderr line. The user's text is still on
     the clipboard, so a manual ⌘V always works as a fallback.
     """
+    process = None
     try:
         process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
         process.communicate(text.encode("utf-8"), timeout=5)
@@ -38,6 +54,7 @@ def paste_text(text: str):
     except subprocess.TimeoutExpired:
         # osascript blocked (likely a macOS consent dialog). The text is
         # already on the clipboard, so manual ⌘V still works.
+        _kill_quietly(process)
         play_sound("error")
         from . import notify
         notify.error(
@@ -74,6 +91,8 @@ def insert_recording_indicator(indicator: str = "🎙") -> bool:
 
     Returns True if insertion succeeded.
     """
+    process = None
+    restore = None
     try:
         original = subprocess.run(["pbpaste"], capture_output=True, timeout=5)
         process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
@@ -94,6 +113,10 @@ def insert_recording_indicator(indicator: str = "🎙") -> bool:
             restore = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
             restore.communicate(original.stdout, timeout=5)
         return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        _kill_quietly(process)
+        _kill_quietly(restore)
+        return False
     except (OSError, subprocess.SubprocessError):
         return False
 
@@ -154,10 +177,13 @@ def log_transcript(raw: str, cleaned: str, config: dict):
     if not config.get("log_transcripts"):
         return
 
-    from ._secure_io import secure_chmod
+    from ._secure_io import secure_chmod, secure_dir
 
-    # BUG-020 fix: ensure log directory exists before writing
+    # BUG-020 fix: ensure log directory exists before writing.
+    # secure_dir keeps it owner-only (0700) — the date-named filenames
+    # themselves reveal usage days, so the directory shouldn't be listable.
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    secure_dir(str(LOG_DIR))
     now = datetime.now()
 
     def _open_append_600(path):

--- a/voiceflow/transcriber.py
+++ b/voiceflow/transcriber.py
@@ -151,3 +151,9 @@ def transcribe(audio_path: str, config: dict) -> str | None:
     except subprocess.TimeoutExpired:
         print("❌ Whisper timed out")
         return None
+    except (FileNotFoundError, OSError) as e:
+        # The binary was present at validate_setup but moved/deleted since
+        # (e.g. a `brew upgrade`), or is not executable. Report the real
+        # cause instead of a generic downstream "Dictation failed".
+        print(f"❌ whisper.cpp could not be run ({e}). Reinstall: brew install whisper-cpp")
+        return None


### PR DESCRIPTION
## What this is

A four-dimension end-to-end audit (runtime/concurrency, macOS UX vs. Apple HIG, packaging/first-run, security/privacy) was run against the codebase. This PR lands the **high-confidence, fully-tested subset**. The complete findings and the remaining roadmap — the genuinely "award-winning native" work — are captured in a new [`PRODUCTION_READINESS.md`](../blob/claude/production-hardening-audit/PRODUCTION_READINESS.md).

**Honest scope note:** this app is a Python/rumps/PyObjC menu-bar app whose first launch bootstraps Homebrew + a venv + a model download. The path to a true Apple-Design-Award experience is a native SwiftUI onboarding, a self-contained (no-Homebrew, no-Terminal) bundle, SF Symbols in the HUD, and Sparkle updates — all scoped in the roadmap doc, none faked here. This PR makes the *current* app materially more robust and is verifiable on any host (the macOS UI changes are standard AppKit idioms and should be eyeballed on a real Mac).

## Runtime robustness

- **H1 — the hotkey can't be wedged by a consent dialog.** `start_recording` ran ~150 ms of `osascript` (selected-text ⌘C, frontmost-app) *on the pynput event-tap callback thread*; a stalled Automation/Accessibility dialog could block it long enough for macOS to disable the tap and swallow the key-release. Now the mic is armed synchronously and the context capture runs on a worker thread.
- **H2 — runaway recordings self-terminate.** There was no ceiling: a lost key-release left `is_recording` true forever with the mic and `whisper-stream` running. Added a max-duration watchdog that force-stops through the normal path.
- **H3 — no PortAudio stream leak.** `recorder.stop()` now always releases the stream even when the device was unplugged mid-recording; the guarded stop path surfaces the error instead of silently freezing the overlay.
- A failed processing-thread start rolls back the `processing` flag (no wedged hotkey); `transcribe()` reports a vanished whisper binary distinctly rather than as a generic "Dictation failed."

## Data-loss & security (defense-in-depth; the security audit found no critical/high)

- **Clipboard data-loss:** selected-text capture no longer clobbers a non-text clipboard (image/file), and never restores empty text over the user's selection.
- Secrets writer uses `O_EXCL|O_NOFOLLOW` (symlink-swap safe); `~/.openvoiceflow/logs/` is created `0700`; hung `pbcopy`/`osascript` children are reaped, not orphaned; LLM/Ollama responses are read with a 16 MB cap; `ollama_url` rejects non-HTTP schemes and warns when it points off-box.

## Packaging

- **Upgrades actually reinstall dependencies.** The DMG venv marker (`.ovf-deps-installed`) was a bare `touch`, so an existing user who upgraded kept their old venv forever — a release that added or bumped a dependency would break on import for exactly the people who upgraded. The marker is now version-stamped, and a mismatch triggers a reinstall.

## UX polish (safe, standard AppKit — verify visually on device)

- Overlay HUD timers run in `NSRunLoopCommonModes` (no freeze while a menu is open or during scroll/tracking), fades honor **Reduce Motion**, and the window is `orderOut`-ed after fading so it doesn't linger in every Space's window list.
- The Know-Me interview no longer abandons itself (data loss) when Escape is pressed while a text field is focused.

## Verification

- New `tests/test_hardening.py` (18 tests) covers the recorder leak, watchdog, guarded stop, thread-start rollback, transcribe error path, clipboard non-text/empty-restore behavior, orphan-kill, symlink-safe secrets write, capped reads, and `ollama_url` validation.
- New launcher test pins the version-stamped upgrade reinstall.
- Whole suite: **247 passed, 1 skipped**; `ruff check .` clean; the rendered DMG launcher still passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_