### PR TITLE
test: fix ruff E501 in test_docs_distribution (unblock main CI)

### DIFF
--- a/tests/test_docs_distribution.py
+++ b/tests/test_docs_distribution.py
@@ -53,6 +53,7 @@ def test_legacy_split_downloads_redirect_to_the_universal_native_dmg():
 
 
 def test_public_downloads_remain_website_hosted():
-    combined = "\n".join((DOCS / name).read_text(encoding="utf-8") for name in ["download.html", "install.html", "how-it-works.html"])
+    pages = ["download.html", "install.html", "how-it-works.html"]
+    combined = "\n".join((DOCS / name).read_text(encoding="utf-8") for name in pages)
     assert "github.com/shimoverse/openvoiceflow/releases/download" not in combined
     assert CANONICAL in (DOCS / "download.html").read_text(encoding="utf-8")


### PR DESCRIPTION
`tests/test_docs_distribution.py:56` (introduced by the 0.4.0 site flip, #34) is 134 characters and trips ruff's E501 (120 limit). Because `ruff check .` gates the whole `test` job, **main's CI is currently red**. Hoist the page list to a local so the join fits under the limit — no behavior change. `ruff check` and the distribution tests pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_