### PR TITLE
feat(native): per-app dictation breakdown ("Where you dictate")

### DIFF
--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -242,9 +242,59 @@ struct DashboardView: View {
 
     // MARK: History
 
+    /// "Where you dictate" — a discreet, all-time per-app word breakdown that
+    /// sits above the History list. Kept off the Home pane on purpose: it's a
+    /// look-if-you-want stat, not a headline number. Single-hue (accent at
+    /// stepped opacity) so it stays on-palette; hides itself until there are at
+    /// least two apps to compare.
+    @ViewBuilder private var appBreakdown: some View {
+        let dist = history.appDistribution
+        if dist.count >= 2 {
+            let top = Array(dist.prefix(6))
+            let shownFraction = top.reduce(0.0) { $0 + $1.fraction }
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    Text("Where you dictate").font(.system(size: 13, weight: .bold)).foregroundStyle(ink)
+                    Text("by words, all time").font(.system(size: 11)).foregroundStyle(ink2)
+                }
+                GeometryReader { geo in
+                    HStack(spacing: 1.5) {
+                        ForEach(Array(top.enumerated()), id: \.offset) { i, row in
+                            Rectangle()
+                                .fill(accent.opacity(1.0 - Double(i) * 0.13))
+                                .frame(width: max(geo.size.width * row.fraction, 2))
+                        }
+                        if shownFraction < 0.999 {
+                            Rectangle().fill(dark ? Color.white.opacity(0.10) : Color.black.opacity(0.10))
+                        }
+                    }
+                }
+                .frame(height: 10)
+                .clipShape(Capsule())
+                VStack(spacing: 6) {
+                    ForEach(Array(top.enumerated()), id: \.offset) { i, row in
+                        HStack(spacing: 8) {
+                            Circle().fill(accent.opacity(1.0 - Double(i) * 0.13)).frame(width: 7, height: 7)
+                            Text(row.app).font(.system(size: 12)).foregroundStyle(ink).lineLimit(1)
+                            Spacer()
+                            Text("\(Int((row.fraction * 100).rounded()))%")
+                                .font(.system(size: 12, weight: .semibold)).foregroundStyle(ink)
+                            Text("\(row.words)").font(.system(size: 11)).foregroundStyle(ink2)
+                                .frame(width: 56, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+            .padding(16)
+            .background(RoundedRectangle(cornerRadius: 12).fill(card))
+            .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(hair))
+        }
+    }
+
     @ViewBuilder private var historyPane: some View {
         VStack(alignment: .leading, spacing: 14) {
             paneTitle("History")
+            appBreakdown
             if history.entries.isEmpty {
                 emptyPanel(
                     title: "Nothing here yet",

--- a/native/Sources/OpenVoiceFlow/FeatureStores.swift
+++ b/native/Sources/OpenVoiceFlow/FeatureStores.swift
@@ -237,21 +237,47 @@ final class HistoryStore: ObservableObject {
     @Published private(set) var entries: [HistoryEntry] { didSet { AppSupport.save(entries, to: "history.json") } }
     /// Persisted daily word totals keyed by yyyy-MM-dd (for the week chart + streak).
     @Published private(set) var dailyWords: [String: Int] { didSet { AppSupport.save(dailyWords, to: "stats.json") } }
+    /// Persisted lifetime word totals keyed by app name (for the per-app
+    /// breakdown). Kept separately from `entries` because `entries` is capped at
+    /// `maxEntries`, so it can't hold a lifetime total on its own.
+    @Published private(set) var appWords: [String: Int] { didSet { AppSupport.save(appWords, to: "app_stats.json") } }
 
     private static let maxEntries = 500
 
     init() {
-        entries = AppSupport.load([HistoryEntry].self, from: "history.json") ?? []
+        let loadedEntries = AppSupport.load([HistoryEntry].self, from: "history.json") ?? []
+        entries = loadedEntries
         dailyWords = AppSupport.load([String: Int].self, from: "stats.json") ?? [:]
+        // Seed the lifetime per-app totals from whatever history exists so the
+        // breakdown isn't empty for existing users; from then on it accumulates.
+        if let saved = AppSupport.load([String: Int].self, from: "app_stats.json") {
+            appWords = saved
+        } else {
+            let seeded = loadedEntries.reduce(into: [String: Int]()) { $0[$1.app, default: 0] += $1.words }
+            appWords = seeded
+            if !seeded.isEmpty { AppSupport.save(seeded, to: "app_stats.json") }
+        }
     }
 
     func record(app: String, text: String, words: Int, now: Date = Date()) {
         entries.insert(HistoryEntry(timestamp: now, app: app, text: text, words: words), at: 0)
         if entries.count > Self.maxEntries { entries.removeLast(entries.count - Self.maxEntries) }
         dailyWords[Self.key(now), default: 0] += words
+        appWords[app, default: 0] += words
     }
 
-    func clearAll() { entries = []; dailyWords = [:] }
+    func clearAll() { entries = []; dailyWords = [:]; appWords = [:] }
+
+    /// Lifetime word totals per app, largest first, each with its share of the
+    /// grand total. Powers the "Where you dictate" breakdown. Empty until there
+    /// is at least one recorded word.
+    var appDistribution: [(app: String, words: Int, fraction: Double)] {
+        let total = appWords.values.reduce(0, +)
+        guard total > 0 else { return [] }
+        return appWords
+            .map { (app: $0.key, words: $0.value, fraction: Double($0.value) / Double(total)) }
+            .sorted { $0.words > $1.words }
+    }
 
     // Stats derived from dailyWords.
     var wordsToday: Int { dailyWords[Self.key(Date())] ?? 0 }


### PR DESCRIPTION
Adds an all-time, per-app word distribution — where you use OpenVoiceFlow most, by percentage — surfaced **discreetly at the top of the History pane** (not on Home; a look-if-you-want stat, not a headline number). Queued for the **0.4.2 fast-follow**, after the on-device smoke test of 0.4.1.

## Why this was easy
Every dictation already records its frontmost app + word count (`HistoryStore.record(app:text:words:)`). This PR only **aggregates and displays** data we were already capturing — no new capture, no privacy change (all local, never sent).

## What changed
- **`FeatureStores.swift`** — `HistoryStore` gains a durable `appWords` accumulator (`app_stats.json`), incremented on every dictation alongside `dailyWords`. Kept separate from `entries` because that list is capped at 500 and can't hold a lifetime total. **Seeded once** from existing history so the breakdown isn't empty for current users, then accumulates. Reset by `clearAll()`. New `appDistribution` returns `(app, words, fraction)` sorted desc.
- **`DashboardView.swift`** — a compact **100% stacked bar + top-6 legend** (app name · % · word count) above the History list. Single-hue (accent at stepped opacity) to stay on-palette; hides itself until there are ≥2 apps to compare.

## Placement note
I put it at the top of **History** rather than Home or Settings: it's contextually a summary of your past dictations, and History is a secondary pane so it stays out of the way — matching the "somewhere not easily visible" intent. Trivial to move to Settings or Home if you'd rather.

## Verification
Linux-authored Swift; validated for style/scope against the current tree (all referenced helpers — `ink/ink2/accent/card/hair/dark` — exist). CI's `native-build` job compiles it; the on-device pass confirms rendering. No behavior change to the dictation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_