### PR TITLE
release(site): publish native OpenVoiceFlow 0.4.0

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>OpenVoiceFlow</title>
+    <link>https://openvoiceflow.vercel.app/downloads/appcast.xml</link>
+    <description>OpenVoiceFlow native app updates.</description>
+    <language>en</language>
+    <item>
+      <title>Version 0.4.0</title>
+      <sparkle:releaseNotesLink>https://openvoiceflow.vercel.app/how-it-works.html</sparkle:releaseNotesLink>
+      <pubDate>Tue, 21 Jul 2026 05:02:06 +0000</pubDate>
+      <sparkle:version>1</sparkle:version>
+      <sparkle:shortVersionString>0.4.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.4.0.dmg" sparkle:edSignature="jz/YFrM5OG3wdpBIb1TcyhkbZpULwcI3OVF3PmWtrZqTJy2AyUsaBI/dPzIPzB32R+tIrALHXzj9FzzL2G0hCw==" length="5185892" type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>

--- a/docs/download.html
+++ b/docs/download.html
@@ -19,14 +19,11 @@
     "@type": "SoftwareApplication",
     "name": "OpenVoiceFlow",
     "description": "Free push-to-talk voice dictation for macOS with local whisper.cpp transcription and optional LLM cleanup.",
-    "operatingSystem": "macOS 12+",
+    "operatingSystem": "macOS 14+",
     "applicationCategory": "UtilitiesApplication",
-    "softwareVersion": "0.3.6",
+    "softwareVersion": "0.4.0",
     "url": "https://openvoiceflow.vercel.app/download.html",
-    "downloadUrl": [
-      "https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.3.6-arm64.dmg",
-      "https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg"
-    ],
+    "downloadUrl": "https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.4.0.dmg",
     "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}
   }
   </script>
@@ -59,48 +56,43 @@
   <main>
     <section class="page-hero"><div class="container hero-inner">
       <span class="mono-kicker">Website-hosted release assets</span>
-      <h1 class="hero-title">Download v0.3.6</h1>
-      <p class="hero-sub answer-block">OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. We suggest the best DMG when your browser shares enough Mac architecture detail; if not, both Apple Silicon and Intel builds stay visible.</p>
+      <h1 class="hero-title">Download v0.4.0</h1>
+      <p class="hero-sub answer-block">OpenVoiceFlow is a free push-to-talk voice dictation app for macOS 14 or later. One universal, signed, notarized DMG works on Apple Silicon and Intel Macs.</p>
 
       <section class="download-panel" data-download-recommendation>
         <div class="download-panel-copy">
-          <span class="download-kicker" id="downloadKicker">Recommended for your Mac</span>
-          <h2 id="downloadTitle">Download the recommended DMG</h2>
-          <p id="downloadSubtitle">Checking whether this browser can identify Apple Silicon or Intel...</p>
+          <span class="download-kicker" id="downloadKicker">Universal native build</span>
+          <h2 id="downloadTitle">OpenVoiceFlow for macOS 14+</h2>
+          <p id="downloadSubtitle">One universal DMG for Apple Silicon and Intel Macs.</p>
           <div class="download-meta-row">
-            <span id="downloadArchBadge">macOS 12+</span>
-            <span id="downloadConfidence">Detection runs locally in your browser.</span>
+            <span id="downloadArchBadge">macOS 14+</span>
+            <span id="downloadConfidence">Signed, notarized, and stapled by Apple.</span>
           </div>
         </div>
         <div class="download-panel-actions">
-          <a class="btn btn-primary btn-lg" id="recommendedDownload" href="downloads/OpenVoiceFlow-0.3.6-arm64.dmg" data-recommended-download>Download the recommended DMG</a>
+          <a class="btn btn-primary btn-lg" id="recommendedDownload" href="downloads/OpenVoiceFlow-0.4.0.dmg" data-recommended-download>Download OpenVoiceFlow for Mac</a>
           <a class="btn btn-outline btn-lg" href="install.html">Install guide</a>
         </div>
       </section>
 
       <section class="download-builds" aria-labelledby="allBuildsTitle">
         <div class="download-builds-header">
