### PR TITLE
design: implement the end-to-end website redesign

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -7,15 +7,11 @@
   <meta name="description" content="Download OpenVoiceFlow, the free macOS voice dictation app. Website-hosted DMG links, checksums, source access notes, and platform notes." />
   <meta property="og:title" content="Download OpenVoiceFlow for macOS" />
   <meta property="og:description" content="Website-hosted DMG downloads, SHA-256 checksums, and source access notes for OpenVoiceFlow." />
-
   <meta property="og:url" content="https://openvoiceflow.vercel.app/download.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://openvoiceflow.vercel.app/download.html" />
-  <link rel="icon" href="assets/openvoiceflow-icon-512.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {
@@ -40,12 +36,32 @@
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
 </head>
 <body>
-  <nav class="nav scrolled" id="nav"><div class="nav-inner container"><a href="index.html" class="nav-logo"><span class="nav-logo-emoji">🎙️</span><span class="nav-logo-text">OpenVoiceFlow</span></a><ul class="nav-links"><li><a href="download.html">Download</a></li><li><a href="install.html">Install</a></li><li><a href="how-it-works.html">How it works</a></li></ul><button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button></div><div class="nav-drawer" id="navDrawer"><a href="index.html">Home</a><a href="download.html">Download</a><a href="install.html">Install</a><a href="how-it-works.html">How it works</a><a href="download.html" class="btn btn-primary">Download for Mac</a></div></nav>
+  <nav class="nav" id="nav" aria-label="Main">
+    <div class="nav-inner container">
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
+      <ul class="nav-links">
+        <li><a href="how-it-works.html">How it works</a></li>
+        <li><a href="install.html">Install</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
+      </ul>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
+    </div>
+    <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
+      <a href="download.html">Download</a>
+      <a href="install.html">Install</a>
+      <a href="how-it-works.html">How it works</a>
+      <a href="download.html" class="btn btn-primary">Download for Mac</a>
+    </div>
+  </nav>
+
   <main>
-    <section class="hero page-hero"><div class="hero-glow"></div><div class="container hero-inner">
-      <div class="hero-badge"><span class="badge-dot"></span>Website-hosted release assets</div>
-      <h1 class="hero-title">Download OpenVoiceFlow for macOS</h1>
+    <section class="page-hero"><div class="container hero-inner">
+      <span class="mono-kicker">Website-hosted release assets</span>
+      <h1 class="hero-title">Download v0.3.5</h1>
       <p class="hero-sub answer-block">OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. We suggest the best DMG when your browser shares enough Mac architecture detail; if not, both Apple Silicon and Intel builds stay visible.</p>
+
       <section class="download-panel" data-download-recommendation>
         <div class="download-panel-copy">
           <span class="download-kicker" id="downloadKicker">Recommended for your Mac</span>
@@ -61,6 +77,7 @@
           <a class="btn btn-outline btn-lg" href="install.html">Install guide</a>
         </div>
       </section>
+
       <section class="download-builds" aria-labelledby="allBuildsTitle">
         <div class="download-builds-header">
           <h2 id="allBuildsTitle">All Mac builds</h2>
@@ -68,29 +85,49 @@
         </div>
         <div class="download-build-list">
           <article class="download-build-row" data-arch="arm64">
-            <div>
-              <span class="download-build-label">Apple Silicon</span>
-              <h3>For M1, M2, M3, M4, and newer Macs</h3>
-              <code class="code-block">sha256: 5393deb12e586b433cd7734beda2cd25ca8db8614825d0fb06cf369a6289b195</code>
-            </div>
-            <a class="btn btn-outline btn-lg" href="downloads/OpenVoiceFlow-0.3.5-arm64.dmg" aria-label="Download OpenVoiceFlow-0.3.5-arm64.dmg">Download Apple Silicon DMG</a>
+            <span class="download-build-flag">RECOMMENDED</span>
+            <span class="download-build-label">Apple Silicon</span>
+            <h3>M1 and later · 1.2 MB installer</h3>
+            <a class="btn btn-outline" href="downloads/OpenVoiceFlow-0.3.5-arm64.dmg" aria-label="Download OpenVoiceFlow-0.3.5-arm64.dmg">OpenVoiceFlow-0.3.5-arm64.dmg</a>
+            <div class="checksum-line"><code class="code-block">sha256: 5393deb12e586b433cd7734beda2cd25ca8db8614825d0fb06cf369a6289b195</code><button class="copy-btn" type="button" data-copy="5393deb12e586b433cd7734beda2cd25ca8db8614825d0fb06cf369a6289b195">copy</button></div>
           </article>
           <article class="download-build-row" data-arch="x86_64">
-            <div>
-              <span class="download-build-label">Intel</span>
-              <h3>For x86_64 Intel Macs</h3>
-              <code class="code-block">sha256: 51628f5233693236eef14bb6a0b8d496507bfc2e72e7fd4a7c6d4aca7e48fa7e</code>
-            </div>
-            <a class="btn btn-outline btn-lg" href="downloads/OpenVoiceFlow-0.3.5-x86_64.dmg" aria-label="Download OpenVoiceFlow-0.3.5-x86_64.dmg">Download Intel DMG</a>
+            <span class="download-build-flag">RECOMMENDED</span>
+            <span class="download-build-label">Intel</span>
+            <h3>2018 and later · 1.2 MB installer</h3>
+            <a class="btn btn-outline" href="downloads/OpenVoiceFlow-0.3.5-x86_64.dmg" aria-label="Download OpenVoiceFlow-0.3.5-x86_64.dmg">OpenVoiceFlow-0.3.5-x86_64.dmg</a>
+            <div class="checksum-line"><code class="code-block">sha256: 51628f5233693236eef14bb6a0b8d496507bfc2e72e7fd4a7c6d4aca7e48fa7e</code><button class="copy-btn" type="button" data-copy="51628f5233693236eef14bb6a0b8d496507bfc2e72e7fd4a7c6d4aca7e48fa7e">copy</button></div>
           </article>
         </div>
       </section>
-      <section class="content-card wide-card"><h2>Install from source</h2><p>The <a href="https://github.com/shimoverse/openvoiceflow">public GitHub repository</a> is MIT licensed. Clone it below if you prefer a source install; use the website-hosted DMGs above for the signed app.</p><code class="code-block">git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow &amp;&amp; bash install.sh</code></section>
-      <section class="content-card wide-card"><h2>Download notes and limitations</h2><ul class="check-list"><li>The website-hosted DMGs above are byte-for-byte copies of the verified OpenVoiceFlow v0.3.5 GitHub Release assets.</li><li>OpenVoiceFlow supports macOS 12+ on Apple Silicon and Intel. Windows and Linux downloads are not currently available.</li><li>The current v0.3.5 DMGs are signed with Developer ID, Apple-notarized, and stapled so Gatekeeper can verify the download offline.</li></ul></section>
-      <section class="content-card wide-card"><h2>Download FAQ</h2><h3>Is the source repository public?</h3><p>Yes. OpenVoiceFlow is MIT-licensed and open source on <a href="https://github.com/shimoverse/openvoiceflow">GitHub</a>. The website-hosted DMGs are the easiest signed install.</p><h3>Does OpenVoiceFlow send audio to the cloud?</h3><p>No. Audio transcription runs locally through whisper.cpp. Cleaned transcript text only goes to a cloud LLM if you choose a cloud backend.</p><h3>Which backend should I choose?</h3><p>The current default cloud cleanup path is OpenRouter Gemma 4. Ollama and the “none” backend keep cleanup local/no-cloud.</p></section>
+
+      <div class="download-build-list" style="width:100%;margin-top:16px">
+        <section class="content-card" style="margin-top:0"><h2>Why the checksums are up front</h2><p>Verify in Terminal: <code class="code-block">shasum -a 256 ~/Downloads/OpenVoiceFlow-0.3.5-arm64.dmg</code> It should match the line above, which is also published with the GitHub release. Two independent places, one truth.</p></section>
+        <section class="content-card" style="margin-top:0"><h2>Signed + notarized</h2><p>Every DMG is Developer-ID signed, Apple-notarized, and stapled: macOS checks the app against Apple's malware scan before first launch — even offline. New releases ship here as the same signed, website-hosted DMGs.</p></section>
+      </div>
+
+      <section class="content-card"><h2>Install from source</h2><p>The <a href="https://github.com/shimoverse/openvoiceflow">public GitHub repository</a> is MIT licensed. Clone it below if you prefer a source install; use the website-hosted DMGs above for the signed app.</p><code class="code-block">git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow &amp;&amp; bash install.sh</code></section>
+
+      <section class="content-card"><h2>Download notes and limitations</h2><ul class="check-list"><li>The website-hosted DMGs above are byte-for-byte copies of the verified OpenVoiceFlow v0.3.5 GitHub Release assets.</li><li>OpenVoiceFlow supports macOS 12+ on Apple Silicon and Intel. Windows and Linux downloads are not currently available.</li><li>The current v0.3.5 DMGs are signed with Developer ID, Apple-notarized, and stapled so Gatekeeper can verify the download offline.</li></ul></section>
+
+      <section class="content-card"><h2>Download FAQ</h2><h3>Is the source repository public?</h3><p>Yes. OpenVoiceFlow is MIT-licensed and open source on <a href="https://github.com/shimoverse/openvoiceflow">GitHub</a>. The website-hosted DMGs are the easiest signed install.</p><h3>Does OpenVoiceFlow send audio to the cloud?</h3><p>No. Audio transcription runs locally through whisper.cpp. Cleaned transcript text only goes to a cloud LLM if you choose a cloud backend.</p><h3>Which backend should I choose?</h3><p>The current default cloud cleanup path is OpenRouter Gemma 4. Ollama and the &ldquo;none&rdquo; backend keep cleanup local/no-cloud.</p></section>
     </div></section>
   </main>
-  <footer class="footer"><div class="container footer-inner"><nav class="footer-links"><a href="index.html">Home</a><a href="download.html">Download</a><a href="install.html">Install</a><a href="how-it-works.html">How it works</a><a href="https://github.com/shimoverse/openvoiceflow">Source</a><a href="llms.txt">llms.txt</a></nav><p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p></div></footer>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="install.html">Install</a>
+        <a href="how-it-works.html">How it works</a>
+        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
+        <a href="llms.txt">llms.txt</a>
+      </nav>
+    </div>
+  </footer>
+
   <script src="site.js"></script>
 </body>
 </html>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -7,11 +7,11 @@
   <meta name="description" content="Learn how OpenVoiceFlow records locally, transcribes with whisper.cpp, applies voice commands, optionally cleans text with an LLM, and pastes at your cursor." />
   <meta property="og:title" content="How OpenVoiceFlow Works" />
   <meta property="og:description" content="The local-audio-first OpenVoiceFlow dictation pipeline explained." />
-
   <meta property="og:url" content="https://openvoiceflow.vercel.app/how-it-works.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://openvoiceflow.vercel.app/how-it-works.html" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is OpenVoiceFlow?","acceptedAnswer":{"@type":"Answer","text":"OpenVoiceFlow is a free push-to-talk voice dictation app for macOS."}},{"@type":"Question","name":"Does OpenVoiceFlow run locally?","acceptedAnswer":{"@type":"Answer","text":"Audio transcription runs locally with whisper.cpp. Cleanup text may go to a cloud LLM if the user chooses one."}},{"@type":"Question","name":"What platforms does OpenVoiceFlow support?","acceptedAnswer":{"@type":"Answer","text":"OpenVoiceFlow supports macOS 12+ on Apple Silicon and Intel Macs."}}]}
@@ -22,10 +22,61 @@
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
 </head>
 <body>
-<nav class="nav scrolled" id="nav"><div class="nav-inner container"><a href="index.html" class="nav-logo"><span class="nav-logo-emoji">🎙️</span><span class="nav-logo-text">OpenVoiceFlow</span></a><ul class="nav-links"><li><a href="download.html">Download</a></li><li><a href="install.html">Install</a></li><li><a href="how-it-works.html">How it works</a></li></ul><button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button></div><div class="nav-drawer" id="navDrawer"><a href="index.html">Home</a><a href="download.html">Download</a><a href="install.html">Install</a><a href="how-it-works.html">How it works</a><a href="download.html" class="btn btn-primary">Download for Mac</a></div></nav>
-<main><section class="hero page-hero"><div class="hero-glow"></div><div class="container hero-inner"><div class="hero-badge"><span class="badge-dot"></span>How it works · local audio first</div><h1 class="hero-title">How OpenVoiceFlow works</h1><p class="hero-sub answer-block">OpenVoiceFlow turns push-to-talk speech into cleaned text at your cursor. It records locally, transcribes with whisper.cpp, applies voice commands and optional LLM cleanup, then pastes the result into the app you were using.</p><div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="install.html">View install guide</a></div>
-<div class="pipeline content-pipeline"><div class="pipeline-step"><div class="pipeline-icon">🎤</div><div class="pipeline-content"><div class="pipeline-step-label">Step 1</div><div class="pipeline-step-title">Hold a hotkey</div><div class="pipeline-step-desc">Speak naturally in any macOS app.</div></div></div><div class="pipeline-step"><div class="pipeline-icon">🔊</div><div class="pipeline-content"><div class="pipeline-step-label">Step 2</div><div class="pipeline-step-title">Transcribe locally</div><div class="pipeline-step-desc">whisper.cpp processes audio on your Mac.</div></div></div><div class="pipeline-step"><div class="pipeline-icon">🗣️</div><div class="pipeline-content"><div class="pipeline-step-label">Step 3</div><div class="pipeline-step-title">Apply voice commands</div><div class="pipeline-step-desc">Natural phrases become punctuation and formatting.</div></div></div><div class="pipeline-step"><div class="pipeline-icon">🧠</div><div class="pipeline-content"><div class="pipeline-step-label">Step 4</div><div class="pipeline-step-title">Clean up text</div><div class="pipeline-step-desc">Optional LLM cleanup uses your selected backend.</div></div></div><div class="pipeline-step"><div class="pipeline-icon">⌨️</div><div class="pipeline-content"><div class="pipeline-step-label">Step 5</div><div class="pipeline-step-title">Paste at cursor</div><div class="pipeline-step-desc">The final text appears where you were working.</div></div></div></div>
-<section class="content-card wide-card"><h2>Best for</h2><p>OpenVoiceFlow is best for Mac users who want fast dictation, local audio transcription, and optional text cleanup without a subscription.</p><h2>Not best for</h2><p>OpenVoiceFlow is not a Windows/Linux app, a hosted speech API, or a completely cloud-free workflow unless you choose Ollama or no cleanup.</p></section><section class="content-card wide-card"><h2>FAQ</h2><h3>What is OpenVoiceFlow?</h3><p>OpenVoiceFlow is a free push-to-talk voice dictation app for macOS.</p><h3>Does OpenVoiceFlow run locally?</h3><p>Audio transcription runs locally. Cleanup text may go to a cloud LLM if you choose one; Ollama and no-cleanup modes avoid cloud cleanup.</p><h3>What platforms does OpenVoiceFlow support?</h3><p>OpenVoiceFlow supports macOS 12+ on Apple Silicon and Intel Macs.</p></section>
-</div></section></main><footer class="footer"><div class="container footer-inner"><nav class="footer-links"><a href="index.html">Home</a><a href="download.html">Download</a><a href="install.html">Install</a><a href="llms.txt">llms.txt</a></nav><p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p></div></footer>
+  <nav class="nav" id="nav" aria-label="Main">
+    <div class="nav-inner container">
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
+      <ul class="nav-links">
+        <li><a href="how-it-works.html">How it works</a></li>
+        <li><a href="install.html">Install</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
+      </ul>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
+    </div>
+    <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
+      <a href="download.html">Download</a>
+      <a href="install.html">Install</a>
+      <a href="how-it-works.html">How it works</a>
+      <a href="download.html" class="btn btn-primary">Download for Mac</a>
+    </div>
+  </nav>
+
+  <main>
+    <section class="page-hero"><div class="container hero-inner">
+      <span class="mono-kicker">How it works · local audio first</span>
+      <h1 class="hero-title">How OpenVoiceFlow works</h1>
+      <p class="hero-sub answer-block">OpenVoiceFlow turns push-to-talk speech into cleaned text at your cursor. It records locally, transcribes with whisper.cpp, applies voice commands and optional LLM cleanup, then pastes the result into the app you were using.</p>
+      <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="install.html">View install guide</a></div>
+
+      <div class="pipeline">
+        <div class="pipeline-step"><span class="pipeline-num">01 · HOLD</span><div><div class="pipeline-step-title">Hold a hotkey</div><div class="pipeline-step-desc">Speak naturally in any macOS app. One key — Right ⌘ by default — works everywhere.</div></div></div>
+        <div class="pipeline-step"><span class="pipeline-num">02 · SPEAK</span><div><div class="pipeline-step-title">Transcribe locally</div><div class="pipeline-step-desc">whisper.cpp processes audio on your Mac. The recording never touches a network.</div></div></div>
+        <div class="pipeline-step"><span class="pipeline-num">03 · SHAPE</span><div><div class="pipeline-step-title">Apply voice commands</div><div class="pipeline-step-desc">Natural phrases become punctuation and formatting.</div></div></div>
+        <div class="pipeline-step"><span class="pipeline-num">04 · CLEAN</span><div><div class="pipeline-step-title">Clean up text</div><div class="pipeline-step-desc">Optional LLM cleanup uses your selected backend — local Ollama, your own cloud key, or none.</div></div></div>
+        <div class="pipeline-step"><span class="pipeline-num">05 · PASTE</span><div><div class="pipeline-step-title">Paste at cursor</div><div class="pipeline-step-desc">The final text appears where you were working.</div></div></div>
+      </div>
+
+      <section class="content-card"><h2>Best for</h2><p>OpenVoiceFlow is best for Mac users who want fast dictation, local audio transcription, and optional text cleanup without a subscription.</p><h2>Not best for</h2><p>OpenVoiceFlow is not a Windows/Linux app, a hosted speech API, or a completely cloud-free workflow unless you choose Ollama or no cleanup.</p></section>
+
+      <section class="content-card"><h2>FAQ</h2><h3>What is OpenVoiceFlow?</h3><p>OpenVoiceFlow is a free push-to-talk voice dictation app for macOS.</p><h3>Does OpenVoiceFlow run locally?</h3><p>Audio transcription runs locally. Cleanup text may go to a cloud LLM if you choose one; Ollama and no-cleanup modes avoid cloud cleanup.</p><h3>What platforms does OpenVoiceFlow support?</h3><p>OpenVoiceFlow supports macOS 12+ on Apple Silicon and Intel Macs.</p></section>
+    </div></section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="download.html">Download</a>
+        <a href="install.html">Install</a>
+        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
+        <a href="llms.txt">llms.txt</a>
+      </nav>
+    </div>
+  </footer>
+
   <script src="site.js"></script>
-</body></html>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Free push-to-talk voice dictation for macOS. Audio transcription runs locally with whisper.cpp; optional LLM cleanup uses the backend you choose." />
   <meta name="keywords" content="voice dictation macOS, Wispr Flow alternative, whisper dictation, free voice dictation mac, local transcription" />
   <meta property="og:title" content="OpenVoiceFlow — Free Voice Dictation for macOS" />
