### PR TITLE
feat(native): OpenRouter as the single cloud cleanup gateway (0.4.2)

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.4.1</string>
-    <key>CFBundleVersion</key><string>2</string>
+    <key>CFBundleShortVersionString</key><string>0.4.2</string>
+    <key>CFBundleVersion</key><string>3</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Menu-bar agent: no Dock icon, no main window on launch. -->
     <key>LSUIElement</key><true/>

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -459,8 +459,11 @@ struct DashboardView: View {
         ("it", "Italian"), ("pt", "Portuguese"), ("nl", "Dutch"), ("hi", "Hindi"),
         ("ja", "Japanese"), ("zh", "Chinese"), ("ko", "Korean"),
     ]
-    /// Cleanup providers offered when cleanup is on (excludes `.none`).
-    static let cleanupProviders: [Backend] = [.anthropic, .openai, .groq, .openrouter, .ollama]
+    /// Cleanup providers offered when cleanup is on. OpenRouter is the single
+    /// cloud gateway (one key → any model); Ollama keeps a fully-local option.
+    /// The direct providers still exist in `Backend` for older saved configs,
+    /// but the UI intentionally offers just the gateway + local.
+    static let cleanupProviders: [Backend] = [.openrouter, .ollama]
 
     private var settingsPane: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -549,6 +552,9 @@ struct DashboardView: View {
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 230)
                     }
+                    if controller.settings.backend == .openrouter {
+                        settingsRow("One key unlocks every model — get one at openrouter.ai/keys") { EmptyView() }
+                    }
                 } else if controller.settings.backend == .ollama {
                     settingsRow("Endpoint") {
                         Text("localhost:11434 · fully local").foregroundStyle(ink2)
@@ -604,12 +610,13 @@ struct DashboardView: View {
         Binding(get: { controller.settings.hotkey }, set: { controller.updateHotkey($0) })
     }
 
-    /// Cleanup on/off: off ⇒ `.none` (local raw), on ⇒ Anthropic by default.
+    /// Cleanup on/off: off ⇒ `.none` (local raw), on ⇒ OpenRouter (the cloud
+    /// gateway). Pick Ollama afterward from the Provider list for local cleanup.
     private var cleanupEnabledBinding: Binding<Bool> {
         Binding(
             get: { controller.settings.backend != .none },
             set: { on in
-                controller.settings.backend = on ? .anthropic : .none
+                controller.settings.backend = on ? .openrouter : .none
                 controller.settings.save()
                 reloadAPIKeyDraft()
             }

--- a/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
+++ b/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
@@ -142,9 +142,9 @@ private struct MenuContent: View {
             Text("Runs on this Mac — downloads once")
         }
 
-        // 8. Cleanup picker (design order: on-device first).
+        // 8. Cleanup picker: off / on-device Ollama / OpenRouter gateway.
         Menu("Cleanup — \(cleanupLabel(controller.settings.backend))") {
-            ForEach([Backend.ollama, .anthropic, .openai, .groq, .openrouter, .none], id: \.self) { backend in
+            ForEach([Backend.none, .ollama, .openrouter], id: \.self) { backend in
                 Button {
                     controller.settings.backend = backend
                     controller.settings.save()
@@ -198,7 +198,7 @@ private struct MenuContent: View {
         case .anthropic: return "Anthropic"
         case .openai: return "OpenAI"
         case .groq: return "Groq"
-        case .openrouter: return "OpenRouter"
+        case .openrouter: return "OpenRouter · any model"
         case .none: return "None — raw transcript"
         }
     }

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.4.1
-        CURRENT_PROJECT_VERSION: 2
+        MARKETING_VERSION: 0.4.2
+        CURRENT_PROJECT_VERSION: 3
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What

Simplify AI cleanup to **one cloud gateway + local**, per the request to make OpenRouter the way in:

- **Off** (default) — raw transcript, nothing leaves the Mac
- **OpenRouter** — the single cloud gateway; paste one key, use any model
- **Ollama** — local LLM cleanup, no key, no cloud

The direct Anthropic/OpenAI/Groq entries are removed from the UI (OpenRouter already fronts those models), so there's one endpoint to maintain instead of four. The local options stay to preserve the "everything local" USP.

## Changes

- `DashboardView`: `cleanupProviders = [.openrouter, .ollama]`; toggling cleanup on now defaults to **OpenRouter**; a hint points to `openrouter.ai/keys`.
- `OpenVoiceFlowApp` menu-bar Cleanup: **Off / On-device Ollama / OpenRouter · any model**.
- The direct providers remain in the `Backend` enum (so any older saved config still decodes) — they're just no longer offered in the UI.
- Default model `google/gemma-4-31b-it` verified present on OpenRouter (there's even a `:free` variant). Users can override in the "Model" field.
- Version bump to **0.4.2** (build 3).

## Ship

Native Swift isn't in CI, so a Mac build validates it. To release: compile, tag `native-v0.4.2` → `release-native.yml` builds the signed DMG + appcast (build 3 → 0.4.1 users auto-update), then flip the site to 0.4.2. Draft until the Mac compile confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_