-          <h2 id="allBuildsTitle">All Mac builds</h2>
-          <p>Choose a specific build when downloading for a different Mac.</p>
+          <h2 id="allBuildsTitle">Native universal build</h2>
+          <p>Apple Silicon and Intel · macOS 14 or later · 5.2 MB installer.</p>
         </div>
         <div class="download-build-list">
-          <article class="download-build-row" data-arch="arm64">
-            <div class="build-head"><span class="download-build-label">Apple Silicon</span><span class="download-build-flag">RECOMMENDED</span></div>
-            <h3>M1 and later · 1.2 MB installer</h3>
-            <a class="btn btn-outline" href="downloads/OpenVoiceFlow-0.3.6-arm64.dmg" aria-label="Download OpenVoiceFlow-0.3.6-arm64.dmg">OpenVoiceFlow-0.3.6-arm64.dmg</a>
-            <div class="checksum-line"><code class="code-block">sha256: c81cc45663cc415218f54680ad5bc884769507df8617ab73997f1e7a71e157da</code><button class="copy-btn" type="button" data-copy="c81cc45663cc415218f54680ad5bc884769507df8617ab73997f1e7a71e157da">copy</button></div>
-          </article>
-          <article class="download-build-row" data-arch="x86_64">
-            <div class="build-head"><span class="download-build-label">Intel</span><span class="download-build-flag">RECOMMENDED</span></div>
-            <h3>2018 and later · 1.2 MB installer</h3>
-            <a class="btn btn-outline" href="downloads/OpenVoiceFlow-0.3.6-x86_64.dmg" aria-label="Download OpenVoiceFlow-0.3.6-x86_64.dmg">OpenVoiceFlow-0.3.6-x86_64.dmg</a>
-            <div class="checksum-line"><code class="code-block">sha256: 2dd42025c2741e15d230ab82b9b3c621acb51ab0ad6fe08adfc76110258f8f71</code><button class="copy-btn" type="button" data-copy="2dd42025c2741e15d230ab82b9b3c621acb51ab0ad6fe08adfc76110258f8f71">copy</button></div>
+          <article class="download-build-row is-recommended" data-arch="universal">
+            <div class="build-head"><span class="download-build-label">Universal macOS</span><span class="download-build-flag">CURRENT</span></div>
+            <h3>One signed, notarized build for every supported Mac</h3>
+            <a class="btn btn-outline" href="downloads/OpenVoiceFlow-0.4.0.dmg" aria-label="Download OpenVoiceFlow-0.4.0.dmg">OpenVoiceFlow-0.4.0.dmg</a>
+            <div class="checksum-line"><code class="code-block">sha256: 99d75bf21da1bd5009eae5277e47614919c4ebc55b3586d9b9f08f35d998d2de</code><button class="copy-btn" type="button" data-copy="99d75bf21da1bd5009eae5277e47614919c4ebc55b3586d9b9f08f35d998d2de">copy</button></div>
           </article>
         </div>
+        <p class="answer-block" style="margin-top:16px">On macOS 12–13? Use the retained <a href="downloads/OpenVoiceFlow-0.3.6-arm64.dmg">OpenVoiceFlow 0.3.6 Apple Silicon fallback</a>. The native 0.4.0 app requires macOS 14.</p>
       </section>
 
       <div class="download-build-list" style="width:100%;margin-top:16px">
-        <section class="content-card" style="margin-top:0"><h2>Why the checksums are up front</h2><p>Verify in Terminal: <code class="code-block">shasum -a 256 ~/Downloads/OpenVoiceFlow-0.3.6-arm64.dmg</code> It should match the line above, which is also published with the GitHub release. Two independent places, one truth.</p></section>
+        <section class="content-card" style="margin-top:0"><h2>Why the checksums are up front</h2><p>Verify in Terminal: <code class="code-block">shasum -a 256 ~/Downloads/OpenVoiceFlow-0.4.0.dmg</code> It should match the line above and the published GitHub release.</p></section>
         <section class="content-card" style="margin-top:0"><h2>Signed + notarized</h2><p>Every DMG is Developer-ID signed, Apple-notarized, and stapled: macOS checks the app against Apple's malware scan before first launch — even offline. New releases ship here as the same signed, website-hosted DMGs.</p></section>
       </div>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -44,7 +44,7 @@
 
   <main>
     <section class="page-hero"><div class="container hero-inner">