-  <meta property="og:description" content="Speak. It types. Your audio never leaves your Mac. Free push-to-talk dictation with local whisper.cpp transcription." />
+  <meta property="og:description" content="Speak. It types. Free forever, and your audio never leaves your Mac. Push-to-talk dictation with local whisper.cpp transcription." />
   <meta property="og:url" content="https://openvoiceflow.vercel.app/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -70,14 +70,14 @@
   </nav>
 
   <main>
-    <!-- ─── Hero ─────────────────────────────────────────── -->
+    <!-- ─── 1 · Hero: what it is, both USPs above the fold ── -->
     <section class="container hero-inner" aria-label="Introduction">
-      <span class="hero-badge"><span class="badge-dot"></span>100% ON-DEVICE AUDIO · OPEN SOURCE · $0</span>
+      <span class="hero-badge"><span class="badge-dot"></span>FREE FOREVER · 100% LOCAL AUDIO · OPEN SOURCE</span>
       <h1 class="hero-title">Speak. It types.<br />Nothing leaves your&nbsp;Mac.</h1>
       <p class="hero-sub answer-block">OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. Hold a key, talk, release — polished text lands at your cursor in any app. Whisper runs on your Mac, not in a cloud. Free forever, MIT-licensed.</p>
       <div class="hero-cta-row">
         <a class="btn btn-primary btn-lg" href="download.html">Download for Mac</a>
-        <a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">View source ↗</a>
+        <a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a>
       </div>
       <div class="hero-trust">Signed &amp; notarized · macOS 12+ · Apple Silicon &amp; Intel · no account, ever</div>
 
@@ -93,8 +93,26 @@
       </div>
     </section>
 
-    <!-- ─── How it works ─────────────────────────────────── -->
+    <!-- ─── 2 · The two USPs, named ────────────────────────── -->
+    <section class="container section" aria-label="Why OpenVoiceFlow">
+      <div class="usp-grid">
+        <div class="usp-card">
+          <span class="mono-kicker">USP 01 · FREE FOREVER</span>
+          <h2 class="usp-title">$0 today. $0 in five years.</h2>
+          <p class="usp-body">MIT-licensed open source. No subscription, no account, no trial clock, no "Pro" tier waiting to ransom your workflow. Whisper is free to run and your Mac provides the compute — there is nothing to sell you.</p>
+        </div>
+        <div class="usp-card">
+          <span class="mono-kicker">USP 02 · EVERYTHING LOCAL</span>
+          <h2 class="usp-title">Your audio never leaves this machine.</h2>
+          <p class="usp-body">Transcription happens on your Mac, in a model you can point at. It works in airplane mode. The cloud touches nothing unless you explicitly add your own API key — and even then, only text, never your voice.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── 3 · How it works ───────────────────────────────── -->
     <section class="container section" aria-label="How it works">
+      <h2 class="section-title">How it works</h2>
+      <p class="section-sub">One key. Three beats. Any app on your Mac.</p>
       <div class="card-grid">
         <div class="card">
           <span class="mono-kicker">01 · Hold</span>
@@ -114,8 +132,10 @@
       </div>
     </section>
 
-    <!-- ─── Privacy ──────────────────────────────────────── -->
+    <!-- ─── 4 · USP deep-dive: Everything local ────────────── -->
     <section class="container section" aria-label="Privacy">
+      <h2 class="section-title">Everything local</h2>
+      <p class="section-sub">"Local" is the architecture, not a marketing adjective.</p>
       <div class="privacy-panel">
         <div class="privacy-grid">
           <div class="privacy-copy">
@@ -138,10 +158,30 @@
       </div>
     </section>
 
-    <!-- ─── Compare ──────────────────────────────────────── -->
-    <section class="container section" aria-label="Comparison with Wispr Flow">
-      <h2 class="section-title">The $144-a-year question</h2>
-      <p class="section-sub">Wispr Flow is a fine product. It is also a subscription to someone else's cloud.</p>
+    <!-- ─── 5 · Features: what the product actually is ─────── -->
+    <section class="container section" aria-label="Features">
+      <h2 class="section-title">Everything you need. Nothing you don't.</h2>
+      <p class="section-sub">Built for people who care about quality, privacy, and getting things done.</p>
+      <div class="card-grid">
+        <div class="card"><span class="mono-kicker">Streaming</span><div class="card-title">Real-time overlay</div><div class="card-body">Watch words appear in the overlay as you speak with optional streaming mode — not just after you stop.</div></div>
+        <div class="card"><span class="mono-kicker">Profile</span><div class="card-title">Know-Me interview</div><div class="card-body">A short first-launch Q&amp;A learns your name, team, and jargon so cleanup writes like you.</div></div>
+        <div class="card"><span class="mono-kicker">Auto-learn</span><div class="card-title">Fix it once</div><div class="card-body">Correct a mis-heard word once and your personal dictionary remembers it forever.</div></div>
+        <div class="card"><span class="mono-kicker">Context</span><div class="card-title">Per-app style</div><div class="card-body">Casual in Slack and iMessage, formal in Mail, terse in your editor — tone adapts to the frontmost app.</div></div>
+        <div class="card"><span class="mono-kicker">Commands</span><div class="card-title">Voice punctuation</div><div class="card-body">&ldquo;New line&rdquo;, &ldquo;comma&rdquo;, &ldquo;period&rdquo; — natural phrases become punctuation and formatting.</div></div>
+        <div class="card"><span class="mono-kicker">Snippets</span><div class="card-title">Say it, expand it</div><div class="card-body">Voice-triggered text expansion for the sentences you type twenty times a day.</div></div>
+      </div>
+    </section>
+
+    <!-- ─── 6 · USP deep-dive: Free forever ────────────────── -->
+    <section class="container section" aria-label="Free forever and comparison with Wispr Flow">
+      <h2 class="section-title">Free forever</h2>
+      <p class="section-sub">Wispr Flow is a fine product. It is also $144 a year for a subscription to someone else's cloud.</p>
+      <div class="stat-row">
+        <div class="stat-card"><div class="stat-value">$0</div><div class="stat-label">Annual cost</div></div>
+        <div class="stat-card stat-accent"><div class="stat-value">$144</div><div class="stat-label">Saved vs Wispr Flow, every year</div></div>
+        <div class="stat-card"><div class="stat-value">MIT</div><div class="stat-label">License</div></div>
+        <div class="stat-card"><div class="stat-value">6</div><div class="stat-label">Cleanup backends to choose from</div></div>
+      </div>
       <div class="compare-table">
         <div class="compare-grid">
           <div class="compare-head-dim" aria-hidden="true">&nbsp;</div><div class="compare-head">OpenVoiceFlow</div><div class="compare-head-dim">Wispr Flow</div>
@@ -157,9 +197,24 @@
       <p class="compare-footnote">Competitor details per their published pricing and docs, July 2026.</p>
     </section>
 
-    <!-- ─── Install ──────────────────────────────────────── -->
+    <!-- ─── 7 · Pick your backend ──────────────────────────── -->
+    <section class="container section" aria-label="Cleanup backend options">
+      <h2 class="section-title">Pick your backend.</h2>
+      <p class="section-sub">From fully local (zero cost, zero cloud) to ultra-fast API. You decide what runs where.</p>
+      <div class="card-grid backend-grid">
+        <div class="card backend-card is-flagged"><span class="backend-flag">DEFAULT CLOUD PATH</span><span class="mono-kicker">OpenRouter Gemma 4</span><div class="backend-meta"><span class="backend-cost">Free tier available</span><span class="backend-chip mid">audio stays local</span></div><div class="card-body">The default cloud cleanup path — google/gemma-4-31b-it through OpenRouter, with your own key.</div><code class="code-block backend-cmd">openvoiceflow --backend openrouter --set-key openrouter YOUR_KEY</code></div>
+        <div class="card backend-card"><span class="mono-kicker">Groq</span><div class="backend-meta"><span class="backend-cost">Free tier / ~$1 per yr</span><span class="backend-chip mid">audio stays local</span></div><div class="card-body">Fastest inference around — Llama on Groq's custom silicon, with your own key.</div><code class="code-block backend-cmd">openvoiceflow --set-key groq YOUR_KEY</code></div>
+        <div class="card backend-card"><span class="mono-kicker">OpenAI</span><div class="backend-meta"><span class="backend-cost">~$5 per yr</span><span class="backend-chip mid">audio stays local</span></div><div class="card-body">GPT-4o mini. Great for complex cleanup and nuanced rewrites.</div><code class="code-block backend-cmd">openvoiceflow --set-key openai YOUR_KEY</code></div>
+        <div class="card backend-card"><span class="mono-kicker">Claude</span><div class="backend-meta"><span class="backend-cost">~$5 per yr</span><span class="backend-chip mid">audio stays local</span></div><div class="card-body">Anthropic's Claude Haiku. Exceptional writing quality and tone.</div><code class="code-block backend-cmd">openvoiceflow --set-key claude YOUR_KEY</code></div>
+        <div class="card backend-card is-flagged is-local"><span class="backend-flag local">100% LOCAL</span><span class="mono-kicker">Ollama</span><div class="backend-meta"><span class="backend-cost free">$0 / forever</span><span class="backend-chip local">never leaves Mac</span></div><div class="card-body">Fully offline. Llama 3, Mistral, or any local model. Air-gapped privacy.</div><code class="code-block backend-cmd">openvoiceflow --backend ollama</code></div>
+        <div class="card backend-card is-local"><span class="mono-kicker">None — Whisper only</span><div class="backend-meta"><span class="backend-cost free">$0 / forever</span><span class="backend-chip local">never leaves Mac</span></div><div class="card-body">Raw Whisper output, no LLM cleanup. Minimal and lightning fast.</div><code class="code-block backend-cmd">openvoiceflow --backend none</code></div>
+      </div>
+      <p class="backend-note"><strong>All options:</strong> audio transcription is <em>always</em> local via Whisper. Only the cleanup call goes to an API — and only if you choose one.</p>
+    </section>
+
+    <!-- ─── 8 · Install ────────────────────────────────────── -->
     <section class="container section" aria-label="Installation overview">
-      <h2 class="section-title">Installed in 60 seconds</h2>
+      <h2 class="section-title">Up and running in 60 seconds.</h2>
       <div class="step-grid">
         <div class="step-card"><div class="step-num">1</div><h3>Download the DMG</h3><p>Apple-notarized — Gatekeeper verifies it before first launch. No warnings to click through.</p></div>
         <div class="step-card"><div class="step-num">2</div><h3>Drag to Applications</h3><p>The classic move. No installer wizard, no launch agents you didn't ask for.</p></div>
@@ -167,7 +222,7 @@
       </div>
     </section>
 
-    <!-- ─── FAQ ──────────────────────────────────────────── -->
+    <!-- ─── 9 · FAQ ────────────────────────────────────────── -->
     <section class="container section faq" aria-label="Frequently asked questions">
       <h2 class="section-title">Questions</h2>
       <details>
@@ -190,6 +245,19 @@
         <summary>Where does my data live?</summary>
         <p>In <code>~/.openvoiceflow</code> on your Mac — transcripts, dictionary, profile, keys. Delete that folder and every trace is gone. Nothing is synced anywhere.</p>
       </details>
+    </section>
+
+    <!-- ─── 10 · Closing CTA ───────────────────────────────── -->
+    <section class="container section" aria-label="Get started">
+      <div class="cta-panel">
+        <h2 class="cta-title">Start dictating for free.<br />Right now.</h2>
+        <p class="cta-sub">No account. No credit card. Local audio transcription. You choose the cleanup backend.</p>
+        <div class="hero-cta-row">
+          <a class="btn btn-primary btn-lg" href="download.html">Download for Mac — Free</a>
+          <a class="btn btn-outline btn-lg" href="install.html">Install guide</a>
+        </div>
+        <p class="cta-footnote">macOS 12+ · Monterey → Sequoia · Apple Silicon &amp; Intel</p>
+      </div>
     </section>
   </main>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Free push-to-talk voice dictation for macOS. Audio transcription runs locally with whisper.cpp; optional LLM cleanup uses the backend you choose." />
   <meta name="keywords" content="voice dictation macOS, Wispr Flow alternative, whisper dictation, free voice dictation mac, local transcription" />
   <meta property="og:title" content="OpenVoiceFlow — Free Voice Dictation for macOS" />
-  <meta property="og:description" content="Free push-to-talk voice dictation for macOS with local whisper.cpp transcription and optional LLM cleanup." />
+  <meta property="og:description" content="Speak. It types. Your audio never leaves your Mac. Free push-to-talk dictation with local whisper.cpp transcription." />
   <meta property="og:url" content="https://openvoiceflow.vercel.app/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -15,13 +15,8 @@
   <meta name="twitter:description" content="Free voice dictation for macOS. $0 forever." />
   <link rel="canonical" href="https://openvoiceflow.vercel.app/" />
 
-  <!-- Emoji favicon -->
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎙️</text></svg>" />
-
-  <!-- Google Fonts: Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <!-- Waveform-ring favicon (brand glyph) -->
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
 
   <link rel="stylesheet" href="style.css" />
 
@@ -54,879 +49,165 @@
 </head>
 <body>
 
-  <!-- ─── NAV ─────────────────────────────────────────── -->
-  <nav class="nav" id="nav">
+  <nav class="nav" id="nav" aria-label="Main">
     <div class="nav-inner container">
-      <a href="#" class="nav-logo">
-        <span class="nav-logo-emoji">🎙️</span>
-        <span class="nav-logo-text">OpenVoiceFlow</span>
-      </a>
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
-        <li><a href="download.html">Download</a></li>
+        <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
-        <li><a href="how-it-works.html">How It Works</a></li>
-        <li><a href="#features">Features</a></li>
-        <li>
-          <a href="download.html" class="btn btn-primary btn-sm">
-            Download
-          </a>
-        </li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
-      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer">
-        <span></span><span></span><span></span>
-      </button>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
     </div>
-    <!-- Mobile drawer -->
     <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
       <a href="download.html">Download</a>
       <a href="install.html">Install</a>
-      <a href="how-it-works.html">How It Works</a>
-      <a href="#features">Features</a>
+      <a href="how-it-works.html">How it works</a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
 
-  <!-- ─── HERO ─────────────────────────────────────────── -->
-  <section class="hero" id="hero">
-    <div class="hero-glow"></div>
-    <div class="container hero-inner">
-      <div class="hero-badge fade-in">
-        <span class="badge-dot"></span>
-        MIT-licensed and open source · 100% Free
+  <main>
+    <!-- ─── Hero ─────────────────────────────────────────── -->
+    <section class="container hero-inner" aria-label="Introduction">
+      <span class="hero-badge"><span class="badge-dot"></span>100% ON-DEVICE AUDIO · OPEN SOURCE · $0</span>
+      <h1 class="hero-title">Speak. It types.<br />Nothing leaves your&nbsp;Mac.</h1>
+      <p class="hero-sub answer-block">OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. Hold a key, talk, release — polished text lands at your cursor in any app. Whisper runs on your Mac, not in a cloud. Free forever, MIT-licensed.</p>
+      <div class="hero-cta-row">
+        <a class="btn btn-primary btn-lg" href="download.html">Download for Mac</a>
+        <a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">View source ↗</a>
       </div>
-      <h1 class="hero-title fade-in fade-in-delay-1">
-        <span class="hero-emoji">🎙️</span>
-        OpenVoiceFlow
-      </h1>
-      <p class="hero-tagline fade-in fade-in-delay-2">
-        Your voice, your rules, your Mac.
-      </p>
-      <p class="hero-sub fade-in fade-in-delay-3">
-        Free push-to-talk dictation for macOS.<br class="desktop-only" />
-        <span class="accent">Audio transcribes locally.</span> Optional cleanup uses the backend you choose.
-      </p>
-      <div class="answer-card fade-in fade-in-delay-3">
-        <strong>OpenVoiceFlow is a free push-to-talk voice dictation app for macOS</strong> that records locally, transcribes audio with whisper.cpp, optionally cleans the text with OpenRouter Gemma 4, Groq, OpenAI, Anthropic, Ollama, or no cleanup, and pastes the result at your cursor.
-      </div>
-      <div class="hero-ctas fade-in fade-in-delay-4">
-        <a href="download.html" class="btn btn-primary btn-lg">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3m0 12-4-4m4 4 4-4M2 17l.621 2.485A2 2 0 0 0 4.561 21h14.878a2 2 0 0 0 1.94-1.515L22 17"/></svg>
-          Download for Mac
-        </a>
-        <a href="how-it-works.html" class="btn btn-outline btn-lg">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-          See how it works
-        </a>
-      </div>
-      <div class="hero-meta fade-in fade-in-delay-4">
-        <span>macOS 12+</span>
-        <span class="meta-sep">·</span>
-        <span>Apple Silicon &amp; Intel</span>
-        <span class="meta-sep">·</span>
-        <span>Whisper-powered</span>
-        <span class="meta-sep">·</span>
-        <span>No account required</span>
-      </div>
+      <div class="hero-trust">Signed &amp; notarized · macOS 12+ · Apple Silicon &amp; Intel · no account, ever</div>
 
-      <!-- Animated Terminal demo card -->
-      <div class="hero-terminal fade-in fade-in-delay-5" id="animTerminal">
-        <div class="terminal-titlebar">
-          <span class="dot dot-red"></span>
-          <span class="dot dot-yellow"></span>
-          <span class="dot dot-green"></span>
-          <span class="terminal-title">OpenVoiceFlow</span>
-        </div>
-        <div class="terminal-body" id="termBody">
-          <!-- Lines injected by JS -->
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ─── HOW IT WORKS ──────────────────────────────────── -->
-  <section class="section" id="how-it-works">
-    <div class="container">
-      <div class="section-header reveal">
-        <span class="section-label">The pipeline</span>
-        <h2 class="section-title">How It Works</h2>
-        <p class="section-sub">Hold a key. Speak. Release. Perfect text at your cursor — anywhere on your Mac.</p>
-      </div>
-
-      <div class="pipeline reveal">
-        <div class="pipeline-step">
-          <div class="pipeline-icon">🎤</div>
-          <div class="pipeline-content">
-            <div class="pipeline-step-label">Step 1</div>
-            <div class="pipeline-step-title">Speak naturally</div>
-            <div class="pipeline-step-desc">Hold your hotkey. Talk.</div>
-          </div>
-        </div>
-        <div class="pipeline-connector">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-        </div>
-        <div class="pipeline-step">
-          <div class="pipeline-icon">🔊</div>
-          <div class="pipeline-content">
-            <div class="pipeline-step-label">Step 2</div>
-            <div class="pipeline-step-title">Whisper transcribes</div>
-            <div class="pipeline-step-desc">Local. Metal GPU. Fast.</div>
-          </div>
-        </div>
-        <div class="pipeline-connector">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-        </div>
-        <div class="pipeline-step">
-          <div class="pipeline-icon">🧠</div>
-          <div class="pipeline-content">
-            <div class="pipeline-step-label">Step 3</div>
-            <div class="pipeline-step-title">LLM cleans up</div>
-            <div class="pipeline-step-desc">Fillers removed. Context applied.</div>
-          </div>
-        </div>
-        <div class="pipeline-connector">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-        </div>
-        <div class="pipeline-step">
-          <div class="pipeline-icon">⌨️</div>
-          <div class="pipeline-content">
-            <div class="pipeline-step-label">Step 4</div>
-            <div class="pipeline-step-title">Perfect text</div>
-            <div class="pipeline-step-desc">At cursor. Any app.</div>
+      <div class="hero-demo" aria-hidden="true">
+        <div class="typed-box"><span id="typedDemo">Ship the beta tonight — the release notes are already in the doc.</span><span class="caret"></span></div>
+        <div class="hero-cap-row">
+          <div class="hero-cap">
+            <span class="hero-chip" id="heroChip">⌘<small>HELD</small></span>
+            <canvas data-wf="hero"></canvas>
+            <span class="hero-status" id="heroStatus">listening</span>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- ─── PERFORMANCE STATS BAR ─────────────────────────── -->
-  <section class="section stats-section" id="stats">
-    <div class="container">
-      <div class="stats-bar reveal">
-        <div class="stats-item">
-          <div class="stats-number gradient-text" data-target="120" data-prefix="~" data-suffix="ms">~0ms</div>
-          <div class="stats-label">Transcription latency</div>
+    <!-- ─── How it works ─────────────────────────────────── -->
+    <section class="container section" aria-label="How it works">
+      <div class="card-grid">
+        <div class="card">
+          <span class="mono-kicker">01 · Hold</span>
+          <span class="key-chip">⌘ <small>right</small></span>
+          <div class="card-body">One key, anywhere in macOS. Your pick: Right ⌘, Right ⌥ or Right ⌃.</div>
         </div>
