### PR TITLE
ci: harden release ops for launch (guard legacy pipeline, build Swift in CI, version discipline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,27 @@ jobs:
         # Syntax/type check only (no signing, no linking) so a broken
         # OpenVoiceFlowLauncher.m is caught in CI, not at release time.
         run: clang -fsyntax-only -fobjc-arc -fblocks packaging/OpenVoiceFlowLauncher.m
+
+  # The native Swift app is the shipping product — compile it on every PR so a
+  # broken main is caught here, not at release time (release-native.yml).
+  native-build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.4"   # Swift 6.1 — WhisperKit 0.18 pulls swift-crypto 4.5.1
+      - name: Install XcodeGen
+        run: brew install xcodegen
+      - name: Generate project + build (unsigned)
+        run: |
+          set -euo pipefail
+          cd native
+          xcodegen generate
+          xcodebuild \
+            -project OpenVoiceFlow.xcodeproj \
+            -scheme OpenVoiceFlow \
+            -configuration Debug \
+            -destination 'generic/platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
+            build

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -52,6 +52,24 @@ jobs:
           if [[ "$BASE_VERSION" != "$PROJ_VERSION" ]]; then
             echo "::error::tag base $BASE_VERSION != native/project.yml MARKETING_VERSION $PROJ_VERSION"; exit 1
           fi
+          # All version sources must agree, and the build number must increment
+          # or Sparkle (which orders updates by CFBundleVersion) won't offer it.
+          PLIST_SHORT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' native/Info.plist)"
+          PLIST_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' native/Info.plist)"
+          PROJ_BUILD="$(grep -E 'CURRENT_PROJECT_VERSION:' native/project.yml | head -1 | sed -E 's/.*: *"?([0-9]+)"?.*/\1/')"
+          if [[ "$PLIST_SHORT" != "$BASE_VERSION" ]]; then
+            echo "::error::Info.plist CFBundleShortVersionString ($PLIST_SHORT) != tag base ($BASE_VERSION)"; exit 1
+          fi
+          if [[ "$PLIST_BUILD" != "$PROJ_BUILD" ]]; then
+            echo "::error::Info.plist CFBundleVersion ($PLIST_BUILD) != project.yml CURRENT_PROJECT_VERSION ($PROJ_BUILD)"; exit 1
+          fi
+          if [[ -f docs/appcast.xml ]]; then
+            LAST_BUILD="$(grep -oE 'sparkle:version>[0-9]+' docs/appcast.xml | grep -oE '[0-9]+' | sort -n | tail -1 || echo 0)"
+            LAST_BUILD="${LAST_BUILD:-0}"
+            if [[ "$PLIST_BUILD" -le "$LAST_BUILD" ]]; then
+              echo "::error::CFBundleVersion ($PLIST_BUILD) must exceed the last published appcast build ($LAST_BUILD), or Sparkle won't offer the update."; exit 1
+            fi
+          fi
           if [[ "$BASE_VERSION" != "$TAG_VERSION" ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -116,11 +134,10 @@ jobs:
           chmod +x native/scripts/build-app.sh
           bash native/scripts/build-app.sh
 
-      - name: Generate Sparkle appcast (if key present)
-        # Non-fatal: the notarized DMG is the critical artifact and must ship
-        # even if appcast signing hiccups (it can be regenerated). A failure
-        # here shows as a red step but never blocks the DMG upload below.
-        continue-on-error: true
+      - name: Generate Sparkle appcast
+        # Required: a signed release must ship a signed update feed, or in-app
+        # updates silently break for everyone. appcast.sh fails loudly if the
+        # Sparkle key is missing, and this step failing fails the release.
         env:
           OVF_VERSION: ${{ steps.classify.outputs.version }}
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -6,8 +6,9 @@ name: Release (native app)
 # namespace so it never collides with the Python `v*` release (release.yml).
 #
 # Signing reuses the SAME secrets as release.yml — nothing new to configure for
-# code signing. The one new (optional) secret is SPARKLE_ED_PRIVATE_KEY, which
-# turns on appcast generation for in-app updates.
+# code signing. One additional secret, SPARKLE_ED_PRIVATE_KEY, is REQUIRED: it
+# signs the update appcast, and a release fails without it (an unsigned/missing
+# feed would silently break in-app updates for everyone).
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,13 @@ jobs:
           # for the equality comparison: the tag carries the pre-release
           # marker, but pyproject + __init__ stay at the base version.
           BASE_VERSION=$(echo "$TAG_VERSION" | python3 -c "import re,sys; print(re.sub(r'([-.]?)(rc|alpha|beta|dev|a|b)\d+\$', '', sys.stdin.read().strip()))")
+          # The native app took over at 0.4.0 and ships from `native-v*` tags
+          # (release-native.yml). Refuse `v*` tags at 0.4.0+ so an accidental
+          # `v0.4.x` can never publish the retired Python app to PyPI + Releases.
+          if python3 -c "import sys; b='$BASE_VERSION'.split('.'); sys.exit(0 if (int(b[0]), int(b[1]) if len(b)>1 else 0) >= (0,4) else 1)"; then
+            echo "::error::Python (v*) releases are EOL at 0.3.x. The native app uses native-v* tags. Refusing $TAG."
+            exit 1
+          fi
           PYPROJECT_VERSION=$(python3 -c "import re,sys; m=re.search(r'^version\s*=\s*\"([^\"]+)\"', open('pyproject.toml').read(), re.M); print(m.group(1))")
           INIT_VERSION=$(python3 -c "import re; m=re.search(r'__version__\s*=\s*\"([^\"]+)\"', open('voiceflow/__init__.py').read()); print(m.group(1))")
           echo "tag=$TAG_VERSION (base=$BASE_VERSION) pyproject=$PYPROJECT_VERSION init=$INIT_VERSION"

--- a/native/BUILD_RUNBOOK.md
+++ b/native/BUILD_RUNBOOK.md
@@ -188,8 +188,9 @@ and a full release pipeline exists:
   staple`. Runnable locally: `OVF_NOTARIZE=0 bash native/scripts/build-app.sh`
   for an unsigned smoke build.
 - **`native/scripts/appcast.sh`** — signs the DMG with the Sparkle EdDSA key
-  and writes `dist/appcast.xml`. No-op (release still ships the DMG) until the
-  key exists.
+  and writes `dist/appcast.xml`. **Required:** the release now fails if
+  `SPARKLE_ED_PRIVATE_KEY` is unset (shipping without a signed feed silently
+  breaks in-app updates), so the key must be configured before tagging.
 
 **The only remaining Mac-gated steps** (see `native/RELEASE_NATIVE_RUNBOOK.md`
 for the copy-paste version):

--- a/native/scripts/appcast.sh
+++ b/native/scripts/appcast.sh
@@ -8,14 +8,14 @@
 #
 # Env:
 #   OVF_VERSION            marketing version (e.g. 0.4.0)          [required]
-#   OVF_BUILD              CFBundleVersion / sparkle:version       [default 1]
-#   SPARKLE_ED_PRIVATE_KEY the exported EdDSA private key string   [required]
+#   OVF_BUILD              CFBundleVersion / sparkle:version       [default: read from Info.plist]
+#   SPARKLE_ED_PRIVATE_KEY the exported EdDSA private key string   [REQUIRED — fails if unset]
 #   OVF_DOWNLOAD_BASE      URL prefix the DMG will be served from
 #                          [default https://openvoiceflow.vercel.app/downloads]
 #   SPARKLE_VERSION        Sparkle release to pull sign_update from [default 2.9.4]
 #
-# No-op (exit 0) if SPARKLE_ED_PRIVATE_KEY is unset — the release still ships a
-# notarized DMG; the appcast simply waits for the key.
+# REQUIRED for a release: fails loudly if SPARKLE_ED_PRIVATE_KEY is unset, since
+# shipping a DMG without a signed appcast silently breaks in-app updates.
 #
 set -euo pipefail
 

--- a/native/scripts/appcast.sh
+++ b/native/scripts/appcast.sh
@@ -23,8 +23,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # native/
 cd "$HERE"
 
 if [[ -z "${SPARKLE_ED_PRIVATE_KEY:-}" ]]; then
-  echo "▸ SPARKLE_ED_PRIVATE_KEY unset — skipping appcast (DMG still ships)."
-  exit 0
+  echo "::error::SPARKLE_ED_PRIVATE_KEY is required — a release without a signed appcast silently breaks in-app updates for every user."
+  exit 1
 fi
 
 : "${OVF_VERSION:?set OVF_VERSION}"


### PR DESCRIPTION
Launch-readiness pass — release/ops (from the full-codebase audit). No app or website content changes.

## Fixes
- **Wrong-product release footgun:** the legacy `release.yml` (Python app, PyPI + split DMGs) is still armed on `v*` tags. Added a guard that **refuses `v*` tags at 0.4.0+** — the native app ships from `native-v*` tags, so an accidental `v0.4.x` can no longer publish the retired Python app. Legit `0.3.x` patches still allowed.
- **Native Swift was never built/tested in CI:** added a `native-build` job (macos-15 / Xcode 16.4) that `xcodegen generate` + `xcodebuild`-compiles the app on every PR, so a broken `main` is caught here instead of at release time.
- **Version discipline:** `release-native.yml` now verifies all version sources agree (`Info.plist` `CFBundleShortVersionString` == tag base, `CFBundleVersion` == `project.yml` `CURRENT_PROJECT_VERSION`) **and** that the build number strictly exceeds the last published appcast — or Sparkle silently won't offer the update.
- **No more silent-no-update-feed releases:** the Sparkle appcast step is now **required** (dropped `continue-on-error`), and `appcast.sh` fails loudly if the signing key is missing, so a release can't go green while shipping a DMG with no update feed.

## Verification
- All three workflow YAMLs parse; `appcast.sh` passes `bash -n`; the version-guard logic was unit-checked (0.3.6 allowed, 0.4.0/0.4.2/1.0.0 blocked on the Python pipeline).
- The new `native-build` job will exercise itself on this PR, confirming `main`'s Swift compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_