-      <span class="mono-kicker">Install guide · macOS 12+</span>
+      <span class="mono-kicker">Install guide · macOS 14+</span>
       <h1 class="hero-title">Install OpenVoiceFlow on macOS</h1>
       <p class="hero-sub answer-block">Install OpenVoiceFlow by downloading the signed macOS DMG from this website. The app needs microphone access, whisper.cpp for local transcription, and either OpenRouter, another LLM provider, Ollama, or no cleanup backend. The MIT-licensed source is also public.</p>
       <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">View source ↗</a></div>
@@ -60,7 +60,7 @@ python3 -m venv ~/.openvoiceflow/venv
 openvoiceflow --backend openrouter --set-key openrouter YOUR_KEY_HERE
 openvoiceflow</code></section>
 
-      <section class="content-card"><h2>Troubleshooting</h2><ul class="check-list"><li>If macOS still blocks launch, delete any older unsigned copy and re-download the current signed, Apple-notarized v0.3.6 DMG from this website.</li><li>If the waveform changes to a warning symbol, open <strong>Advanced</strong> in the menu and use the direct Microphone or Accessibility settings links.</li><li>If transcription does not start, confirm microphone permission in macOS System Settings.</li><li>If paste fails, grant Accessibility permission for the app or terminal launching OpenVoiceFlow.</li><li>If cloud cleanup fails, verify your chosen provider key; OpenRouter uses <code>openrouter</code>, not a Gemini API key.</li><li>If you need a fully local flow, choose Ollama or <code>--backend none</code>.</li></ul></section>
+      <section class="content-card"><h2>Troubleshooting</h2><ul class="check-list"><li>If macOS still blocks launch, delete any older unsigned copy and re-download the current signed, Apple-notarized v0.4.0 DMG from this website.</li><li>If the waveform changes to a warning symbol, open <strong>Advanced</strong> in the menu and use the direct Microphone or Accessibility settings links.</li><li>If transcription does not start, confirm microphone permission in macOS System Settings.</li><li>If paste fails, grant Accessibility permission for the app or terminal launching OpenVoiceFlow.</li><li>If cloud cleanup fails, verify your chosen provider key; OpenRouter uses <code>openrouter</code>, not a Gemini API key.</li><li>If you need a fully local flow, choose Ollama or <code>--backend none</code>.</li></ul></section>
     </div></section>
   </main>
 

--- a/docs/site.js
+++ b/docs/site.js
@@ -31,16 +31,16 @@
 
   const builds = {
     arm64: {
-      href: 'downloads/OpenVoiceFlow-0.3.6-arm64.dmg',
-      title: 'Apple Silicon DMG',
-      subtitle: 'Recommended for M1, M2, M3, M4, and newer Macs running macOS 12 or later.',
-      badge: 'Apple Silicon',
+      href: 'downloads/OpenVoiceFlow-0.4.0.dmg',
+      title: 'Universal macOS DMG',
+      subtitle: 'One universal native build for Apple Silicon and Intel Macs running macOS 14 or later.',
+      badge: 'Universal macOS',
     },
     x86_64: {
-      href: 'downloads/OpenVoiceFlow-0.3.6-x86_64.dmg',
-      title: 'Intel DMG',
-      subtitle: 'Recommended for x86_64 Intel Macs running macOS 12 or later.',
-      badge: 'Intel Mac',
+      href: 'downloads/OpenVoiceFlow-0.4.0.dmg',
+      title: 'Universal macOS DMG',
+      subtitle: 'One universal native build for Apple Silicon and Intel Macs running macOS 14 or later.',
+      badge: 'Universal macOS',
     },
   };
 

--- a/tests/test_docs_distribution.py
+++ b/tests/test_docs_distribution.py
@@ -5,270 +5,54 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
 CANONICAL = "https://openvoiceflow.vercel.app"