-        <div class="stats-divider"></div>
-        <div class="stats-item">
-          <div class="stats-number gradient-text" data-target="6" data-prefix="" data-suffix="">0</div>
-          <div class="stats-label">AI backends</div>
+        <div class="card">
+          <span class="mono-kicker">02 · Speak</span>
+          <canvas data-wf="card" aria-hidden="true"></canvas>
+          <div class="card-body">Whisper transcribes on your Mac with whisper.cpp — Metal-accelerated on Apple Silicon. Airplane mode changes nothing.</div>
         </div>
-        <div class="stats-divider"></div>
-        <div class="stats-item">
-          <div class="stats-number gradient-text" data-target="24" data-prefix="" data-suffix="">0</div>
-          <div class="stats-label">Voice commands</div>
-        </div>
-        <div class="stats-divider"></div>
-        <div class="stats-item">
-          <div class="stats-number gradient-text" data-target="100" data-prefix="" data-suffix="+">0+</div>
-          <div class="stats-label">Languages supported</div>
+        <div class="card">
+          <span class="mono-kicker">03 · Release</span>
+          <div class="card-lede">Polished text at your cursor<span class="caret-sm"></span></div>
+          <div class="card-body">Optional cleanup fixes ums and grammar — local Ollama, your own cloud key, or off entirely. <a href="how-it-works.html">See the full pipeline →</a></div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- ─── FEATURES ──────────────────────────────────────── -->
-  <section class="section section-alt" id="features">
-    <div class="container">
-      <div class="section-header reveal">
-        <span class="section-label">What you get</span>
-        <h2 class="section-title">Everything you need.<br />Nothing you don't.</h2>
-        <p class="section-sub">Built for people who care about quality, privacy, and getting things done.</p>
-      </div>
-
-      <div class="features-grid">
-        <div class="feature-card reveal">
-          <div class="feature-icon">⚡</div>
-          <h3 class="feature-title">Real-Time Streaming</h3>
-          <p class="feature-desc">Words appear in the overlay as you speak — not after you stop.</p>
-        </div>
-        <div class="feature-card reveal">
-          <div class="feature-icon">🧬</div>
-          <h3 class="feature-title">Smart Profile</h3>
-          <p class="feature-desc">Learns your name, team, and jargon on first launch.</p>
-        </div>
-        <div class="feature-card reveal">
-          <div class="feature-icon">🔁</div>
-          <h3 class="feature-title">Auto-Learn</h3>
-          <p class="feature-desc">Fix a typo once — it learns forever. Gets smarter daily.</p>
-        </div>
-        <div class="feature-card reveal">
-          <div class="feature-icon">🎯</div>
-          <h3 class="feature-title">Per-App Context</h3>
-          <p class="feature-desc">Adapts tone and style for Slack, VS Code, Gmail, and more.</p>
-        </div>
-        <div class="feature-card reveal">
-          <div class="feature-icon">🗣️</div>
-          <h3 class="feature-title">Voice Commands</h3>
-          <p class="feature-desc">"New line", "comma", "period" — natural punctuation control.</p>
-        </div>
-        <div class="feature-card reveal">
-          <div class="feature-icon">🔒</div>
-          <h3 class="feature-title">100% Local Audio</h3>
-          <p class="feature-desc">Your voice never leaves your Mac. Ever. Full stop.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ─── GET STARTED IN 60 SECONDS ────────────────────── -->
-  <section class="section" id="get-started">
-    <div class="container">
-      <div class="section-header reveal">
-        <span class="section-label">Get started</span>
-        <h2 class="section-title">Up and running in 60 seconds.</h2>
-        <p class="section-sub">One command. Or click to download. You're dictating in under a minute.</p>
-      </div>
-
-      <div class="install-wrap reveal">
-        <!-- Primary: DMG Download -->
-        <a href="download.html" class="install-dmg-btn">
-          <svg class="macos-icon" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-          </svg>
-          <div class="install-dmg-text">
-            <span class="install-dmg-title">Download for macOS</span>
-            <span class="install-dmg-sub">Free · Apple Silicon &amp; Intel · macOS 12+</span>
+    <!-- ─── Privacy ──────────────────────────────────────── -->
+    <section class="container section" aria-label="Privacy">
+      <div class="privacy-panel">
+        <div class="privacy-grid">
+          <div class="privacy-copy">
+            <div class="privacy-title">Your voice never leaves your&nbsp;Mac.</div>
+            <div class="privacy-body">Not &ldquo;encrypted in transit.&rdquo; Not &ldquo;anonymized.&rdquo; <b>Not sent.</b> Audio goes from your microphone into a model running on your machine, and is discarded the moment text exists. The only required network call is the one-time model download. Cloud text cleanup happens only if you add your own API key — and it only ever sees text, never audio.</div>
+            <div class="privacy-note">Don't take our word for it — <a href="https://github.com/shimoverse/openvoiceflow">read the source</a>. That's the point of open source.</div>
           </div>
-          <svg class="install-dmg-arrow" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3m0 12-4-4m4 4 4-4M2 17l.621 2.485A2 2 0 0 0 4.561 21h14.878a2 2 0 0 0 1.94-1.515L22 17"/></svg>
-        </a>
-
-        <div class="install-divider">
-          <span>or read setup details</span>
-        </div>
-
-        <!-- Terminal one-liner -->
-        <div class="install-terminal">
-          <div class="install-terminal-inner">
-            <span class="install-prompt">$</span>
-            <code class="install-cmd" id="installCmd">https://openvoiceflow.vercel.app/download.html</code>
-            <button class="install-copy-btn" id="installCopyBtn" aria-label="Copy install command">
-              <svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-              <svg class="check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-              <span class="copy-label">Copy</span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ─── COMPARISON ────────────────────────────────────── -->
-  <section class="section section-alt" id="compare">
-    <div class="container">
-      <div class="section-header reveal">
-        <span class="section-label">See the difference</span>
-        <h2 class="section-title">Why switch from Wispr Flow?</h2>
-        <p class="section-sub">Same quality. Zero cost. Total transparency.</p>
-      </div>
-
-      <div class="table-scroll-hint reveal">
-        <span>←</span> Swipe to compare <span>→</span>
-      </div>
-      <div class="table-wrap reveal">
-        <table class="compare-table">
-          <thead>
-            <tr>
-              <th class="col-feature">Feature</th>
-              <th class="col-ovf">
-                <div class="th-inner">
-                  <span class="th-emoji">🎙️</span>
-                  <span class="th-name">OpenVoiceFlow</span>
-                  <span class="th-badge">Free</span>
-                </div>
-              </th>
-              <th>
-                <div class="th-inner th-competitor">
-                  <span class="th-name">Wispr Flow</span>
-                  <span class="th-price">$144/yr</span>
-                </div>
-              </th>
-              <th>
-                <div class="th-inner th-competitor">
-                  <span class="th-name">Superwhisper</span>
-                  <span class="th-price">$85/yr</span>
-                </div>
-              </th>
-              <th>
-                <div class="th-inner th-competitor">
-                  <span class="th-name">VoiceInk</span>
-                  <span class="th-price">Free (GPL)</span>
-                </div>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="col-feature">Annual Cost</td>
-              <td class="col-ovf highlight-cell">
-                <span class="check">✓</span> <strong class="green">$0–3</strong>
-              </td>
-              <td><span class="cross">✗</span> $144</td>
-              <td><span class="cross">✗</span> $85</td>
-              <td><span class="check">✓</span> Free</td>
-            </tr>
-            <tr>
-              <td class="col-feature">Source repository</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span> MIT</td>
-              <td><span class="cross">✗</span></td>
-              <td><span class="cross">✗</span></td>
-              <td><span class="partial">~</span> GPL (limited)</td>
-            </tr>
-            <tr>
-              <td class="col-feature">Local Audio</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span></td>
-              <td><span class="cross">✗</span> Cloud</td>
-              <td><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-            </tr>
-            <tr>
-              <td class="col-feature">Auto-Learn</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-              <td><span class="partial">~</span> Partial</td>
-              <td><span class="cross">✗</span></td>
-            </tr>
-            <tr>
-              <td class="col-feature">Per-App Context</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-            </tr>
-            <tr>
-              <td class="col-feature">Voice Commands</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-              <td><span class="partial">~</span> Basic</td>
-              <td><span class="partial">~</span> Basic</td>
-            </tr>
-            <tr>
-              <td class="col-feature">Real-Time Streaming</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-              <td><span class="cross">✗</span></td>
-              <td><span class="cross">✗</span></td>
-            </tr>
-            <tr>
-              <td class="col-feature">Selected Text Context</td>
-              <td class="col-ovf highlight-cell"><span class="check">✓</span></td>
-              <td><span class="check">✓</span></td>
-              <td><span class="partial">~</span> Partial</td>
-              <td><span class="cross">✗</span></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
-
-  <!-- ─── BACKENDS ─────────────────────────────────────── -->
-  <section class="section" id="backends">
-    <div class="container">
-      <div class="section-header reveal">
-        <span class="section-label">Your choice</span>
-        <h2 class="section-title">Pick your backend.</h2>
-        <p class="section-sub">From fully local (zero cost, zero cloud) to ultra-fast API. You decide what runs where.</p>
-      </div>
-
-      <div class="backends-grid">
-        <div class="backend-card backend-recommended reveal">
-          <div class="backend-badge">Recommended</div>
-          <div class="backend-icon">✨</div>
-          <div class="backend-name">OpenRouter Gemma 4</div>
-          <div class="backend-cost">OpenRouter pricing/free tiers</div>
-          <div class="backend-privacy privacy-mid">Audio stays local</div>
-          <div class="backend-desc">Default cloud cleanup path using google/gemma-4-31b-it through OpenRouter.</div>
-          <code class="backend-cmd">openvoiceflow --backend openrouter --set-key openrouter YOUR_KEY</code>
-        </div>
-        <div class="backend-card reveal">
-          <div class="backend-icon">⚡</div>
-          <div class="backend-name">Groq</div>
-          <div class="backend-cost">Free tier / ~$1/yr</div>
-          <div class="backend-privacy privacy-mid">API call</div>
-          <div class="backend-desc">Fastest inference on the planet. Llama on Groq's custom silicon.</div>
-          <code class="backend-cmd">openvoiceflow --set-key groq YOUR_KEY</code>
-        </div>
-        <div class="backend-card reveal">
-          <div class="backend-icon">🤖</div>
-          <div class="backend-name">OpenAI</div>
-          <div class="backend-cost">~$5/yr</div>
-          <div class="backend-privacy privacy-mid">API call</div>
-          <div class="backend-desc">GPT-4o mini. Great for complex cleanup and nuanced rewrites.</div>
-          <code class="backend-cmd">openvoiceflow --set-key openai YOUR_KEY</code>
-        </div>
-        <div class="backend-card reveal">
-          <div class="backend-icon">🌟</div>
-          <div class="backend-name">Claude</div>
-          <div class="backend-cost">~$5/yr</div>
-          <div class="backend-privacy privacy-mid">API call</div>
-          <div class="backend-desc">Anthropic's Claude Haiku. Exceptional writing quality and tone.</div>
-          <code class="backend-cmd">openvoiceflow --set-key claude YOUR_KEY</code>
-        </div>
-        <div class="backend-card backend-local reveal">
-          <div class="backend-badge backend-badge-green">100% Local</div>
-          <div class="backend-icon">🦙</div>
-          <div class="backend-name">Ollama</div>
-          <div class="backend-cost text-green">$0 / forever</div>
-          <div class="backend-privacy privacy-local">Never leaves Mac</div>
-          <div class="backend-desc">Fully offline. Llama 3, Mistral, or any local model. Air-gapped privacy.</div>
-          <code class="backend-cmd">openvoiceflow --backend ollama</code>
-        </div>
-        <div class="backend-card reveal">
-          <div class="backend-icon">⚙️</div>
-          <div class="backend-name">None (Whisper only)</div>
-          <div class="backend-cost text-green">$0 / forever</div>
-          <div class="backend-privacy privacy-local">Never leaves Mac</div>
-          <div class="backend-desc">Raw Whisper output only. No LLM cleanup. Minimal and lightning fast.</div>
-          <code class="backend-cmd">openvoiceflow --backend none</code>
-        </div>
-      </div>
-
-      <div class="backends-note reveal">
-        <span class="note-icon">💡</span>
-        <strong>All options:</strong> Audio transcription is <em>always</em> local via Whisper. Only the cleanup LLM call goes to an API (if you choose one).
-      </div>
-    </div>
-  </section>
-
-  <!-- ─── FAQ ──────────────────────────────────────────── -->
-  <section class="section section-alt" id="faq">
-    <div class="container">
-      <div class="section-header reveal">
-        <span class="section-label">Common questions</span>
-        <h2 class="section-title">FAQ</h2>
-        <p class="section-sub">Everything you want to know before you install.</p>
-      </div>
-
-      <div class="faq-list reveal" id="faqList">
-
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Is it really free?</span>
-            <span class="faq-icon" aria-hidden="true">+</span>
-          </button>
-          <div class="faq-answer">
-            <div class="faq-answer-inner">
-              Yes. The signed DMG is free, and the source repository is public under the MIT License. Use Ollama for $0/forever, or choose a cloud LLM backend if you want hosted cleanup.
+          <div class="privacy-box">
+            <div class="privacy-box-label">YOUR MAC — AUDIO NEVER LEAVES THIS BOX</div>
+            <div class="pipe-row">
+              <span class="pipe-chip">mic</span><span class="pipe-arrow">→</span>
+              <span class="pipe-chip">Whisper</span><span class="pipe-arrow">→</span>
+              <span class="pipe-chip">cleanup</span><span class="pipe-arrow">→</span>
+              <span class="pipe-chip dest">your cursor</span>
             </div>
-          </div>
-        </div>
-
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Does my audio leave my Mac?</span>
-            <span class="faq-icon" aria-hidden="true">+</span>
-          </button>
-          <div class="faq-answer">
-            <div class="faq-answer-inner">
-              Never. Whisper runs 100% locally on your Mac using Metal GPU acceleration. Only the cleaned-up text goes to an LLM API (if you choose one). With Ollama, nothing leaves your Mac at all.
-            </div>
-          </div>
-        </div>
-
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>How does it compare to macOS built-in dictation?</span>
-            <span class="faq-icon" aria-hidden="true">+</span>
-          </button>
-          <div class="faq-answer">
-            <div class="faq-answer-inner">
-              macOS dictation is basic transcription with no cleanup, no context awareness, no learning. OpenVoiceFlow removes fillers ("um", "uh"), understands corrections ("no wait"), adapts to each app, and learns your vocabulary.
-            </div>
-          </div>
-        </div>
-
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>What if I don't have an API key?</span>
-            <span class="faq-icon" aria-hidden="true">+</span>
-          </button>
-          <div class="faq-answer">
-            <div class="faq-answer-inner">
-              Use Ollama (fully local, free), choose no cleanup, or configure a paid/free-tier cloud provider such as OpenRouter, Groq, OpenAI, or Anthropic with your own key.
-            </div>
-          </div>
-        </div>
-
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Does it work on Intel Macs?</span>
-            <span class="faq-icon" aria-hidden="true">+</span>
-          </button>
-          <div class="faq-answer">
-            <div class="faq-answer-inner">
-              Yes. Both Apple Silicon and Intel are supported. Streaming mode uses Metal GPU on Apple Silicon; Intel falls back to CPU-based batch mode.
-            </div>
-          </div>
-        </div>
-
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Can I use it offline?</span>
-            <span class="faq-icon" aria-hidden="true">+</span>
-          </button>
-          <div class="faq-answer">
-            <div class="faq-answer-inner">
-              Yes. With the Ollama backend + local Whisper model, everything runs offline. No internet needed.
-            </div>
-          </div>
-        </div>
-
-      </div>
-    </div>
-  </section>
-
-  <!-- ─── SOCIAL PROOF ──────────────────────────────────── -->
-  <section class="section" id="community">
-    <div class="container">
-      <div class="community-wrap reveal">
-        <div class="community-text">
-          <span class="section-label">Open source</span>
-          <h2 class="section-title">Built for Mac users<br />who want voice without lock-in.</h2>
-          <p class="section-sub">OpenVoiceFlow is MIT-licensed and open source. Install the verified website-hosted DMGs or inspect and build the public source on GitHub.</p>
-          <p class="community-cta-text">If this saves you $144 a year, share the download page with another Mac user who wants local-audio dictation.</p>
-          <div class="community-actions">
-            <a href="download.html" class="btn btn-primary btn-lg">
-              Download for Mac
-            </a>
-            <a href="install.html" class="btn btn-outline btn-lg">
-              Install guide
-            </a>
-            <a href="https://github.com/shimoverse/openvoiceflow" class="btn btn-outline btn-lg">
-              View source
-            </a>
-          </div>
-        </div>
-        <div class="community-stats">
-          <div class="stat-card">
-            <div class="stat-value">$0</div>
-            <div class="stat-label">Annual cost</div>
-          </div>
-          <div class="stat-card stat-card-accent">
-            <div class="stat-value">$144</div>
-            <div class="stat-label">You save vs Wispr Flow</div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-value">MIT</div>
-            <div class="stat-label">License</div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-value">100%</div>
-            <div class="stat-label">Local audio</div>
+            <canvas data-wf="pline" aria-hidden="true"></canvas>
+            <div class="privacy-box-note">With Ollama or cleanup off, no byte crosses this border at all.</div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- ─── FINAL CTA ─────────────────────────────────────── -->
-  <section class="section cta-section">
-    <div class="container">
-      <div class="cta-wrap reveal">
-        <div class="cta-glow"></div>
-        <h2 class="cta-title">Start dictating for free.<br />Right now.</h2>
-        <p class="cta-sub">No account. No credit card. Local audio transcription. You choose the cleanup backend.</p>
-        <div class="cta-buttons">
-          <a href="download.html" class="btn btn-primary btn-xl">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3m0 12-4-4m4 4 4-4M2 17l.621 2.485A2 2 0 0 0 4.561 21h14.878a2 2 0 0 0 1.94-1.515L22 17"/></svg>
-            Download for Mac — Free
-          </a>
+    <!-- ─── Compare ──────────────────────────────────────── -->
+    <section class="container section" aria-label="Comparison with Wispr Flow">
+      <h2 class="section-title">The $144-a-year question</h2>
+      <p class="section-sub">Wispr Flow is a fine product. It is also a subscription to someone else's cloud.</p>
+      <div class="compare-table">
+        <div class="compare-grid">
+          <div class="compare-head-dim" aria-hidden="true">&nbsp;</div><div class="compare-head">OpenVoiceFlow</div><div class="compare-head-dim">Wispr Flow</div>
+          <div class="compare-label">Price</div><div class="compare-us-strong">$0, forever</div><div class="compare-them">$12/mo — $144/yr</div>
+          <div class="compare-label">Transcription</div><div class="compare-us">On this Mac</div><div class="compare-them">Their cloud</div>
+          <div class="compare-label">Works offline</div><div class="compare-yes">Yes</div><div class="compare-them">No</div>
+          <div class="compare-label">Your audio leaves the machine</div><div class="compare-yes">Never</div><div class="compare-them">Uploaded to transcribe</div>
+          <div class="compare-label">Source code</div><div class="compare-us">Open — MIT</div><div class="compare-them">Closed</div>
+          <div class="compare-label">Account required</div><div class="compare-yes">No</div><div class="compare-them">Yes</div>
+          <div class="compare-label">AI cleanup</div><div class="compare-us">Your choice — local Ollama, or your own API key</div><div class="compare-them">Their pipeline</div>
         </div>