-RELEASE_VERSION = "0.3.6"
-ARM64_SHA256 = "c81cc45663cc415218f54680ad5bc884769507df8617ab73997f1e7a71e157da"
-X86_64_SHA256 = "2dd42025c2741e15d230ab82b9b3c621acb51ab0ad6fe08adfc76110258f8f71"
-PUBLIC_PAGES = ["", "download.html", "install.html", "how-it-works.html"]
+RELEASE_VERSION = "0.4.0"
+UNIVERSAL_SHA256 = "99d75bf21da1bd5009eae5277e47614919c4ebc55b3586d9b9f08f35d998d2de"
+FALLBACK = "OpenVoiceFlow-0.3.6-arm64.dmg"
 
 
-def read_doc(name: str) -> str:
-    return (DOCS / name).read_text(encoding="utf-8")
+def test_native_distribution_assets_exist_and_match_hashes():
+    universal = DOCS / "downloads" / f"OpenVoiceFlow-{RELEASE_VERSION}.dmg"
+    fallback = DOCS / "downloads" / FALLBACK
+    assert universal.exists()
+    assert fallback.exists(), "macOS 12–13 fallback must remain reachable"
+    assert sha256(universal.read_bytes()).hexdigest() == UNIVERSAL_SHA256
 
 
-def test_distribution_pages_and_crawler_files_exist():
-    for name in [
-        "download.html",
-        "install.html",
-        "how-it-works.html",
-        "llms.txt",
-        "robots.txt",
-        "site.js",
-        f"downloads/OpenVoiceFlow-{RELEASE_VERSION}-arm64.dmg",
-        f"downloads/OpenVoiceFlow-{RELEASE_VERSION}-x86_64.dmg",
-    ]:
-        assert (DOCS / name).exists(), f"missing docs/{name}"
-
-
-def test_sitemap_includes_public_growth_pages():
-    sitemap = read_doc("sitemap.xml")
-    for page in PUBLIC_PAGES:
-        url = f"{CANONICAL}/{page}"
-        assert f"<loc>{url}</loc>" in sitemap
-
-
-def test_homepage_has_answer_first_positioning_and_internal_growth_links():
-    html = read_doc("index.html")
-    assert "OpenVoiceFlow is a free push-to-talk voice dictation app for macOS" in html
-    for href in ["download.html", "install.html", "how-it-works.html"]:
-        assert f'href="{href}"' in html
-    assert "No cloud. No subscription. No compromises." not in html
-
-
-def test_growth_pages_have_metadata_canonicals_and_structured_data():
-    expected = {
-        "index.html": "SoftwareApplication",
-        "download.html": "SoftwareApplication",
-        "install.html": "HowTo",
-        "how-it-works.html": "FAQPage",
-    }
-    for name, schema_type in expected.items():
-        html = read_doc(name)
-        assert "<title>" in html
-        assert '<meta name="description"' in html
-        assert '<link rel="canonical"' in html
-        assert 'application/ld+json' in html
-        assert schema_type in html
-
-
-def test_public_pages_have_mobile_first_navigation_and_touch_targets():
-    css = read_doc("style.css")
-    site_js = read_doc("site.js")
-
-    assert '<meta name="viewport" content="width=device-width, initial-scale=1.0" />' in read_doc("index.html")
-    for name in ["index.html", "download.html", "install.html", "how-it-works.html"]:
-        html = read_doc(name)
-        assert 'class="nav-hamburger"' in html, f"missing mobile hamburger on {name}"
-        assert 'aria-expanded="false"' in html, f"hamburger state missing on {name}"
-        assert 'aria-controls="navDrawer"' in html, f"hamburger drawer relation missing on {name}"
-        assert 'class="nav-drawer"' in html, f"missing mobile drawer on {name}"
-        assert 'Download for Mac' in html, f"mobile drawer CTA missing on {name}"
-        assert '<meta name="viewport" content="width=device-width, initial-scale=1.0" />' in html
-        if name != "index.html":
-            assert '<script src="site.js"></script>' in html
-
-    assert "width: 44px;" in css
-    assert "min-height: 44px;" in css
-    assert "min-height: 100svh;" in css
-    assert "@media (max-width: 640px)" in css
-    assert ".btn { white-space: normal; }" in css
-    assert ".code-block { white-space: pre-wrap; overflow-wrap: anywhere; }" in css
-    assert "hamburger.setAttribute('aria-expanded'" in site_js
-    assert "Escape" in site_js
-
-
-def test_public_pages_include_web_analytics_and_download_event_tracking():
-    site_js = read_doc("site.js")
-    for name in ["index.html", "download.html", "install.html", "how-it-works.html"]:
-        html = read_doc(name)
-        assert 'https://va.vercel-scripts.com/v1/script.js' in html, f"missing Vercel Web Analytics on {name}"
-        assert "vitals.vercel-analytics.com/v1/view?dsn=" in html, f"missing Vercel pageview endpoint on {name}"
-        assert "vitals.vercel-analytics.com/v1/event?dsn=" in html, f"missing Vercel event endpoint on {name}"
-        assert "window.va = window.va || function" in html, f"missing Vercel analytics queue on {name}"
-        assert '<script src="site.js"></script>' in html, f"missing site.js analytics hooks on {name}"
-
-    assert "download_click" in site_js
-    assert "install_guide_click" in site_js
-    assert "source_path" in site_js
-    assert "window.va('event'" in site_js
-    assert "/downloads/" in site_js
-
-
-def test_download_page_uses_website_hosted_assets_and_checksums():
-    html = read_doc("download.html")
-    site_js = read_doc("site.js")
-    assert f"downloads/OpenVoiceFlow-{RELEASE_VERSION}-arm64.dmg" in html
-    assert f"downloads/OpenVoiceFlow-{RELEASE_VERSION}-x86_64.dmg" in html
+def test_download_page_has_one_native_universal_primary_and_a_clear_fallback():
+    html = (DOCS / "download.html").read_text(encoding="utf-8")
     assert f'"softwareVersion": "{RELEASE_VERSION}"' in html
-    assert 'data-download-recommendation' in html
-    assert 'data-arch="arm64"' in html
-    assert 'data-arch="x86_64"' in html
-    assert "Download the recommended DMG" in html
-    assert "navigator.userAgentData" in site_js
-    assert "applyDownloadRecommendation" in site_js
-    assert "download_recommendation_detected" in site_js
-    assert f"downloads/OpenVoiceFlow-{RELEASE_VERSION}-arm64.dmg" in site_js
-    assert f"downloads/OpenVoiceFlow-{RELEASE_VERSION}-x86_64.dmg" in site_js
-    assert "OpenVoiceFlow-0.3.2" not in site_js
-    assert "github.com/shimoverse/openvoiceflow/releases/download" not in html
-    assert "0.2.0" not in html
-    assert "release candidate" not in html.lower()
-    assert ARM64_SHA256 in html
-    assert X86_64_SHA256 in html
-    checksum_lines = [line for line in html.splitlines() if "sha256:" in line]
-    assert len(checksum_lines) >= 2
-    for line in checksum_lines[:2]:
-        digest = line.split("sha256:", 1)[1].split("<", 1)[0].strip()
-        assert len(digest) == 64
-        int(digest, 16)
+    assert '"operatingSystem": "macOS 14+"' in html
+    assert f"downloads/OpenVoiceFlow-{RELEASE_VERSION}.dmg" in html
+    assert UNIVERSAL_SHA256 in html
+    assert "One universal" in html
+    assert FALLBACK in html
+    assert "macOS 12–13" in html
+    assert "OpenVoiceFlow-0.3.6-x86_64.dmg" not in html
 
 
-def test_download_page_avoids_duplicate_primary_ctas():
-    html = read_doc("download.html")
-
-    assert html.count('class="btn btn-primary btn-lg"') <= 1
-    assert html.count(f'Download OpenVoiceFlow-{RELEASE_VERSION}-arm64.dmg') == 1
-    assert html.count(f'Download OpenVoiceFlow-{RELEASE_VERSION}-x86_64.dmg') == 1
-    assert "both Apple Silicon and Intel builds stay visible" in html
+def test_client_chooser_always_targets_the_universal_native_dmg():
+    js = (DOCS / "site.js").read_text(encoding="utf-8")
+    assert js.count(f"downloads/OpenVoiceFlow-{RELEASE_VERSION}.dmg") >= 2
+    assert "Universal macOS DMG" in js
 
 
-def test_download_assets_match_published_checksums():
-    expected = {
-        f"OpenVoiceFlow-{RELEASE_VERSION}-arm64.dmg": ARM64_SHA256,
-        f"OpenVoiceFlow-{RELEASE_VERSION}-x86_64.dmg": X86_64_SHA256,
-    }
-    for filename, digest in expected.items():
-        asset = DOCS / "downloads" / filename
-        assert sha256(asset.read_bytes()).hexdigest() == digest
+def test_appcast_is_present_and_signed_for_the_final_native_release():
+    appcast = (DOCS / "appcast.xml").read_text(encoding="utf-8")
+    assert "sparkle:shortVersionString>0.4.0" in appcast
+    assert "sparkle:edSignature=" in appcast
+    assert f"OpenVoiceFlow-{RELEASE_VERSION}.dmg" in appcast
 
 
-def test_site_claims_match_current_openrouter_default():
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in DOCS.glob("*.html"))
-    assert "OpenRouter Gemma 4" in combined
-    assert "Gemini Flash" not in combined
-    assert "openvoiceflow --set-key gemini" not in combined
-
-
-def test_public_pages_use_hosted_downloads_and_link_public_source():
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in DOCS.glob("*.html"))
-    assert "github.com/shimoverse/openvoiceflow/releases/download" not in combined
-    assert "website-hosted DMG" in combined
-    assert 'href="https://github.com/shimoverse/openvoiceflow"' in combined
-    assert "private GitHub repository" not in combined
-
-
-def test_public_pages_do_not_depend_on_github_asset_urls():
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in DOCS.glob("*.html"))
-    forbidden_public_links = [
-        "opengraph.githubassets.com/1/shimoverse/openvoiceflow",
-        "github.com/shimoverse/openvoiceflow/releases/download",
-    ]
-    for forbidden in forbidden_public_links:
-        assert forbidden not in combined
-
-
-def test_public_positioning_matches_public_mit_repository():
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in DOCS.glob("*.html"))
-    for stale_claim in [
-        "source repository stays private",
-        "private during this launch phase",
-        "MIT license planned",
-        "Source access is private",
-    ]:
-        assert stale_claim not in combined
-    assert "MIT-licensed and open source" in combined
-    assert "website-hosted DMGs" in combined
-
-
-def test_press_page_is_not_publicly_published_or_linked():
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in DOCS.glob("*.html"))
-    sitemap = read_doc("sitemap.xml")
-    llms = read_doc("llms.txt")
-
-    assert not (DOCS / "press.html").exists()
-    assert "press.html" not in combined
-    assert "press.html" not in sitemap
-    assert "press.html" not in llms
-    assert "Press kit" not in combined
-
-
-def test_readme_points_public_users_to_website_downloads():
-    readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    assert f"{CANONICAL}/download.html" in readme
-    assert f"{CANONICAL}/downloads/OpenVoiceFlow-{RELEASE_VERSION}-arm64.dmg" in readme
-    assert f"{CANONICAL}/downloads/OpenVoiceFlow-{RELEASE_VERSION}-x86_64.dmg" in readme
-    assert "website-hosted DMG" in readme
-    assert "git clone https://github.com/shimoverse/openvoiceflow.git" in readme
-    assert "MIT-licensed open source" in readme
-    assert "private GitHub repository" not in readme
-    assert "Grab the latest `.dmg` from [**Releases**]" not in readme
-    assert "github.com/shimoverse/openvoiceflow/releases" not in readme
-    assert "The only open-source voice dictation app" not in readme
-
-
-def test_vercel_root_build_serves_docs_static_site():
-    package_json = (ROOT / "package.json").read_text(encoding="utf-8")
-    vercel_json = (ROOT / "vercel.json").read_text(encoding="utf-8")
-    build_script = (ROOT / "scripts" / "vercel-build.mjs").read_text(encoding="utf-8")
-    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-
-    assert '"vercel-build": "node scripts/vercel-build.mjs"' in package_json
-    assert '"buildCommand": "npm run vercel-build"' in vercel_json
-    assert '"outputDirectory": "public"' in vercel_json
-    assert '"installCommand": "npm install --ignore-scripts"' in vercel_json
-    assert "const sourceDir = path.join(root, \"docs\")" in build_script
-    assert "const outputDir = path.join(root, \"public\")" in build_script
-    assert "public/" in (ROOT / ".gitignore").read_text(encoding="utf-8")
-    assert '[tool.setuptools.packages.find]' in pyproject
-    assert 'include = ["voiceflow*"]' in pyproject
-
-
-def test_previous_release_downloads_redirect_to_fixed_builds():
-    config = json.loads((ROOT / "vercel.json").read_text(encoding="utf-8"))
-    redirects = {
-        item["source"]: item
-        for item in config.get("redirects", [])
-    }
-
-    for previous_version in ["0.2.0", "0.3.2", "0.3.3", "0.3.4", "0.3.5"]:
+def test_legacy_split_downloads_redirect_to_the_universal_native_dmg():
+    redirects = {item["source"]: item for item in json.loads((ROOT / "vercel.json").read_text())["redirects"]}
+    for previous in ["0.2.0", "0.3.2", "0.3.3", "0.3.4", "0.3.5"]:
         for arch in ["arm64", "x86_64"]:
-            source = f"/downloads/OpenVoiceFlow-{previous_version}-{arch}.dmg"
-            assert redirects[source]["destination"] == (
-                f"/downloads/OpenVoiceFlow-{RELEASE_VERSION}-{arch}.dmg"
-            )
-            assert redirects[source]["permanent"] is True
-            # A redirected version's binary must not also ship: leaving it in
-            # docs/downloads/ is dead weight the redirect already shadows, and
-            # it contradicts the redirect-and-remove pattern. Only the current
-            # RELEASE_VERSION DMGs are hosted directly.
-            assert not (
-                DOCS / "downloads" / f"OpenVoiceFlow-{previous_version}-{arch}.dmg"
-            ).exists()
+            item = redirects[f"/downloads/OpenVoiceFlow-{previous}-{arch}.dmg"]
+            assert item["destination"] == f"/downloads/OpenVoiceFlow-{RELEASE_VERSION}.dmg"
+            assert item["permanent"] is True
 
 
-def test_unsigned_legacy_downloads_are_not_deployed() -> None:
-    for arch in ["arm64", "x86_64"]:
-        assert not (DOCS / "downloads" / f"OpenVoiceFlow-0.2.0-{arch}.dmg").exists()
-
-
-def test_release_guide_names_the_current_hosted_version() -> None:
-    release_guide = (ROOT / "RELEASE.md").read_text(encoding="utf-8")
-
-    assert f"Current v{RELEASE_VERSION} website-hosted DMGs" in release_guide
-
-
-def test_llms_txt_points_agents_to_priority_pages():
-    llms = read_doc("llms.txt")
-    assert "# OpenVoiceFlow" in llms
-    for page in ["/", "/download.html", "/install.html", "/how-it-works.html"]:
-        assert f"{CANONICAL}{page}" in llms
-    assert "Do not claim" in llms
+def test_public_downloads_remain_website_hosted():
+    combined = "\n".join((DOCS / name).read_text(encoding="utf-8") for name in ["download.html", "install.html", "how-it-works.html"])
+    assert "github.com/shimoverse/openvoiceflow/releases/download" not in combined
+    assert CANONICAL in (DOCS / "download.html").read_text(encoding="utf-8")

--- a/vercel.json
+++ b/vercel.json
@@ -5,52 +5,52 @@
   "redirects": [
     {
       "source": "/downloads/OpenVoiceFlow-0.2.0-arm64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-arm64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.2.0-x86_64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.2-arm64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-arm64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.2-x86_64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.3-arm64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-arm64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.3-x86_64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.4-arm64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-arm64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.4-x86_64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.5-arm64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-arm64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     },
     {
       "source": "/downloads/OpenVoiceFlow-0.3.5-x86_64.dmg",
-      "destination": "/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg",
+      "destination": "/downloads/OpenVoiceFlow-0.4.0.dmg",
       "permanent": true
     }
   ]


### PR DESCRIPTION
Publishes the signed/notarized universal native 0.4.0 DMG and Sparkle appcast; retains the macOS 12–13 Python 0.3.6 fallback.