-        <p class="cta-footnote">macOS 12 · Monterey · Ventura · Sonoma · Sequoia · Apple Silicon · Intel</p>
       </div>
-    </div>
-  </section>
+      <p class="compare-footnote">Competitor details per their published pricing and docs, July 2026.</p>
+    </section>
 
-  <!-- ─── FOOTER ────────────────────────────────────────── -->
+    <!-- ─── Install ──────────────────────────────────────── -->
+    <section class="container section" aria-label="Installation overview">
+      <h2 class="section-title">Installed in 60 seconds</h2>
+      <div class="step-grid">
+        <div class="step-card"><div class="step-num">1</div><h3>Download the DMG</h3><p>Apple-notarized — Gatekeeper verifies it before first launch. No warnings to click through.</p></div>
+        <div class="step-card"><div class="step-num">2</div><h3>Drag to Applications</h3><p>The classic move. No installer wizard, no launch agents you didn't ask for.</p></div>
+        <div class="step-card"><div class="step-num">3</div><h3>Say hello</h3><p>First launch runs a one-time setup (~5 minutes: speech engine + model) with each permission explained before macOS asks. <a href="install.html">Full install guide →</a></p></div>
+      </div>
+    </section>
+
+    <!-- ─── FAQ ──────────────────────────────────────────── -->
+    <section class="container section faq" aria-label="Frequently asked questions">
+      <h2 class="section-title">Questions</h2>
+      <details>
+        <summary>Really free? What's the catch?</summary>
+        <p>MIT-licensed, community-built, no account, no telemetry. Whisper is free to run; your Mac provides the compute. There is nothing to sell you.</p>
+      </details>
+      <details>
+        <summary>How accurate is it?</summary>
+        <p>Whisper runs on-device with your pick of models from tiny to large — trade speed for accuracy per your Mac. Your personal dictionary fixes names and jargon once, forever, and the Know-Me interview teaches cleanup your tone.</p>
+      </details>
+      <details>
+        <summary>Does AI cleanup send my text to the cloud?</summary>
+        <p>Only if you add your own API key for a cloud provider — the default cloud path is OpenRouter Gemma 4, and keys are stored only on your Mac. Choose local Ollama, or turn cleanup off entirely, for a fully on-device flow. Audio never goes anywhere, regardless.</p>
+      </details>
+      <details>
+        <summary>Which Macs?</summary>
+        <p>macOS 12 Monterey or newer. Apple Silicon flies; Intel Macs work with smaller models. Setup is honest with you about what your hardware can handle.</p>
+      </details>
+      <details>
+        <summary>Where does my data live?</summary>
+        <p>In <code>~/.openvoiceflow</code> on your Mac — transcripts, dictionary, profile, keys. Delete that folder and every trace is gone. Nothing is synced anywhere.</p>
+      </details>
+    </section>
+  </main>
+
+  <!-- ─── Footer ─────────────────────────────────────────── -->
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-brand">
-        <a href="#" class="nav-logo">
-          <span class="nav-logo-emoji">🎙️</span>
-          <span class="nav-logo-text">OpenVoiceFlow</span>
-        </a>
-        <p class="footer-tagline">Made with 🎤 for Mac users who want local-audio dictation</p>
-      </div>
-      <nav class="footer-links">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License · made for people who talk faster than they type.</p>
+      <nav class="footer-links" aria-label="Footer">
         <a href="download.html">Download</a>
         <a href="install.html">Install</a>
         <a href="how-it-works.html">How it works</a>
         <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
-      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
     </div>
   </footer>
 
-  <script>
-    // ─── Smooth scroll ─────────────────────────────────────
-    document.querySelectorAll('a[href^="#"]').forEach(a => {
-      a.addEventListener('click', e => {
-        const id = a.getAttribute('href').slice(1);
-        const el = document.getElementById(id);
-        if (!el) return;
-        e.preventDefault();
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        // Close mobile drawer
-        document.getElementById('navDrawer').classList.remove('open');
-        document.getElementById('navHamburger').classList.remove('active');
-      });
-    });
-
-    // ─── Nav scroll shadow ─────────────────────────────────
-    const nav = document.getElementById('nav');
-    window.addEventListener('scroll', () => {
-      nav.classList.toggle('scrolled', window.scrollY > 20);
-    }, { passive: true });
-
-    // ─── Hamburger menu ────────────────────────────────────
-    const hamburger = document.getElementById('navHamburger');
-    const drawer = document.getElementById('navDrawer');
-    function setDrawerOpen(open) {
-      hamburger.classList.toggle('active', open);
-      drawer.classList.toggle('open', open);
-      hamburger.setAttribute('aria-expanded', open ? 'true' : 'false');
-    }
-    hamburger.addEventListener('click', () => {
-      setDrawerOpen(!drawer.classList.contains('open'));
-    });
-    drawer.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', () => setDrawerOpen(false));
-    });
-    document.addEventListener('keydown', event => {
-      if (event.key === 'Escape') setDrawerOpen(false);
-    });
-
-    // ─── Intersection Observer (reveal on scroll) ──────────
-    const revealEls = document.querySelectorAll('.reveal');
-    const revealObserver = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('visible');
-          revealObserver.unobserve(entry.target);
-        }
-      });
-    }, { threshold: 0.1, rootMargin: '0px 0px -50px 0px' });
-
-    revealEls.forEach(el => revealObserver.observe(el));
-
-    // ─── Hero fade-ins (immediate) ─────────────────────────
-    document.querySelectorAll('.fade-in').forEach((el, i) => {
-      setTimeout(() => el.classList.add('visible'), i * 80);
-    });
-
-    // ─── Animated Terminal ─────────────────────────────────
-    (function initAnimTerminal() {
-      const termBody = document.getElementById('termBody');
-      if (!termBody) return;
-
-      const STEPS = [
-        {
-          emoji: '🎤',
-          label: 'You say:',
-          text: '"um hey uh can you schedule a meeting for Thursday no wait Friday"',
-          cls: 't-text',
-          showArrow: false
-        },
-        {
-          emoji: '🔊',
-          label: 'Whisper:',
-          text: 'local transcription · Metal GPU · ~120ms',
-          cls: 't-text',
-          showArrow: true
-        },
-        {
-          emoji: '🧠',
-          label: 'LLM:',
-          text: 'cleaning fillers, applying your context…',
-          cls: 't-text',
-          showArrow: true
-        },
-        {
-          emoji: '⌨️',
-          label: 'Output:',
-          text: '"Hey, can you schedule a meeting for Friday?"',
-          cls: 't-accent',
-          showArrow: true
-        }
-      ];
-
-      const CHAR_DELAY = 40;    // ms per character
-      const LINE_PAUSE = 800;   // ms between lines
-      const LOOP_PAUSE = 4000;  // ms idle before restarting
-      const CURSOR_HTML = '<span class="term-cursor">▋</span>';
-
-      function sleep(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
-      }
-
-      async function typeText(el, text, cls) {
-        el.innerHTML = CURSOR_HTML;
-        for (let i = 0; i < text.length; i++) {
-          await sleep(CHAR_DELAY);
-          const span = document.createElement('span');
-          span.className = cls;
-          span.textContent = text.slice(0, i + 1);
-          el.innerHTML = '';
-          el.appendChild(span);
-          el.innerHTML += CURSOR_HTML;
-        }
-        // Remove cursor after line finishes
-        await sleep(200);
-        const cursorEl = el.querySelector('.term-cursor');
-        if (cursorEl) cursorEl.remove();
-      }
-
-      async function runAnimation() {
-        termBody.innerHTML = '';
-
-        for (let i = 0; i < STEPS.length; i++) {
-          const step = STEPS[i];
-
-          // Arrow separator (before step, except first)
-          if (step.showArrow) {
-            const arrowEl = document.createElement('div');
-            arrowEl.className = 'terminal-arrow term-arrow-hidden';
-            arrowEl.textContent = '↓';
-            termBody.appendChild(arrowEl);
-            await sleep(120);
-            arrowEl.classList.remove('term-arrow-hidden');
-            arrowEl.classList.add('term-arrow-visible');
-            await sleep(LINE_PAUSE / 2);
-          }
-
-          // Line wrapper
-          const lineEl = document.createElement('div');
-          lineEl.className = 'terminal-line';
-
-          const emojiSpan = document.createElement('span');
-          emojiSpan.className = 't-dim';
-          emojiSpan.textContent = step.emoji + ' ';
-          lineEl.appendChild(emojiSpan);
-
-          const labelSpan = document.createElement('span');
-          labelSpan.className = 't-muted';
-          labelSpan.textContent = step.label + ' ';
-          lineEl.appendChild(labelSpan);
-
-          const textContainer = document.createElement('span');
-          lineEl.appendChild(textContainer);
-
-          termBody.appendChild(lineEl);
-
-          // Scroll terminal into view if needed
-          termBody.scrollTop = termBody.scrollHeight;
-
-          // Type the text
-          await typeText(textContainer, step.text, step.cls);
-          await sleep(LINE_PAUSE);
-        }
-
-        // Pause before loop
-        await sleep(LOOP_PAUSE);
-        // Fade out and restart
-        termBody.style.opacity = '0';
-        termBody.style.transition = 'opacity 0.4s ease';
-        await sleep(450);
-        termBody.style.opacity = '1';
-        termBody.style.transition = 'opacity 0.4s ease';
-        await sleep(200);
-        runAnimation();
-      }
-
-      // Start after hero fade-in settles
-      setTimeout(runAnimation, 900);
-    })();
-
-    // ─── Copy install command ──────────────────────────────
-    (function initCopyBtn() {
-      const btn = document.getElementById('installCopyBtn');
-      if (!btn) return;
-      btn.addEventListener('click', () => {
-        const cmd = 'https://openvoiceflow.vercel.app/download.html';
-        navigator.clipboard.writeText(cmd).then(() => {
-          btn.classList.add('copied');
-          setTimeout(() => btn.classList.remove('copied'), 2000);
-        }).catch(() => {
-          // Fallback for older browsers
-          const ta = document.createElement('textarea');
-          ta.value = cmd;
-          ta.style.position = 'fixed';
-          ta.style.opacity = '0';
-          document.body.appendChild(ta);
-          ta.focus();
-          ta.select();
-          document.execCommand('copy');
-          document.body.removeChild(ta);
-          btn.classList.add('copied');
-          setTimeout(() => btn.classList.remove('copied'), 2000);
-        });
-      });
-    })();
-
-    // ─── Stats count-up animation ──────────────────────────
-    (function initStatsCountup() {
-      const statNums = document.querySelectorAll('.stats-number[data-target]');
-      if (!statNums.length) return;
-
-      function animateCountUp(el) {
-        const target = parseInt(el.dataset.target, 10);
-        const prefix = el.dataset.prefix || '';
-        const suffix = el.dataset.suffix || '';
-        const duration = 1200;
-        const startTime = performance.now();
-
-        function update(now) {
-          const elapsed = now - startTime;
-          const progress = Math.min(elapsed / duration, 1);
-          // Ease out cubic
-          const eased = 1 - Math.pow(1 - progress, 3);
-          const current = Math.round(eased * target);
-          el.textContent = prefix + current + suffix;
-          if (progress < 1) requestAnimationFrame(update);
-        }
-        requestAnimationFrame(update);
-      }
-
-      const statsObserver = new IntersectionObserver(entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            entry.target.querySelectorAll('.stats-number[data-target]').forEach(animateCountUp);
-            statsObserver.unobserve(entry.target);
-          }
-        });
-      }, { threshold: 0.3 });
-
-      const statsBar = document.querySelector('.stats-bar');
-      if (statsBar) statsObserver.observe(statsBar);
-    })();
-
-    // ─── FAQ accordion ────────────────────────────────────
-    (function initFAQ() {
-      const faqList = document.getElementById('faqList');
-      if (!faqList) return;
-
-      faqList.addEventListener('click', e => {
-        const btn = e.target.closest('.faq-question');
-        if (!btn) return;
-
-        const item = btn.closest('.faq-item');
-        const isOpen = btn.getAttribute('aria-expanded') === 'true';
-
-        // Close all
-        faqList.querySelectorAll('.faq-item').forEach(i => {
-          i.querySelector('.faq-question').setAttribute('aria-expanded', 'false');
-          i.classList.remove('open');
-        });
-
-        // Open clicked if it was closed
-        if (!isOpen) {
-          btn.setAttribute('aria-expanded', 'true');
-          item.classList.add('open');
-        }
-      });
-    })();
-  </script>
   <script src="site.js"></script>
 </body>
 </html>

--- a/docs/install.html
+++ b/docs/install.html
@@ -7,11 +7,11 @@
   <meta name="description" content="Step-by-step OpenVoiceFlow install guide for macOS, including DMG install, source install, backend setup, permissions, and troubleshooting." />
   <meta property="og:title" content="Install OpenVoiceFlow on macOS" />
   <meta property="og:description" content="DMG install, source install, permissions, backend setup, and troubleshooting." />
-
   <meta property="og:url" content="https://openvoiceflow.vercel.app/install.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://openvoiceflow.vercel.app/install.html" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"HowTo","name":"How to install OpenVoiceFlow on macOS","description":"Install OpenVoiceFlow from a DMG or from source on macOS.","totalTime":"PT5M","step":[{"@type":"HowToStep","name":"Download","text":"Download the matching Apple Silicon or Intel DMG from the OpenVoiceFlow download page."},{"@type":"HowToStep","name":"Install","text":"Open the DMG and drag OpenVoiceFlow into Applications."},{"@type":"HowToStep","name":"Configure","text":"Grant macOS permissions and choose OpenRouter, another provider, Ollama, or no cleanup backend."}]}
@@ -22,13 +22,62 @@
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
 </head>
 <body>
-<nav class="nav scrolled" id="nav"><div class="nav-inner container"><a href="index.html" class="nav-logo"><span class="nav-logo-emoji">🎙️</span><span class="nav-logo-text">OpenVoiceFlow</span></a><ul class="nav-links"><li><a href="download.html">Download</a></li><li><a href="install.html">Install</a></li><li><a href="how-it-works.html">How it works</a></li></ul><button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button></div><div class="nav-drawer" id="navDrawer"><a href="index.html">Home</a><a href="download.html">Download</a><a href="install.html">Install</a><a href="how-it-works.html">How it works</a><a href="download.html" class="btn btn-primary">Download for Mac</a></div></nav>
-<main><section class="hero page-hero"><div class="hero-glow"></div><div class="container hero-inner">
-<div class="hero-badge"><span class="badge-dot"></span>Install guide · macOS 12+</div><h1 class="hero-title">Install OpenVoiceFlow on macOS</h1><p class="hero-sub answer-block">Install OpenVoiceFlow by downloading the signed macOS DMG from this website. The app needs microphone access, whisper.cpp for local transcription, and either OpenRouter, another LLM provider, Ollama, or no cleanup backend. The MIT-licensed source is also public.</p><div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">View source</a></div>
-<section class="content-card wide-card"><h2>Fast path: DMG install</h2><ol class="step-list"><li>Open <a href="download.html">the download page</a> and pick Apple Silicon or Intel.</li><li>Download the DMG from this website.</li><li>Open the DMG and drag OpenVoiceFlow into Applications.</li><li>Launch OpenVoiceFlow and grant macOS microphone/accessibility permissions when prompted.</li><li>Look for the monochrome <strong>waveform menu-bar icon</strong> at the top-right; OpenVoiceFlow does not stay in the Dock.</li><li>Click the waveform and choose <strong>Open OpenVoiceFlow</strong> to confirm the app is ready.</li><li>Click in any text field, hold the <strong>Right Command (⌘)</strong> key, speak, then release it to paste the transcription.</li><li>Use the same menu to pause listening, change the dictation shortcut, open permission settings, or check for updates.</li></ol></section>
-<section class="content-card wide-card"><h2>Terminal install from source</h2><code class="code-block">git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow &amp;&amp; bash install.sh</code><p>The <a href="https://github.com/shimoverse/openvoiceflow">public GitHub repository</a> is available to everyone. Use the DMG path for the signed app.</p></section>
-<section class="content-card wide-card"><h2>Manual setup</h2><code class="code-block">brew install whisper-cpp<br>git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow<br>python3 -m venv ~/.openvoiceflow/venv<br>~/.openvoiceflow/venv/bin/pip install -e ".[all]"<br>openvoiceflow --backend openrouter --set-key openrouter YOUR_KEY_HERE<br>openvoiceflow</code></section>
-<section class="content-card wide-card"><h2>Troubleshooting</h2><ul class="check-list"><li>If macOS still blocks launch, delete any older unsigned copy and re-download the current signed, Apple-notarized v0.3.5 DMG from this website.</li><li>If the waveform changes to a warning symbol, open <strong>Advanced</strong> in the menu and use the direct Microphone or Accessibility settings links.</li><li>If transcription does not start, confirm microphone permission in macOS System Settings.</li><li>If paste fails, grant Accessibility permission for the app or terminal launching OpenVoiceFlow.</li><li>If cloud cleanup fails, verify your chosen provider key; OpenRouter uses <code>openrouter</code>, not a Gemini API key.</li><li>If you need a fully local flow, choose Ollama or <code>--backend none</code>.</li></ul></section>
-</div></section></main><footer class="footer"><div class="container footer-inner"><nav class="footer-links"><a href="index.html">Home</a><a href="download.html">Download</a><a href="how-it-works.html">How it works</a><a href="llms.txt">llms.txt</a></nav><p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p></div></footer>
+  <nav class="nav" id="nav" aria-label="Main">
+    <div class="nav-inner container">
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
+      <ul class="nav-links">
+        <li><a href="how-it-works.html">How it works</a></li>
+        <li><a href="install.html">Install</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
+      </ul>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
+    </div>
+    <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
+      <a href="download.html">Download</a>
+      <a href="install.html">Install</a>
+      <a href="how-it-works.html">How it works</a>
+      <a href="download.html" class="btn btn-primary">Download for Mac</a>
+    </div>
+  </nav>
+
+  <main>
+    <section class="page-hero"><div class="container hero-inner">
+      <span class="mono-kicker">Install guide · macOS 12+</span>
+      <h1 class="hero-title">Install OpenVoiceFlow on macOS</h1>
+      <p class="hero-sub answer-block">Install OpenVoiceFlow by downloading the signed macOS DMG from this website. The app needs microphone access, whisper.cpp for local transcription, and either OpenRouter, another LLM provider, Ollama, or no cleanup backend. The MIT-licensed source is also public.</p>
+      <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">View source ↗</a></div>
+
+      <section class="content-card"><h2>Fast path: DMG install</h2><ol class="step-list"><li>Open <a href="download.html">the download page</a> and pick Apple Silicon or Intel.</li><li>Download the DMG from this website.</li><li>Open the DMG and drag OpenVoiceFlow into Applications.</li><li>Launch OpenVoiceFlow. First launch runs a one-time setup (~5 minutes: speech engine + model) with a progress dialog — grant microphone and accessibility permissions when prompted.</li><li>Look for the monochrome <strong>waveform menu-bar icon</strong> at the top-right; OpenVoiceFlow does not stay in the Dock.</li><li>Click the waveform and choose <strong>Open OpenVoiceFlow</strong> to confirm the app is ready.</li><li>Click in any text field, hold the <strong>Right Command (⌘)</strong> key, speak, then release it to paste the transcription.</li><li>Use the same menu to pause listening, change the dictation shortcut, open permission settings, or check for updates.</li></ol></section>
+
+      <section class="content-card"><h2>Terminal install from source</h2><code class="code-block">git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow &amp;&amp; bash install.sh</code><p>The <a href="https://github.com/shimoverse/openvoiceflow">public GitHub repository</a> is available to everyone. Use the DMG path for the signed app.</p></section>
+
+      <section class="content-card"><h2>Manual setup</h2><code class="code-block">brew install whisper-cpp
+git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow
+python3 -m venv ~/.openvoiceflow/venv
+~/.openvoiceflow/venv/bin/pip install -e ".[all]"
+openvoiceflow --backend openrouter --set-key openrouter YOUR_KEY_HERE
+openvoiceflow</code></section>
+
+      <section class="content-card"><h2>Troubleshooting</h2><ul class="check-list"><li>If macOS still blocks launch, delete any older unsigned copy and re-download the current signed, Apple-notarized v0.3.5 DMG from this website.</li><li>If the waveform changes to a warning symbol, open <strong>Advanced</strong> in the menu and use the direct Microphone or Accessibility settings links.</li><li>If transcription does not start, confirm microphone permission in macOS System Settings.</li><li>If paste fails, grant Accessibility permission for the app or terminal launching OpenVoiceFlow.</li><li>If cloud cleanup fails, verify your chosen provider key; OpenRouter uses <code>openrouter</code>, not a Gemini API key.</li><li>If you need a fully local flow, choose Ollama or <code>--backend none</code>.</li></ul></section>
+    </div></section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="download.html">Download</a>
+        <a href="how-it-works.html">How it works</a>
+        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
+        <a href="llms.txt">llms.txt</a>
+      </nav>
+    </div>
+  </footer>
+
   <script src="site.js"></script>
-</body></html>
+</body>
+</html>

--- a/docs/site.js
+++ b/docs/site.js
@@ -246,3 +246,242 @@
     });
   });
 })();
+
+/* ── Waveform identity ──────────────────────────────────────────────────
+   One brand waveform everywhere: the ring glyph (nav/footer), the hero
+   listen→transcribe→type demo, the "02 · SPEAK" card wave, and the
+   privacy-panel pipeline wave. Ported from the design spec; vanilla JS,
+   no dependencies. Honors prefers-reduced-motion (static frames, full
+   sentence shown immediately) and pauses when the tab is hidden. */
+(() => {
+  const canvases = Array.from(document.querySelectorAll('canvas[data-wf]'));
+  if (!canvases.length) return;
+
+  const typedNode = document.getElementById('typedDemo');
+  const chipNode = document.getElementById('heroChip');
+  const statusNode = document.getElementById('heroStatus');
+  const TYPED_TEXT = 'Ship the beta tonight — the release notes are already in the doc.';
+
+  const darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  function palette() {
+    const dark = darkQuery.matches;
+    return {
+      acc: dark ? '#E8974E' : '#B4661F',
+      dim: dark ? 'rgba(214,208,194,.5)' : 'rgba(58,52,40,.45)',
+      // The privacy panel is deliberately dark in both themes.
+      pline: '#E8974E',
+    };
+  }
+
+  const state = { loop: 'listen', amp: 0, tgt: 0, sylT: 0, last: 0 };
+  const hist = new Float32Array(150);
+  const timers = [];
+  let typeTimer = null;
+  let raf = 0;
+
+  function after(ms, fn) { timers.push(setTimeout(fn, ms)); }
+
+  function setLoop(loop) {
+    state.loop = loop;
+    if (chipNode) chipNode.classList.toggle('idle', loop !== 'listen');
+    if (statusNode) {
+      statusNode.textContent =
+        loop === 'listen' ? 'listening'
+        : loop === 'spool' ? 'transcribing — on device'
+        : 'pasted at the cursor';
+    }
+  }
+
+  function cycle() {
+    setLoop('listen');
+    if (typedNode) typedNode.textContent = '';
+    after(3000, () => {
+      setLoop('spool');
+      after(900, () => {
+        setLoop('type');
+        let i = 0;
+        typeTimer = setInterval(() => {
+          i += 2;
+          if (typedNode) typedNode.textContent = TYPED_TEXT.slice(0, i);
+          if (i >= TYPED_TEXT.length) {
+            clearInterval(typeTimer);
+            typeTimer = null;
+            after(2600, cycle);
+          }
+        }, 20);
+      });
+    });
+  }
+
+  function speechEnvelope(t) {
+    const gate = (Math.sin(t * 0.9) + Math.sin(t * 0.53 + 1.2)) > 0.9 ? 0.06 : 1;
+    let v = (Math.sin(t * 2.3) + Math.sin(t * 3.85 + 1.4) + Math.sin(t * 5.9 + 0.4)) / 3;
+    v = Math.max(0, v * 0.75 + 0.5);
+    return Math.min(1, v * gate);
+  }
+
+  function windowFn(u) { return Math.pow(Math.max(0, Math.sin(Math.PI * u)), 0.85); }
+
+  function drawRing(ctx, w, h, t, color) {
+    const cx = w / 2, cy = h / 2, R = Math.min(w, h) * 0.34, gap = 0.62, off = -1.0;
+    ctx.beginPath();
+    for (let a = off + gap / 2; a <= off + 2 * Math.PI - gap / 2; a += 0.045) {
+      const r = R * (1 + 0.10 * Math.sin(a * 5 - t * 0.7));
+      const x = cx + Math.cos(a) * r, y = cy + Math.sin(a) * r;
+      a <= off + gap / 2 + 0.05 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.lineWidth = 2.2;
+    ctx.lineCap = 'round';
+    ctx.strokeStyle = color;
+    ctx.stroke();
+  }
+
+  function drawWave(ctx, w, h, t, ampAt, color, glow) {
+    ctx.beginPath();
+    const mid = h / 2;
+    for (let x = 0; x <= w; x += 2) {
+      const u = x / w, a = ampAt(u);
+      const y = mid
+        + (a < 0.03 ? Math.sin(x * 0.045 - t * 1.7) * 1.15 : 0)
+        + a * h * 0.30 * (
+          Math.sin(x * 0.052 + t * 6.6) * 0.55 +
+          Math.sin(x * 0.117 - t * 9.4) * 0.26 +
+          Math.sin(x * 0.026 + t * 3.2) * 0.42
+        ) * windowFn(u);
+      x === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.lineWidth = 2;
+    ctx.lineCap = 'round';
+    ctx.strokeStyle = color;
+    if (glow) { ctx.shadowColor = color; ctx.shadowBlur = 7; }
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+  }
+
+  function drawSpool(ctx, w, h, t, color) {
+    const cx = w / 2, cy = h / 2, rot = t * 6.9;
+    ctx.beginPath();
+    for (let a = 0; a <= 4 * Math.PI; a += 0.12) {
+      const r = (2.5 + a * 0.95) * Math.min(1, h * 0.028);
+      const x = cx + Math.cos(a + rot) * r, y = cy + Math.sin(a + rot) * r * 0.92;
+      a === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.lineWidth = 2;
+    ctx.lineCap = 'round';
+    ctx.strokeStyle = color;
+    ctx.stroke();
+  }
+
+  function paint(now) {
+    const t = now / 1000;
+    const dt = Math.min(50, now - (state.last || now));
+    state.last = now;
+    const colors = palette();
+
+    if (state.loop === 'listen') {
+      if (now > state.sylT) {
+        state.sylT = now + 90 + Math.random() * 190;
+        const r = Math.random();
+        state.tgt = r < 0.18 ? 0.04 : 0.25 + Math.random() * 0.7;
+      }
+    } else {
+      state.tgt = 0;
+    }
+    state.amp += (state.tgt - state.amp) * (1 - Math.exp(-dt / 70));
+    hist.copyWithin(0, 1);
+    hist[hist.length - 1] = state.amp;
+
+    const d = Math.min(2, window.devicePixelRatio || 1);
+    for (const el of canvases) {
+      const w = el.clientWidth, h = el.clientHeight;
+      if (!w || !h) continue;
+      if (el.width !== (w * d | 0) || el.height !== (h * d | 0)) {
+        el.width = w * d | 0;
+        el.height = h * d | 0;
+      }
+      const ctx = el.getContext('2d');
+      ctx.setTransform(d, 0, 0, d, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+      const mode = el.dataset.wf;
+
+      if (mode === 'glyph') {
+        drawRing(ctx, w, h, t, colors.acc);
+      } else if (mode === 'hero') {
+        if (state.loop === 'listen') {
+          const n = hist.length;
+          const ampAt = u => hist[Math.min(n - 1, (u * (n - 1)) | 0)];
+          drawWave(ctx, w, h, t, ampAt, state.amp > 0.06 ? colors.acc : colors.dim, state.amp > 0.12);
+        } else if (state.loop === 'spool') {
+          drawSpool(ctx, w, h, t, colors.acc);
+        } else {
+          const mid = h / 2, cx = w / 2;
+          ctx.beginPath();
+          ctx.moveTo(cx - 8, mid);
+          ctx.lineTo(cx + 8, mid);
+          ctx.lineWidth = 2.4;
+          ctx.lineCap = 'round';
+          ctx.strokeStyle = colors.acc;
+          ctx.stroke();
+        }
+      } else if (mode === 'card') {
+        drawWave(ctx, w, h, t, u => speechEnvelope(t - (1 - u) * 1.25), colors.acc, true);
+      } else if (mode === 'pline') {
+        drawWave(ctx, w, h, t, u => speechEnvelope(t * 0.8 - (1 - u) * 1.4), colors.pline, true);
+      }
+    }
+  }
+
+  function tick(now) {
+    if (!document.hidden) paint(now);
+    raf = requestAnimationFrame(tick);
+  }
+
+  function staticFrame() {
+    // Reduce Motion: one calm, representative frame — no loops, no typing.
+    if (typedNode) typedNode.textContent = TYPED_TEXT;
+    setLoop('listen');
+    for (let i = 0; i < hist.length; i++) {
+      hist[i] = speechEnvelope(i / 18) * 0.6;
+    }
+    state.amp = 0.4;
+    state.loop = 'listen';
+    paint(1000);
+    if (statusNode) statusNode.textContent = 'listening';
+  }
+
+  if (motionQuery.matches) {
+    staticFrame();
+    darkQuery.addEventListener('change', staticFrame);
+    window.addEventListener('resize', staticFrame);
+  } else {
+    cycle();
+    raf = requestAnimationFrame(tick);
+    motionQuery.addEventListener('change', () => {
+      if (motionQuery.matches) {
+        cancelAnimationFrame(raf);
+        timers.forEach(clearTimeout);
+        if (typeTimer) clearInterval(typeTimer);
+        staticFrame();
+      }
+    });
+  }
+})();
+
+/* ── Checksum copy buttons (download page) ─────────────────────────── */
+(() => {
+  document.querySelectorAll('.copy-btn[data-copy]').forEach(button => {
+    button.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(button.dataset.copy);
+        const original = button.textContent;
+        button.textContent = 'copied';
+        setTimeout(() => { button.textContent = original; }, 1600);
+      } catch (error) {
+        // Clipboard API unavailable (http, older browser) — leave the
+        // checksum selectable in the adjacent code block.
+      }
+    });
+  });
+})();

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,1881 +1,888 @@
-/* ═══════════════════════════════════════════════════════════
-   OpenVoiceFlow — Landing Page CSS
-   Inspired by Linear.app + Raycast.com
-   ═══════════════════════════════════════════════════════════ */
+/* ==========================================================================
+   OpenVoiceFlow — design system
+   From the end-to-end redesign (Claude Design, Phase 5/6 "Website").
+   Warm-paper light theme / campfire-dark theme, system SF stack, one
+   waveform identity everywhere. Self-contained: no external fonts.
+   ========================================================================== */
 
-/* ─── Static growth pages ─────────────────────────────────── */
-.answer-card,
-.answer-block {
-  max-width: 760px;
-  color: var(--text-secondary);
-  background: rgba(255,255,255,0.04);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 18px 22px;
-  margin: -18px auto 32px;
-  line-height: 1.75;
-}
-.answer-card strong { color: var(--text-primary); }
-.page-hero { min-height: auto; padding: 140px 0 80px; }
-.page-link-row { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin: 0 0 44px; }
-.content-grid { width: 100%; display: grid; gap: 18px; margin-top: 12px; }
-.two-col { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
-.content-card { text-align: left; width: 100%; }
-.content-card h2 { font-size: 24px; margin: 8px 0 12px; letter-spacing: -0.02em; }
-.content-card h3 { font-size: 17px; margin: 20px 0 6px; color: var(--text-primary); }
-.content-card p, .content-card li { color: var(--text-secondary); }
-.wide-card { max-width: 900px; margin: 18px auto 0; padding: 28px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); }
-.code-block { display: block; width: 100%; overflow-x: auto; white-space: nowrap; background: rgba(0,0,0,0.35); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; margin: 14px 0; color: var(--teal); line-height: 1.8; }
-.check-list { list-style: none; display: grid; gap: 10px; padding: 0; }
-.check-list li { position: relative; padding-left: 26px; }
-.check-list li::before { content: "✓"; position: absolute; left: 0; color: var(--teal); font-weight: 700; }
-.step-list { list-style: decimal; padding-left: 24px; color: var(--text-secondary); }
-.step-list li { margin: 10px 0; }
-.content-pipeline { align-items: stretch; gap: 12px; margin: 10px auto 36px; }
-.content-pipeline .pipeline-step { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); min-width: 180px; flex: 1 1 180px; }
-.download-panel {
-  width: min(900px, 100%);
-  margin: 0 auto 24px;
-  padding: 26px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 24px;
-  text-align: left;
-  background: linear-gradient(135deg, rgba(124, 92, 252, 0.16), rgba(0, 212, 170, 0.07)), var(--surface);
-  border: 1px solid rgba(124, 92, 252, 0.36);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.28);
-}
-.download-panel h2 {
-  font-size: clamp(24px, 3vw, 34px);
-  margin: 6px 0 8px;
-  letter-spacing: -0.02em;
-}
-.download-panel p {
-  color: var(--text-secondary);
-  max-width: 620px;
-}
-.download-panel-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-width: min(300px, 100%);
-}
-.download-kicker,
-.download-build-label {
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--teal);
-  background: var(--teal-dim);
-  border: 1px solid rgba(0, 212, 170, 0.28);
-  border-radius: 999px;
-  padding: 4px 9px;
-}
-.download-meta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 16px;
-}
-.download-meta-row span {
-  color: var(--text-primary);
-  background: rgba(255,255,255,0.06);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 5px 10px;
-  font-size: 12px;
-}
-.download-builds {
-  width: min(980px, 100%);
-  margin: 18px auto 0;
-  text-align: left;
-}
-.download-builds-header {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 12px;
-}
-.download-builds-header h2 {
-  font-size: 22px;
-  letter-spacing: -0.02em;
-}
-.download-builds-header p {
-  color: var(--text-secondary);
-  font-size: 14px;
-}
-.download-build-list {
-  display: grid;
-  gap: 12px;
-}
-.download-build-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 20px;
-  padding: 22px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  transition: border-color var(--transition), box-shadow var(--transition);
-}
-.download-build-row.is-recommended {
-  border-color: rgba(0, 212, 170, 0.55);
-  box-shadow: 0 0 0 1px rgba(0, 212, 170, 0.12);
-}
-.download-build-row h3 {
-  font-size: 18px;
-  margin: 10px 0 12px;
-  letter-spacing: -0.01em;
-}
-.download-build-row .code-block {
-  margin-bottom: 0;
-  font-size: 12.5px;
-}
-.press-hero-card {
-  width: min(900px, 100%);
-  margin: 0 auto 24px;
-  padding: 28px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 28px;
-  text-align: left;
-  background: linear-gradient(135deg, rgba(0, 212, 170, 0.12), rgba(124, 92, 252, 0.14)), var(--surface);
-  border: 1px solid rgba(0, 212, 170, 0.28);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.28);
-}
-.press-hero-copy h2 {
-  font-size: clamp(25px, 3vw, 36px);
-  line-height: 1.15;
-  letter-spacing: -0.02em;
-  margin: 10px 0 12px;
-}
-.press-hero-copy p {
-  color: var(--text-secondary);
-  max-width: 650px;
-}
-.press-app-icon,
-.brand-asset-icon {
-  border-radius: 24px;
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.32);
-}
-.press-grid {
-  width: min(980px, 100%);
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
-  gap: 18px;
-  margin: 18px auto 0;
-}
-.press-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px;
-}
-.fact-list {
-  display: grid;
-  gap: 12px;
-}
-.fact-list div {
-  display: grid;
-  grid-template-columns: 130px minmax(0, 1fr);
-  gap: 16px;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-.fact-list div:last-child {
-  border-bottom: none;
-}
-.fact-list dt {
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.fact-list dd {
-  color: var(--text-secondary);
-}
-.press-link-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 12px;
-}
-.press-link-card {
-  display: block;
-  min-height: 118px;
-  padding: 18px;
-  background: rgba(255,255,255,0.035);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  transition: border-color var(--transition), transform var(--transition), background var(--transition);
-}
-.press-link-card:hover {
-  background: rgba(255,255,255,0.06);
-  border-color: var(--border-hover);
-  transform: translateY(-1px);
-}
-.press-link-card span {
-  display: block;
-  color: var(--teal);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin-bottom: 10px;
-}
-.press-link-card strong {
-  color: var(--text-primary);
-  font-size: 17px;
-  line-height: 1.35;
-}
-.brand-asset-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 22px;
-  align-items: center;
-}
-@media (max-width: 640px) {
-  .page-link-row .btn { width: 100%; }
-  .answer-card, .answer-block { margin-top: -8px; }
-  .btn { white-space: normal; }
-  .code-block { white-space: pre-wrap; overflow-wrap: anywhere; }
-  .wide-card { padding: 22px 18px; }
-  .feature-card { padding: 24px 18px; }
-  .download-panel,
-  .download-build-row {
-    grid-template-columns: 1fr;
-    padding: 22px 18px;
-  }
-  .download-panel-actions,
-  .download-panel-actions .btn,
-  .download-build-row .btn {
-    width: 100%;
-  }
-  .download-builds-header {
-    display: block;
-  }
-  .download-builds-header p {
-    margin-top: 4px;
-  }
-  .press-hero-card,
-  .press-grid,
-  .brand-asset-row {
-    grid-template-columns: 1fr;
-  }
-  .press-app-icon {
-    width: 120px;
-    height: 120px;
-  }
-  .fact-list div {
-    grid-template-columns: 1fr;
-    gap: 3px;
-  }
-}
-
-/* ─── CSS Variables ─────────────────────────────────────── */
+/* ─── Tokens ─────────────────────────────────────────────────────────── */
 :root {
-  --bg: #0a0a0f;
-  --bg-alt: #0d0d15;
-  --surface: #141420;
-  --surface-hover: #191928;
-  --border: #1e1e2e;
-  --border-hover: #2a2a3e;
-  --accent: #7c5cfc;
-  --accent-hover: #9070ff;
-  --accent-dim: rgba(124, 92, 252, 0.12);
-  --accent-glow: rgba(124, 92, 252, 0.25);
-  --teal: #00d4aa;
-  --teal-dim: rgba(0, 212, 170, 0.12);
-  --red: #ff4444;
-  --yellow: #f5a623;
-  --text-primary: #ffffff;
-  --text-secondary: #8888aa;
-  --text-muted: #55556a;
-  --radius: 12px;
-  --radius-lg: 20px;
-  --radius-xl: 28px;
-  --shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 8px 48px rgba(0, 0, 0, 0.6);
-  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --transition: 0.2s ease;
-  --transition-slow: 0.4s ease;
+  --bg: #F7F5F0;
+  --ink: #26221B;
+  --ink-2: #6E6759;
+  --hair: rgba(0, 0, 0, .10);
+  --card: #FFFFFF;
+  --fill: rgba(0, 0, 0, .04);
+  --acc: #B4661F;
+  --btn-bg: #B4661F;
+  --btn-ink: #FFFFFF;
+  --moss: #4E7A58;
+  --moss-b: rgba(78, 122, 88, .5);
+  --cap-bg: rgba(253, 252, 249, .9);
+  --nav-bg: rgba(247, 245, 240, .82);
+  --shadow-cap: 0 18px 40px rgba(38, 34, 27, .16);
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  --r-sm: 8px;
+  --r-md: 11px;
+  --r-lg: 14px;
+  --r-xl: 18px;
+
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  color-scheme: light;
 }
 
-/* ─── Reset & Base ───────────────────────────────────────── */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-html {
-  scroll-behavior: smooth;
-  font-size: 16px;
-  overflow-x: hidden;
-  -webkit-text-size-adjust: 100%;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #131210;
+    --ink: #EDE9E0;
+    --ink-2: #9C9585;
+    --hair: rgba(255, 255, 255, .10);
+    --card: #1D1B18;
+    --fill: rgba(255, 255, 255, .05);
+    --acc: #E8974E;
+    --btn-bg: #E8974E;
+    --btn-ink: #1A1508;
+    --moss: #7FAF8A;
+    --moss-b: rgba(127, 175, 138, .5);
+    --cap-bg: rgba(32, 30, 26, .9);
+    --nav-bg: rgba(19, 18, 16, .82);
+    --shadow-cap: 0 18px 40px rgba(0, 0, 0, .28);
+    color-scheme: dark;
+  }
 }
+
+/* ─── Base ───────────────────────────────────────────────────────────── */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
 
 body {
-  font-family: var(--font);
+  min-height: 100svh;
   background: var(--bg);
-  color: var(--text-primary);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 16px;
   line-height: 1.6;
-  overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
-img { max-width: 100%; display: block; }
-a { color: inherit; text-decoration: none; }
-ul { list-style: none; }
-button { border: none; background: none; cursor: pointer; font-family: var(--font); }
-code { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace; }
+p { text-wrap: pretty; }
+
+a { color: var(--acc); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+img, canvas { max-width: 100%; }
+
+::selection { background: var(--acc); color: var(--btn-ink); }
 
 .container {
-  max-width: 1100px;
+  max-width: 1020px;
   margin: 0 auto;
-  padding: 0 clamp(16px, 5vw, 24px);
+  padding-left: 32px;
+  padding-right: 32px;
 }
 
-.desktop-only { display: none; }
-@media (min-width: 768px) { .desktop-only { display: inline; } }
-
-/* ─── Animations ─────────────────────────────────────────── */
-@keyframes float {
-  0%, 100% { transform: translateY(0px); }
-  50%       { transform: translateY(-6px); }
+.mono-kicker {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--acc);
 }
 
-@keyframes pulse-glow {
-  0%, 100% { opacity: 0.6; }
-  50%       { opacity: 1; }
+/* ─── Buttons ────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 44px;
+  padding: 10px 20px;
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+  cursor: pointer;
+  text-align: center;
+  transition: transform .16s var(--ease-out), background .16s, border-color .16s, box-shadow .16s;
+}
+.btn { white-space: normal; }
+.btn:hover { text-decoration: none; transform: translateY(-1px); }
+.btn:active { transform: translateY(0); }
+.btn:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.btn-primary {
+  background: var(--btn-bg);
+  color: var(--btn-ink);
+  font-weight: 700;
+}
+.btn-primary:hover { box-shadow: 0 6px 18px rgba(180, 102, 31, .28); }
+
+.btn-outline {
+  border-color: var(--hair);
+  color: var(--ink);
+  background: transparent;
+}
+.btn-outline:hover { background: var(--fill); }
+
+.btn-lg { padding: 12px 24px; font-size: 15px; border-radius: var(--r-md); }
+
+.btn-unavailable {
+  background: var(--fill);
+  color: var(--ink-2);
+  cursor: not-allowed;
 }
 
-@keyframes shimmer {
-  0%   { background-position: -200% center; }
-  100% { background-position:  200% center; }
-}
-
-/* Fade-in (hero — JS triggers) */
-.fade-in {
-  opacity: 0;
-  transform: translateY(18px);
-  transition: opacity 0.55s ease, transform 0.55s ease;
-}
-.fade-in.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-.fade-in-delay-1 { transition-delay: 0.08s; }
-.fade-in-delay-2 { transition-delay: 0.18s; }
-.fade-in-delay-3 { transition-delay: 0.30s; }
-.fade-in-delay-4 { transition-delay: 0.42s; }
-.fade-in-delay-5 { transition-delay: 0.58s; }
-
-/* Reveal (scroll — IntersectionObserver) */
-.reveal {
-  opacity: 0;
-  transform: translateY(28px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
-}
-.reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-/* ─── NAV ────────────────────────────────────────────────── */
+/* ─── Nav ────────────────────────────────────────────────────────────── */
 .nav {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  padding: 16px 0;
-  transition: background var(--transition), border-color var(--transition), backdrop-filter var(--transition);
-}
-
-.nav.scrolled {
-  background: rgba(10, 10, 15, 0.85);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-bottom: 1px solid var(--border);
+  z-index: 50;
+  background: var(--nav-bg);
+  -webkit-backdrop-filter: saturate(160%) blur(14px);
+  backdrop-filter: saturate(160%) blur(14px);
+  border-bottom: 1px solid var(--hair);
 }
 
 .nav-inner {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 24px;
+  gap: 22px;
+  padding-top: 14px;
+  padding-bottom: 14px;
 }
 
 .nav-logo {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  text-decoration: none;
+  gap: 9px;
+  color: var(--ink);
 }
+.nav-logo:hover { text-decoration: none; }
 
-.nav-logo-emoji { font-size: 20px; line-height: 1; }
+.nav-glyph { width: 26px; height: 26px; display: block; }
+
 .nav-logo-text {
   font-size: 15px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .nav-links {
-  display: none;
+  display: flex;
   align-items: center;
-  gap: 4px;
-}
-
-@media (min-width: 768px) {
-  .nav-links {
-    display: flex;
-  }
+  gap: 22px;
+  list-style: none;
+  margin-left: auto;
 }
 
 .nav-links a {
-  font-size: 13.5px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  padding: 6px 10px;
-  border-radius: 8px;
-  transition: color var(--transition), background var(--transition);
+  font-size: 13px;
+  color: var(--ink-2);
 }
-.nav-links a:hover { color: var(--text-primary); background: rgba(255,255,255,0.06); }
+.nav-links a:hover { color: var(--ink); text-decoration: none; }
 
-/* Hamburger */
+.nav-links .btn { min-height: 36px; padding: 7px 14px; font-size: 13px; }
+.nav-links a.btn-primary { color: var(--btn-ink); }
+.nav-links a.btn-primary:hover { color: var(--btn-ink); }
+
+/* Hamburger (mobile) */
 .nav-hamburger {
-  display: flex;
+  display: none;
+  width: 44px;
+  min-height: 44px;
+  margin-left: auto;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 5px;
-  width: 44px;
-  min-height: 44px;
-  padding: 8px;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
   cursor: pointer;
-  position: relative;
-  z-index: 1;
 }
-@media (min-width: 768px) { .nav-hamburger { display: none; } }
-
 .nav-hamburger span {
   display: block;
-  width: 22px;
+  width: 20px;
   height: 2px;
-  background: var(--text-secondary);
-  border-radius: 2px;
-  pointer-events: none;
-  transition: transform 0.25s, opacity 0.25s;
+  border-radius: 1px;
+  background: var(--ink);
+  transition: transform .2s var(--ease-out), opacity .2s;
 }
 .nav-hamburger.active span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
 .nav-hamburger.active span:nth-child(2) { opacity: 0; }
 .nav-hamburger.active span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
 
-/* Mobile drawer */
 .nav-drawer {
   display: none;
   flex-direction: column;
-  gap: 2px;
-  padding: 12px 24px 20px;
-  border-top: 1px solid var(--border);
-  background: rgba(10, 10, 15, 0.97);
-  backdrop-filter: blur(20px);
+  gap: 4px;
+  padding: 8px 20px 18px;
+  border-bottom: 1px solid var(--hair);
+  background: var(--nav-bg);
+  -webkit-backdrop-filter: saturate(160%) blur(14px);
+  backdrop-filter: saturate(160%) blur(14px);
 }
-.nav-drawer.open { display: flex; }
 .nav-drawer a {
-  font-size: 15px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  padding: 10px 8px;
-  border-radius: 8px;
-  transition: color var(--transition), background var(--transition);
-}
-.nav-drawer a:hover { color: var(--text-primary); background: rgba(255,255,255,0.06); }
-.nav-drawer .btn { margin-top: 8px; text-align: center; justify-content: center; }
-
-/* ─── Buttons ────────────────────────────────────────────── */
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-family: var(--font);
-  font-weight: 600;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: all var(--transition);
-  text-decoration: none;
-  text-align: center;
-  white-space: nowrap;
-  border: 1px solid transparent;
-  line-height: 1.2;
-}
-
-.btn-sm  { font-size: 13px; padding: 6px 14px; }
-.btn-lg  { font-size: 15px; min-height: 44px; padding: 12px 24px; }
-.btn-xl  { font-size: 16px; min-height: 48px; padding: 14px 32px; border-radius: var(--radius-lg); }
-
-.btn-primary {
-  background: var(--accent);
-  color: #fff;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 0 var(--accent-glow);
-}
-.btn-primary:hover {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
-  box-shadow: 0 0 0 4px var(--accent-glow), 0 4px 20px rgba(124, 92, 252, 0.35);
-  transform: translateY(-1px);
-}
-.btn-primary:active { transform: translateY(0); }
-
-.btn-outline {
-  background: transparent;
-  color: var(--text-primary);
-  border-color: var(--border);
-}
-.btn-outline:hover {
-  background: rgba(255,255,255,0.06);
-  border-color: var(--border-hover);
-  transform: translateY(-1px);
-}
-
-.btn-ghost {
-  background: transparent;
-  color: var(--text-secondary);
-  border-color: transparent;
-}
-.btn-ghost:hover { color: var(--text-primary); background: rgba(255,255,255,0.06); }
-
-/* Non-Mac visitors: the recommended-download CTA becomes an inert notice. */
-.btn-unavailable {
-  background: rgba(255,255,255,0.05);
-  color: var(--text-secondary);
-  border-color: var(--border);
-  cursor: not-allowed;
-}
-.btn-unavailable:hover { transform: none; }
-
-/* ─── Section layout ─────────────────────────────────────── */
-.section { padding: 100px 0; }
-.section-alt { background: var(--bg-alt); }
-
-.section-header {
-  text-align: center;
-  margin-bottom: 64px;
-}
-
-.section-label {
-  display: inline-block;
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--accent);
-  margin-bottom: 12px;
-}
-
-.section-title {
-  font-size: clamp(28px, 5vw, 42px);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.15;
-  margin-bottom: 16px;
-  color: var(--text-primary);
-}
-
-.section-sub {
-  font-size: 17px;
-  color: var(--text-secondary);
-  max-width: 540px;
-  margin: 0 auto;
-  line-height: 1.7;
-}
-
-/* ─── HERO ───────────────────────────────────────────────── */
-.hero {
-  position: relative;
-  min-height: 100svh;
+  min-height: 44px;
   display: flex;
   align-items: center;
-  padding: 120px 0 80px;
-  overflow: hidden;
+  font-size: 15px;
+  color: var(--ink);
 }
+.nav-drawer a:hover { text-decoration: none; color: var(--acc); }
+.nav-drawer .btn { justify-content: center; margin-top: 8px; }
+.nav-drawer a.btn-primary,
+.nav-drawer a.btn-primary:hover { color: var(--btn-ink); }
 
-.hero-glow {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-  max-width: 800px;
-  height: 500px;
-  background: radial-gradient(ellipse 60% 50% at 50% 0%,
-    rgba(124, 92, 252, 0.22) 0%,
-    rgba(82, 120, 252, 0.10) 50%,
-    transparent 100%);
-  pointer-events: none;
-  animation: pulse-glow 6s ease-in-out infinite;
-}
-
+/* ─── Hero ───────────────────────────────────────────────────────────── */
 .hero-inner {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  min-width: 0;
-  text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
+  gap: 18px;
+  padding-top: 64px;
+  padding-bottom: 56px;
+}
+
+.page-hero .hero-inner {
+  align-items: flex-start;
+  text-align: left;
+  padding-top: 44px;
+  padding-bottom: 24px;
+  gap: 14px;
 }
 
 .hero-badge {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 12.5px;
-  font-weight: 500;
-  color: var(--accent);
-  background: var(--accent-dim);
-  border: 1px solid rgba(124, 92, 252, 0.25);
-  padding: 6px 14px;
-  border-radius: 100px;
-  margin-bottom: 28px;
-  letter-spacing: 0.02em;
+  gap: 7px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--moss-b);
+  color: var(--moss);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: .02em;
 }
-
 .badge-dot {
   width: 6px;
   height: 6px;
-  background: var(--teal);
-  border-radius: 50%;
-  animation: pulse-glow 2s ease-in-out infinite;
-}
-
-.hero-emoji {
-  display: block;
-  font-size: 56px;
-  margin-bottom: 8px;
-  animation: float 4s ease-in-out infinite;
+  border-radius: 3px;
+  background: var(--moss);
 }
 
 .hero-title {
-  font-size: clamp(42px, 8vw, 80px);
+  font-size: clamp(34px, 6vw, 56px);
+  line-height: 1.04;
   font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.05;
-  margin-bottom: 20px;
-  background: linear-gradient(135deg, #ffffff 0%, rgba(255,255,255,0.75) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  letter-spacing: -0.028em;
+  max-width: 760px;
 }
 
-.hero-tagline {
-  font-size: clamp(20px, 3.5vw, 28px);
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-  margin-bottom: 16px;
-}
+.page-hero .hero-title { font-size: clamp(28px, 4.6vw, 40px); }
 
 .hero-sub {
-  font-size: clamp(15px, 2vw, 18px);
-  color: var(--text-secondary);
-  line-height: 1.7;
-  max-width: 520px;
-  margin-bottom: 40px;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-2);
+  max-width: 560px;
 }
 
-.accent { color: var(--teal); font-weight: 600; }
+.page-hero .hero-sub { max-width: 640px; font-size: 15px; }
 
-.hero-ctas {
+.hero-cta-row {
   display: flex;
   gap: 12px;
+  align-items: center;
   flex-wrap: wrap;
   justify-content: center;
-  margin-bottom: 24px;
 }
 
-.hero-meta {
+.page-link-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 6px 0 10px;
+}
+
+.hero-trust {
+  font-size: 11.5px;
+  color: var(--ink-2);
+}
+
+/* Hero live demo: typed line + capsule waveform */
+.hero-demo {
+  width: 640px;
+  max-width: 100%;
+  margin-top: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.typed-box {
+  border-radius: 12px;
+  background: var(--card);
+  border: 1px solid var(--hair);
+  padding: 16px 18px;
+  text-align: left;
+  font-size: 14.5px;
+  line-height: 1.6;
+  min-height: 54px;
+}
+
+.caret {
+  display: inline-block;
+  width: 2px;
+  height: 16px;
+  vertical-align: -2px;
+  background: var(--acc);
+  animation: ovfCaret 1.05s step-end infinite;
+}
+@keyframes ovfCaret { 0%, 55% { opacity: 1; } 56%, 100% { opacity: 0; } }
+
+.hero-cap-row { display: flex; justify-content: center; }
+
+.hero-cap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 44px;
+  border-radius: 22px;
+  padding: 0 14px;
+  min-width: min(300px, 100%);
+  background: var(--cap-bg);
+  border: 1px solid var(--hair);
+  box-shadow: var(--shadow-cap);
+}
+
+.hero-chip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 23px;
+  padding: 0 8px;
+  border-radius: 6px;
+  background: var(--fill);
+  color: var(--ink-2);
+  font-size: 12.5px;
+  font-weight: 600;
+  transition: opacity .3s;
+}
+.hero-chip small { font-size: 8.5px; font-weight: 600; opacity: .6; letter-spacing: .04em; }
+.hero-chip.idle { opacity: .35; }
+
+.hero-cap canvas { flex: 1; height: 32px; min-width: 0; }
+
+.hero-status {
+  font-size: 11.5px;
+  color: var(--ink-2);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Sections ───────────────────────────────────────────────────────── */
+.section { padding-bottom: 56px; }
+
+.section-title {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+}
+
+.section-sub {
+  font-size: 13.5px;
+  color: var(--ink-2);
+  margin-bottom: 18px;
+}
+
+.section-title + .card-grid,
+.section-title + .step-grid { margin-top: 18px; }
+
+/* Cards */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
+}
+
+.card {
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  padding: 22px;
+  background: var(--card);
+}
+
+.card .mono-kicker { display: block; margin-bottom: 10px; }
+
+.card-title { font-size: 13.5px; font-weight: 600; margin-bottom: 4px; }
+
+.card-body { font-size: 13px; line-height: 1.6; color: var(--ink-2); }
+
+.card canvas { width: 100%; height: 34px; margin-bottom: 10px; display: block; }
+
+.key-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border-radius: var(--r-sm);
+  background: var(--fill);
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+.key-chip small { font-size: 10px; opacity: .6; }
+
+.card-lede { font-size: 14px; line-height: 1.5; margin-bottom: 10px; }
+
+.caret-sm {
+  display: inline-block;
+  width: 2px;
+  height: 14px;
+  vertical-align: -2px;
+  background: var(--acc);
+  margin-left: 2px;
+}
+
+/* Numbered install steps */
+.step-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
+}
+
+.step-card {
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  padding: 20px;
+  background: var(--card);
+}
+
+.step-num {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--acc);
+  margin-bottom: 8px;
+}
+
+.step-card h3 { font-size: 13.5px; font-weight: 600; margin-bottom: 4px; }
+.step-card p { font-size: 12.5px; line-height: 1.6; color: var(--ink-2); }
+
+/* ─── Privacy panel (deliberately dark in both themes) ───────────────── */
+.privacy-panel {
+  border-radius: var(--r-xl);
+  background: linear-gradient(165deg, #26241F, #141311);
+  border: 1px solid rgba(255, 255, 255, .10);
+  padding: 44px 40px;
+  color: #EAE6DD;
+}
+
+.privacy-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 36px;
+  align-items: center;
+}
+
+.privacy-copy { display: flex; flex-direction: column; gap: 12px; }
+
+.privacy-title {
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.privacy-body { font-size: 13.5px; line-height: 1.75; color: #96907F; }
+.privacy-body b { color: #EAE6DD; }
+.privacy-note { font-size: 12px; color: #96907F; }
+.privacy-note a { color: #E8974E; }
+
+.privacy-box {
+  border: 1.5px solid rgba(232, 151, 78, .5);
+  border-radius: var(--r-lg);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.privacy-box-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: .08em;
+  color: #E8974E;
+}
+
+.pipe-row {
   display: flex;
   align-items: center;
   gap: 8px;
   font-size: 12.5px;
-  color: var(--text-muted);
   flex-wrap: wrap;
-  justify-content: center;
-  margin-bottom: 56px;
 }
+.pipe-chip {
+  padding: 5px 10px;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, .07);
+}
+.pipe-chip.dest {
+  background: rgba(232, 151, 78, .15);
+  color: #E8974E;
+}
+.pipe-arrow { color: #96907F; }
 
-.meta-sep { color: var(--border-hover); }
+.privacy-box canvas { width: 100%; height: 30px; display: block; }
 
-/* Terminal card */
-.hero-terminal {
-  width: 100%;
-  max-width: 640px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+.privacy-box-note { font-size: 11px; color: #96907F; }
+
+/* ─── Compare table ──────────────────────────────────────────────────── */
+.compare-table {
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
   overflow: hidden;
-  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(124,92,252,0.1) inset;
+  background: var(--card);
 }
 
-.terminal-titlebar {
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 1fr;
+  font-size: 13px;
+}
+
+.compare-grid > div {
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--hair);
+}
+.compare-grid > div:nth-last-child(-n+3) { border-bottom: none; }
+
+.compare-head { font-weight: 700; padding-top: 12px; padding-bottom: 12px; }
+.compare-head-dim { color: var(--ink-2); font-weight: 600; padding-top: 12px; padding-bottom: 12px; }
+.compare-label { color: var(--ink-2); }
+.compare-us { font-weight: 600; }
+.compare-us-strong { font-weight: 700; }
+.compare-yes { color: var(--moss); font-weight: 700; }
+.compare-them { color: var(--ink-2); }
+
+.compare-footnote { font-size: 10.5px; color: var(--ink-2); margin-top: 8px; }
+
+/* ─── FAQ ────────────────────────────────────────────────────────────── */
+.faq { max-width: 720px; }
+
+.faq details {
+  border-top: 1px solid var(--hair);
+  padding: 14px 4px;
+}
+.faq details:last-of-type { border-bottom: 1px solid var(--hair); }
+
+.faq summary {
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  background: rgba(255,255,255,0.03);
-  border-bottom: 1px solid var(--border);
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 24px;
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after {
+  content: "+";
+  color: var(--ink-2);
+  font-weight: 400;
+  font-size: 17px;
+  transition: transform .18s var(--ease-out);
+}
+.faq details[open] summary::after { transform: rotate(45deg); }
+
+.faq p {
+  margin-top: 10px;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--ink-2);
 }
 
-.dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-}
-.dot-red    { background: #ff5f57; }
-.dot-yellow { background: #febc2e; }
-.dot-green  { background: #28c840; }
-
-.terminal-title {
-  margin-left: auto;
-  margin-right: auto;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-muted);
-  letter-spacing: 0.02em;
+/* ─── Download page ──────────────────────────────────────────────────── */
+.download-panel {
+  width: 100%;
+  border: 1px solid var(--hair);
+  border-radius: var(--r-xl);
+  background: var(--card);
+  padding: 26px;
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin: 10px 0 6px;
 }
 
-.terminal-body {
-  padding: 24px;
+.download-panel-copy { display: flex; flex-direction: column; gap: 6px; max-width: 480px; }
+.download-panel-copy h2 { font-size: 20px; font-weight: 700; letter-spacing: -0.015em; }
+.download-panel-copy p { font-size: 13px; color: var(--ink-2); }
+
+.download-kicker {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--acc);
+}
+
+.download-meta-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+  color: var(--ink-2);
+}
+.download-meta-row span:first-child {
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--hair);
+  font-weight: 600;
+}
+
+.download-panel-actions {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
+  min-width: 240px;
 }
 
-.terminal-line {
+.download-builds { width: 100%; margin-top: 22px; }
+.download-builds-header h2 { font-size: 20px; font-weight: 700; letter-spacing: -0.015em; }
+.download-builds-header p { font-size: 13px; color: var(--ink-2); margin: 4px 0 14px; }
+
+.download-build-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.download-build-row {
+  position: relative;
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  padding: 22px;
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+}
+.download-build-row.is-recommended { border: 1.5px solid var(--acc); }
+
+.download-build-flag {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: none;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--acc);
+  border: 1px solid var(--acc);
+  border-radius: 5px;
+  padding: 2px 7px;
+  letter-spacing: .04em;
+}
+.download-build-row.is-recommended .download-build-flag { display: inline-block; }
+
+.download-build-label {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 2px;
+  display: block;
+  color: var(--ink);
+}
+
+.download-build-row h3 {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--ink-2);
+  margin-bottom: 14px;
+}
+
+.download-build-row .btn { align-self: flex-start; font-family: var(--font-mono); font-size: 12.5px; }
+
+.checksum-line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.checksum-line .code-block { flex: 1; min-width: 0; margin: 0; font-size: 10.5px; }
+
+.copy-btn {
+  border: none;
+  background: none;
+  color: var(--acc);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 5px;
+}
+.copy-btn:hover { background: var(--fill); }
+
+/* ─── Content cards (guides, notes) ──────────────────────────────────── */
+.content-card {
+  width: 100%;
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  padding: 22px;
+  background: var(--card);
+  margin-top: 16px;
+}
+
+.content-card h2 { font-size: 17px; font-weight: 700; letter-spacing: -0.015em; margin-bottom: 8px; }
+.content-card h2:not(:first-child) { margin-top: 18px; }
+.content-card h3 { font-size: 14px; font-weight: 600; margin: 14px 0 4px; }
+.content-card p { font-size: 13.5px; color: var(--ink-2); }
+.content-card p + p { margin-top: 8px; }
+
+.code-block {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  background: var(--fill);
+  border: 1px solid var(--hair);
+  border-radius: var(--r-sm);
+  padding: 12px 14px;
+  margin: 10px 0;
+  color: var(--ink);
+}
+.code-block { white-space: pre-wrap; overflow-wrap: anywhere; }
+
+.step-list, .check-list {
+  margin: 8px 0 0 0;
+  padding-left: 22px;
   font-size: 13.5px;
-  line-height: 1.5;
+  color: var(--ink-2);
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.step-list li::marker { color: var(--acc); font-weight: 700; }
+.check-list { list-style: none; padding-left: 2px; }
+.check-list li { padding-left: 22px; position: relative; }
+.check-list li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: var(--moss);
+  font-weight: 700;
 }
 
-.terminal-arrow {
-  font-size: 18px;
-  color: var(--border-hover);
-  padding: 2px 0 2px 20px;
-}
-
-.t-dim    { opacity: 0.5; }
-.t-muted  { color: var(--text-muted); }
-.t-text   { color: var(--text-secondary); font-family: 'SF Mono', Consolas, monospace; font-size: 12.5px; }
-.t-accent { color: var(--teal); font-family: 'SF Mono', Consolas, monospace; font-size: 12.5px; font-weight: 600; }
-
-@media (max-width: 480px) {
-  .terminal-body { padding: 16px; gap: 4px; }
-  .terminal-line { font-size: 12px; }
-  .t-text, .t-accent { font-size: 10.5px; word-break: break-word; white-space: normal; }
-  .terminal-arrow { font-size: 14px; padding: 1px 0 1px 12px; }
-  .hero-terminal { border-radius: var(--radius); }
-}
-
-/* ─── HOW IT WORKS ───────────────────────────────────────── */
+/* Pipeline (how-it-works) */
 .pipeline {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  margin-top: 16px;
 }
 
 .pipeline-step {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 24px;
-  min-width: 160px;
-  max-width: 180px;
-  flex: 1;
-  transition: border-color var(--transition), box-shadow var(--transition);
-}
-
-.pipeline-step:hover {
-  border-color: var(--border-hover);
-  box-shadow: 0 0 0 1px var(--accent-dim), 0 8px 32px rgba(0,0,0,0.3);
-}
-
-.pipeline-icon {
-  font-size: 36px;
-  margin-bottom: 12px;
-  animation: float 4s ease-in-out infinite;
-}
-.pipeline-step:nth-child(1) .pipeline-icon { animation-delay: 0s; }
-.pipeline-step:nth-child(3) .pipeline-icon { animation-delay: 1s; }
-.pipeline-step:nth-child(5) .pipeline-icon { animation-delay: 2s; }
-.pipeline-step:nth-child(7) .pipeline-icon { animation-delay: 3s; }
-
-.pipeline-step-label {
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--accent);
-  margin-bottom: 6px;
-}
-
-.pipeline-step-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 4px;
-  letter-spacing: -0.01em;
-}
-
-.pipeline-step-desc {
-  font-size: 12.5px;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.pipeline-connector {
-  color: var(--text-muted);
-  padding: 0 8px;
-  flex-shrink: 0;
-}
-
-@media (max-width: 767px) {
-  .pipeline {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0;
-  }
-  .pipeline-step {
-    max-width: 100%;
-    flex-direction: row;
-    text-align: left;
-    gap: 16px;
-  }
-  .pipeline-icon { margin-bottom: 0; font-size: 28px; }
-  .pipeline-connector {
-    display: flex;
-    justify-content: center;
-    transform: rotate(90deg);
-    padding: 8px 0;
-  }
-}
-
-/* ─── FEATURES GRID ──────────────────────────────────────── */
-.features-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-}
-
-@media (min-width: 768px) {
-  .features-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.feature-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 24px;
-  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
-  position: relative;
-  overflow: hidden;
-  min-width: 0;
-}
-
-.feature-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 0% 0%, var(--accent-dim) 0%, transparent 60%);
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
-.feature-card:hover {
-  border-color: rgba(124, 92, 252, 0.35);
-  box-shadow: 0 0 0 1px rgba(124, 92, 252, 0.08), 0 8px 32px rgba(0,0,0,0.4);
-  transform: translateY(-2px);
-}
-
-.feature-card:hover::before { opacity: 1; }
-
-.feature-icon {
-  font-size: 28px;
-  margin-bottom: 14px;
-  display: block;
-}
-
-.feature-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 8px;
-  letter-spacing: -0.01em;
-}
-
-.feature-desc {
-  font-size: 13.5px;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-/* ─── COMPARISON TABLE ───────────────────────────────────── */
-.table-wrap {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-}
-
-.compare-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 14px;
-  min-width: 600px;
-}
-
-.compare-table thead tr {
-  background: var(--surface);
-}
-
-.compare-table th {
-  padding: 18px 16px;
-  text-align: center;
-  font-weight: 600;
-  font-size: 13px;
-  border-bottom: 1px solid var(--border);
-}
-
-.compare-table th.col-feature {
-  text-align: left;
-  color: var(--text-muted);
-  font-weight: 500;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.col-ovf { background: rgba(124, 92, 252, 0.07) !important; }
-
-.th-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-
-.th-emoji { font-size: 20px; }
-.th-name { font-size: 14px; font-weight: 600; color: var(--text-primary); }
-.th-badge {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--teal);
-  background: var(--teal-dim);
-  padding: 2px 8px;
-  border-radius: 100px;
-  border: 1px solid rgba(0, 212, 170, 0.25);
-}
-.th-price {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-weight: 400;
-}
-
-.compare-table tbody tr {
-  border-bottom: 1px solid var(--border);
-  transition: background var(--transition);
-}
-.compare-table tbody tr:last-child { border-bottom: none; }
-.compare-table tbody tr:hover { background: rgba(255,255,255,0.02); }
-
-.compare-table td {
-  padding: 14px 16px;
-  text-align: center;
-  color: var(--text-secondary);
-  font-size: 13.5px;
-}
-.compare-table td.col-feature {
-  text-align: left;
-  font-weight: 500;
-  color: var(--text-primary);
-  font-size: 14px;
-}
-
-.highlight-cell {
-  background: rgba(124, 92, 252, 0.07);
-  font-weight: 600;
-}
-
-.check {
-  color: var(--teal);
-  font-weight: 700;
-  font-size: 15px;
-}
-.cross {
-  color: var(--text-muted);
-  font-size: 14px;
-}
-.partial {
-  color: var(--yellow);
-  font-weight: 700;
-  font-size: 15px;
-}
-
-.green { color: var(--teal); }
-
-/* ─── BACKENDS ───────────────────────────────────────────── */
-.backends-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-  margin-bottom: 32px;
-}
-
-@media (min-width: 768px) {
-  .backends-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.backend-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 24px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  position: relative;
-  min-width: 0;
-  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
-}
-
-.backend-card:hover {
-  border-color: var(--border-hover);
-  box-shadow: 0 0 0 1px rgba(124,92,252,0.1), 0 8px 32px rgba(0,0,0,0.35);
-  transform: translateY(-2px);
-}
-
-.backend-recommended {
-  border-color: rgba(124, 92, 252, 0.35);
-  background: linear-gradient(135deg, var(--surface) 0%, rgba(124, 92, 252, 0.06) 100%);
-}
-
-.backend-local {
-  border-color: rgba(0, 212, 170, 0.25);
-  background: linear-gradient(135deg, var(--surface) 0%, rgba(0, 212, 170, 0.05) 100%);
-}
-
-.backend-badge {
-  position: absolute;
-  top: -10px;
-  left: 16px;
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--accent);
-  background: var(--bg-alt);
-  padding: 3px 10px;
-  border-radius: 100px;
-  border: 1px solid rgba(124, 92, 252, 0.35);
-}
-
-.backend-badge-green {
-  color: var(--teal);
-  border-color: rgba(0, 212, 170, 0.35);
-}
-
-.backend-icon { font-size: 28px; }
-.backend-name {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.01em;
-}
-.backend-cost {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-.text-green { color: var(--teal) !important; }
-
-.backend-privacy {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 3px 8px;
-  border-radius: 100px;
-  width: fit-content;
-}
-.privacy-mid {
-  color: var(--yellow);
-  background: rgba(245, 166, 35, 0.1);
-  border: 1px solid rgba(245, 166, 35, 0.2);
-}
-.privacy-local {
-  color: var(--teal);
-  background: var(--teal-dim);
-  border: 1px solid rgba(0, 212, 170, 0.2);
-}
-
-.backend-desc {
-  font-size: 12.5px;
-  color: var(--text-muted);
-  line-height: 1.6;
-}
-
-.backend-cmd {
-  font-size: 11px;
-  color: var(--text-muted);
-  background: rgba(255,255,255,0.04);
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  display: block;
-  margin-top: 4px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.backends-note {
-  display: flex;
+  gap: 14px;
   align-items: flex-start;
-  gap: 12px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 16px 20px;
-  font-size: 13.5px;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-.note-icon { font-size: 18px; flex-shrink: 0; margin-top: 2px; }
-.backends-note strong { color: var(--text-primary); }
-.backends-note em { color: var(--teal); font-style: normal; font-weight: 600; }
-
-/* ─── COMMUNITY / SOCIAL PROOF ───────────────────────────── */
-.community-wrap {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 56px;
-  align-items: center;
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  background: var(--card);
+  padding: 16px 18px;
 }
 
-@media (min-width: 900px) {
-  .community-wrap {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-.community-text .section-label { display: block; margin-bottom: 12px; }
-.community-text .section-title { text-align: left; margin-bottom: 16px; }
-.community-text .section-sub { text-align: left; margin: 0 0 16px; max-width: none; }
-
-.community-cta-text {
-  font-size: 16px;
-  font-weight: 500;
-  color: var(--text-primary);
-  margin-bottom: 24px;
-  line-height: 1.5;
-}
-
-.community-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 28px;
-}
-.community-badges img { height: 26px; }
-
-.community-actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.community-stats {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.stat-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 24px;
-  text-align: center;
-  transition: border-color var(--transition), transform var(--transition);
-}
-
-.stat-card:hover {
-  border-color: var(--border-hover);
-  transform: translateY(-2px);
-}
-
-.stat-card-accent {
-  border-color: rgba(124, 92, 252, 0.3);
-  background: linear-gradient(135deg, var(--surface) 0%, rgba(124, 92, 252, 0.08) 100%);
-}
-
-.stat-value {
-  font-size: 40px;
+.pipeline-num {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
   font-weight: 700;
-  letter-spacing: -0.04em;
-  color: var(--text-primary);
-  background: linear-gradient(135deg, #fff 0%, var(--accent) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  line-height: 1.1;
-  margin-bottom: 8px;
+  color: var(--acc);
+  letter-spacing: .06em;
+  padding-top: 2px;
+  white-space: nowrap;
 }
 
-.stat-card-accent .stat-value {
-  background: linear-gradient(135deg, var(--teal) 0%, #7c5cfc 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
+.pipeline-step-title { font-size: 14px; font-weight: 600; }
+.pipeline-step-desc { font-size: 12.5px; color: var(--ink-2); margin-top: 2px; }
 
-.stat-label {
-  font-size: 12.5px;
-  color: var(--text-muted);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-}
-
-/* ─── FINAL CTA ──────────────────────────────────────────── */
-.cta-section {
-  background: var(--bg);
-  position: relative;
-  overflow: hidden;
-}
-
-.cta-wrap {
-  position: relative;
-  text-align: center;
-  padding: 80px 24px;
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--border);
-  background: var(--surface);
-  overflow: hidden;
-}
-
-.cta-glow {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 100%;
-  max-width: 600px;
-  height: 300px;
-  background: radial-gradient(ellipse 50% 60% at 50% 50%,
-    rgba(124, 92, 252, 0.18) 0%,
-    transparent 70%);
-  pointer-events: none;
-}
-
-.cta-title {
-  font-size: clamp(28px, 5vw, 44px);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.15;
-  margin-bottom: 16px;
-  position: relative;
-}
-
-.cta-sub {
-  font-size: 17px;
-  color: var(--text-secondary);
-  max-width: 480px;
-  margin: 0 auto 36px;
-  line-height: 1.6;
-  position: relative;
-}
-
-.cta-buttons {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  position: relative;
-  margin-bottom: 20px;
-}
-
-.cta-footnote {
-  font-size: 12px;
-  color: var(--text-muted);
-  position: relative;
-}
-
-/* ─── FOOTER ─────────────────────────────────────────────── */
+/* ─── Footer ─────────────────────────────────────────────────────────── */
 .footer {
-  border-top: 1px solid var(--border);
-  padding: 40px 0;
-  background: var(--bg);
+  border-top: 1px solid var(--hair);
+  margin-top: 20px;
 }
 
 .footer-inner {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 24px;
-  text-align: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding-top: 28px;
+  padding-bottom: 44px;
 }
 
-@media (min-width: 768px) {
-  .footer-inner {
-    flex-direction: row;
-    justify-content: space-between;
-    text-align: left;
-  }
-}
+.footer-glyph { width: 20px; height: 20px; display: block; }
 
-.footer-brand {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.footer-tagline {
-  font-size: 13px;
-  color: var(--text-muted);
-}
+.footer-copy { font-size: 12px; color: var(--ink-2); }
 
 .footer-links {
   display: flex;
+  gap: 16px;
   flex-wrap: wrap;
-  gap: 4px;
-  justify-content: center;
+  margin-left: auto;
+}
+.footer-links a { font-size: 12px; color: var(--ink-2); }
+.footer-links a:hover { color: var(--ink); text-decoration: none; }
+
+/* ─── Answer block (SEO positioning paragraph) ───────────────────────── */
+.answer-block { max-width: 640px; }
+
+/* ─── Motion safety ──────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
-.footer-links a {
-  font-size: 13.5px;
-  color: var(--text-secondary);
-  padding: 6px 10px;
-  border-radius: 8px;
-  transition: color var(--transition), background var(--transition);
-}
-.footer-links a:hover {
-  color: var(--text-primary);
-  background: rgba(255,255,255,0.06);
-}
-
-.footer-copy {
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-/* ─── Scrollbar ──────────────────────────────────────────── */
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: var(--bg); }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--border-hover); }
-
-/* ─── Selection ──────────────────────────────────────────── */
-::selection { background: rgba(124, 92, 252, 0.3); color: #fff; }
-
-/* ─── Focus visible ──────────────────────────────────────── */
-:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
-
-/* ─── Mobile adjustments ─────────────────────────────────── */
-@media (max-width: 480px) {
-  .section { padding: 72px 0; }
-  .section-header { margin-bottom: 44px; }
-  .hero { padding: 100px 0 60px; }
-  .hero-ctas { flex-direction: column; width: 100%; }
-  .hero-ctas .btn { width: 100%; justify-content: center; }
-  .community-stats { grid-template-columns: 1fr 1fr; }
-  .backend-cmd { font-size: 10px; }
-  .features-grid { grid-template-columns: 1fr; }
-}
-
-@media (max-width: 767px) {
-  .backends-grid { grid-template-columns: 1fr; }
-  .community-actions { flex-direction: column; }
-  .community-actions .btn { width: 100%; justify-content: center; }
-}
-
-/* ─── Mobile comparison table ────────────────────────────── */
-.table-scroll-hint {
-  display: none;
-  text-align: center;
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-bottom: 10px;
-  gap: 6px;
-  align-items: center;
-  justify-content: center;
+/* ─── Responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .privacy-grid { grid-template-columns: 1fr; gap: 24px; }
+  .privacy-panel { padding: 30px 24px; }
+  .compare-grid { font-size: 12px; }
+  .compare-grid > div { padding: 10px 12px; }
 }
 
 @media (max-width: 640px) {
-  .table-scroll-hint { display: flex; }
-  .compare-table {
-    width: 100%;
-    min-width: 0;
-    table-layout: fixed;
-    font-size: 12px;
-  }
-  .compare-table th { padding: 12px 6px; font-size: 10.5px; overflow-wrap: anywhere; }
-  .compare-table td { padding: 10px 6px; font-size: 11.5px; overflow-wrap: anywhere; }
-  .compare-table td.col-feature { font-size: 11.5px; }
-  .th-emoji { font-size: 16px; }
-  .th-name { font-size: 11px; }
-  .th-badge { font-size: 8.5px; padding: 2px 5px; }
-  .th-price { font-size: 9.5px; }
-  .table-wrap {
-    position: relative;
-    max-width: 100%;
-    border-radius: var(--radius);
-  }
-  .table-wrap::after {
-    content: none;
-  }
-}
-
-/* ═══════════════════════════════════════════════════════════
-   NEW SECTIONS — Animated Terminal, Stats Bar, Install,
-   FAQ accordion
-   ═══════════════════════════════════════════════════════════ */
-
-/* ─── Animated Terminal cursor ───────────────────────────── */
-@keyframes blink-cursor {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0; }
-}
-
-.term-cursor {
-  display: inline-block;
-  color: var(--teal);
-  font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-  font-size: 13px;
-  line-height: 1;
-  margin-left: 1px;
-  animation: blink-cursor 0.9s step-end infinite;
-  vertical-align: middle;
-}
-
-/* Arrow fade-in animation */
-@keyframes arrow-appear {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-.term-arrow-hidden {
-  opacity: 0;
-}
-
-.term-arrow-visible {
-  animation: arrow-appear 0.25s ease forwards;
-}
-
-/* ─── PERFORMANCE STATS BAR ──────────────────────────────── */
-.stats-section {
-  background: var(--bg);
-  padding: 56px 0;
-}
-
-.stats-bar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: 40px 32px;
-  flex-wrap: wrap;
-}
-
-.stats-item {
-  flex: 1;
-  min-width: 120px;
-  text-align: center;
-  padding: 12px 24px;
-}
-
-.stats-divider {
-  width: 1px;
-  height: 56px;
-  background: var(--border);
-  flex-shrink: 0;
-}
-
-.stats-number {
-  font-size: clamp(32px, 5vw, 48px);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.1;
-  margin-bottom: 8px;
-}
-
-.gradient-text {
-  background: linear-gradient(135deg, #ffffff 0%, var(--accent) 60%, var(--teal) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.stats-label {
-  font-size: 12.5px;
-  color: var(--text-secondary);
-  font-weight: 500;
-  letter-spacing: 0.01em;
-}
-
-@media (max-width: 600px) {
-  .stats-bar {
-    padding: 28px 16px;
-    gap: 0;
-  }
-  .stats-divider { display: none; }
-  .stats-item {
-    flex: 0 0 50%;
-    padding: 16px 12px;
-    border-bottom: 1px solid var(--border);
-  }
-  .stats-item:nth-child(1),
-  .stats-item:nth-child(3) {
-    border-right: 1px solid var(--border);
-  }
-  .stats-item:nth-last-child(1),
-  .stats-item:nth-last-child(2) {
-    border-bottom: none;
-  }
-}
-
-/* ─── GET STARTED / INSTALL SECTION ─────────────────────── */
-.install-wrap {
-  max-width: 680px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-/* Primary DMG download button */
-.install-dmg-btn {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  background: var(--surface);
-  border: 1px solid rgba(124, 92, 252, 0.4);
-  border-radius: var(--radius-lg);
-  padding: 20px 24px;
-  cursor: pointer;
-  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
-  text-decoration: none;
-  color: var(--text-primary);
-  position: relative;
-  overflow: hidden;
-}
-
-.install-dmg-btn::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(124, 92, 252, 0.08) 0%, transparent 60%);
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
-.install-dmg-btn:hover {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-glow), 0 8px 32px rgba(124, 92, 252, 0.2);
-  transform: translateY(-2px);
-}
-
-.install-dmg-btn:hover::before { opacity: 1; }
-
-.macos-icon {
-  color: var(--accent);
-  flex-shrink: 0;
-}
-
-.install-dmg-text {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  flex: 1;
-}
-
-.install-dmg-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.01em;
-}
-
-.install-dmg-sub {
-  font-size: 12.5px;
-  color: var(--text-muted);
-}
-
-.install-dmg-arrow {
-  color: var(--accent);
-  flex-shrink: 0;
-  opacity: 0.7;
-  transition: opacity var(--transition), transform var(--transition);
-}
-
-.install-dmg-btn:hover .install-dmg-arrow {
-  opacity: 1;
-  transform: translateY(2px);
-}
-
-/* Divider "or" */
-.install-divider {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 20px 0;
-  color: var(--text-muted);
-  font-size: 12.5px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-}
-
-.install-divider::before,
-.install-divider::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--border);
-}
-
-/* Terminal one-liner */
-.install-terminal {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 4px;
-  transition: border-color var(--transition);
-}
-
-.install-terminal:focus-within {
-  border-color: var(--border-hover);
-}
-
-.install-terminal-inner {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 16px;
-  background: rgba(255,255,255,0.02);
-  border-radius: calc(var(--radius-lg) - 4px);
-}
-
-.install-prompt {
-  font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-  font-size: 14px;
-  color: var(--teal);
-  font-weight: 700;
-  flex-shrink: 0;
-  user-select: none;
-}
-
-.install-cmd {
-  flex: 1;
-  font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-  font-size: 12.5px;
-  color: var(--text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.5;
-}
-
-/* Copy button */
-.install-copy-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-  padding: 7px 14px;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12.5px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--transition);
-  font-family: var(--font);
-}
-
-.install-copy-btn:hover {
-  border-color: var(--border-hover);
-  color: var(--text-primary);
-  background: rgba(255,255,255,0.06);
-}
-
-.install-copy-btn .check-icon {
-  display: none;
-  color: var(--teal);
-}
-
-.install-copy-btn.copied {
-  border-color: rgba(0, 212, 170, 0.4);
-  color: var(--teal);
-  background: var(--teal-dim);
-}
-
-.install-copy-btn.copied .copy-icon { display: none; }
-.install-copy-btn.copied .check-icon { display: block; }
-.install-copy-btn.copied .copy-label { display: none; }
-
-@media (max-width: 480px) {
-  .install-cmd { font-size: 11px; }
-  .install-terminal-inner { padding: 12px; }
-  .install-copy-btn { padding: 7px 10px; }
-  .install-dmg-btn { padding: 16px; gap: 12px; }
-}
-
-/* ─── FAQ ACCORDION ──────────────────────────────────────── */
-.faq-list {
-  max-width: 740px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.faq-item {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  transition: border-color var(--transition);
-}
-
-.faq-item.open {
-  border-color: rgba(124, 92, 252, 0.35);
-}
-
-.faq-question {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 20px 24px;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: 15px;
-  font-weight: 600;
-  cursor: pointer;
-  text-align: left;
-  transition: color var(--transition), background var(--transition);
-  line-height: 1.4;
-  letter-spacing: -0.01em;
-}
-
-.faq-question:hover {
-  background: rgba(255,255,255,0.03);
-}
-
-.faq-item.open .faq-question {
-  color: var(--text-primary);
-}
-
-.faq-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  font-size: 20px;
-  font-weight: 300;
-  color: var(--text-muted);
-  transition: transform 0.3s ease, color var(--transition);
-  line-height: 1;
-}
-
-.faq-item.open .faq-icon {
-  transform: rotate(45deg);
-  color: var(--accent);
-}
-
-.faq-answer {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 0.35s ease;
-}
-
-.faq-item.open .faq-answer {
-  grid-template-rows: 1fr;
-}
-
-.faq-answer-inner {
-  overflow: hidden;
-  padding: 0 24px;
-  font-size: 14.5px;
-  color: var(--text-secondary);
-  line-height: 1.75;
-  transition: padding 0.35s ease;
-}
-
-.faq-item.open .faq-answer-inner {
-  padding: 0 24px 20px;
-}
-
-.faq-link {
-  color: var(--teal);
-  text-decoration: underline;
-  text-decoration-color: rgba(0, 212, 170, 0.35);
-  text-underline-offset: 3px;
-  transition: text-decoration-color var(--transition);
-}
-
-.faq-link:hover {
-  text-decoration-color: var(--teal);
-}
-
-/* Final mobile overrides: keep these after base component rules so the cascade wins. */
-@media (max-width: 640px) {
-  .page-link-row .btn,
-  .hero-ctas .btn,
-  .community-actions .btn,
-  .cta-buttons .btn {
-    width: 100%;
-    justify-content: center;
-    white-space: normal;
-  }
-  .code-block {
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-  }
-}
-
-@media (max-width: 480px) {
-  .faq-question { padding: 16px 18px; font-size: 14px; }
-  .faq-answer-inner { padding: 0 18px; font-size: 13.5px; }
-  .faq-item.open .faq-answer-inner { padding: 0 18px 16px; }
+  .container { padding-left: 20px; padding-right: 20px; }
+  .nav-links { display: none; }
+  .nav-hamburger { display: flex; }
+  .nav-drawer.open { display: flex; }
+  .hero-inner { padding-top: 44px; padding-bottom: 40px; }
+  .section { padding-bottom: 40px; }
+  .privacy-title { font-size: 24px; }
+  .download-panel { padding: 20px; }
+  .download-panel-actions { min-width: 100%; }
+  .download-panel-actions .btn { width: 100%; }
+  .hero-cta-row .btn { flex: 1 1 auto; }
+  .compare-grid { grid-template-columns: 1.2fr 1fr 1fr; }
+  .footer-links { margin-left: 0; }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -394,6 +394,140 @@ img, canvas { max-width: 100%; }
 /* ─── Sections ───────────────────────────────────────────────────────── */
 .section { padding-bottom: 56px; }
 
+/* ─── USP pillars ────────────────────────────────────────────────────── */
+.usp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 14px;
+}
+
+.usp-card {
+  border: 1px solid var(--hair);
+  border-radius: var(--r-xl);
+  padding: 30px 28px;
+  background: var(--card);
+}
+
+.usp-card .mono-kicker { display: block; margin-bottom: 12px; }
+
+.usp-title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin-bottom: 8px;
+}
+
+.usp-body { font-size: 13.5px; line-height: 1.7; color: var(--ink-2); }
+
+/* ─── Stat band (free-forever section) ───────────────────────────────── */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.stat-card {
+  border: 1px solid var(--hair);
+  border-radius: var(--r-lg);
+  padding: 18px 20px;
+  background: var(--card);
+  text-align: center;
+}
+.stat-card.stat-accent { border: 1.5px solid var(--acc); }
+
+.stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--acc);
+}
+.stat-card .stat-label { font-size: 11.5px; color: var(--ink-2); margin-top: 2px; }
+
+/* ─── Backend cards ──────────────────────────────────────────────────── */
+.backend-grid { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+
+.backend-card { position: relative; display: flex; flex-direction: column; }
+.backend-card.is-flagged .mono-kicker { padding-right: 120px; }
+.backend-card.is-flagged { border: 1.5px solid var(--acc); }
+.backend-card.is-flagged.is-local { border-color: var(--moss); }
+
+.backend-flag {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  color: var(--acc);
+  border: 1px solid var(--acc);
+  border-radius: 5px;
+  padding: 2px 7px;
+}
+.backend-flag.local { color: var(--moss); border-color: var(--moss); }
+
+.backend-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.backend-cost { font-size: 12.5px; font-weight: 600; }
+.backend-cost.free { color: var(--moss); }
+
+.backend-chip {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--hair);
+  color: var(--ink-2);
+}
+.backend-chip.local { color: var(--moss); border-color: var(--moss-b); }
+
+.backend-cmd { margin-top: auto; font-size: 10.5px; }
+
+.backend-note {
+  font-size: 12.5px;
+  color: var(--ink-2);
+  margin-top: 14px;
+  border: 1px dashed var(--hair);
+  border-radius: var(--r-md);
+  padding: 12px 16px;
+}
+.backend-note strong { color: var(--ink); }
+
+/* ─── Closing CTA ────────────────────────────────────────────────────── */
+.cta-panel {
+  border: 1px solid var(--hair);
+  border-radius: var(--r-xl);
+  background:
+    radial-gradient(60% 120% at 50% 0%, rgba(232, 151, 78, .10), transparent 70%),
+    var(--card);
+  padding: 52px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+}
+
+.cta-title {
+  font-size: clamp(26px, 4vw, 36px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.12;
+}
+
+.cta-sub { font-size: 14px; color: var(--ink-2); max-width: 480px; }
+
+.cta-footnote { font-size: 11px; color: var(--ink-2); }
+
 .section-title {
   font-size: 26px;
   font-weight: 700;


### PR DESCRIPTION
## What this is

The website half of the end-to-end redesign, implemented from the Claude Design system (Phase 5/6 — "Website", shared by the user). All four public pages rebuilt on one design language, verified visually in both themes and on mobile via headless Chromium.

## The design system

- **Palette**: warm-paper light theme / campfire-dark theme, switching automatically via `prefers-color-scheme`. Amber accent (`#B4661F` light / `#E8974E` dark), moss green for privacy/trust signals.
- **One waveform identity everywhere**: an animated ring glyph in the nav + footer, a hero **listen → transcribe → type** demo capsule (live canvas waveform, spool spinner, typed sentence with caret), a speech wave in the "02 · SPEAK" card, and a pipeline wave inside the privacy panel. Vanilla-JS canvas engine ported from the design spec — no libraries.
- **Typography**: system SF stack; the Google Fonts dependency is gone, so the site is fully self-contained.
- **Motion safety**: `prefers-reduced-motion` renders a single static frame and shows the full demo sentence immediately; animation also pauses while the tab is hidden.

## Page-by-page

- **index.html** — hero ("Speak. It types. Nothing leaves your Mac.") with live demo capsule, 3-card loop (HOLD / SPEAK / RELEASE), the "Your voice never leaves your Mac" privacy panel (deliberately dark in both themes, with the mic → Whisper → cleanup → cursor diagram), the "$144-a-year question" comparison table vs Wispr Flow, "Installed in 60 seconds" steps, and a 5-question FAQ.
- **download.html** — architecture cards with the filename as the button, SHA-256 checksums up front with copy buttons, "Why the checksums are up front" and "Signed + notarized" trust cards. The existing arch-detection/recommendation machinery is preserved untouched (verified working: headless Linux correctly triggers the Mac-only notice).
- **install.html / how-it-works.html** — restyled onto the same system; the pipeline is now numbered mono-kicker rows instead of emoji tiles.

## Truthfulness pass on the design copy

The design mockup's copy was corrected to the shipping product before implementation:

- Hotkey list excludes fn/🌐 (removed from the Python app in v0.3.6).
- Default cloud cleanup named as **OpenRouter Gemma 4**, "local Ollama by default" claim dropped; audio-vs-text distinction made explicit.
- Data location is `~/.openvoiceflow` (not App Support); no Sparkle or Neural-Engine claims; macOS **12+** floor (not 13+); real ~1.2 MB installer sizes (not the mock's 24 MB); first-launch ~5-minute setup stated honestly.
- Placeholder v0.4.0/hashes replaced with the real v0.3.5 assets and published checksums.

## Compatibility

- **All 20 `test_docs_distribution.py` tests pass unchanged** (251 total, 1 macOS-only skip). Nav/hamburger/drawer contract, Vercel analytics hooks, schema.org blocks, checksum formats, and pinned marketing strings all preserved.
- `site.js` modules (hamburger, arch recommendation, event tracking) untouched; the waveform engine and checksum-copy handlers are appended.
- `vercel.json`, `sitemap.xml`, `llms.txt`, DMG assets: untouched.

## Note on branch history

This branch previously held stale v0.3.2-era commits whose content long since shipped on main; it was restarted from current main per the stale-branch protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_