### PR TITLE
fix(native): don't label the per-app breakdown "all time" (Codex P2)

### DIFF
--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -255,7 +255,7 @@ struct DashboardView: View {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 8) {
                     Text("Where you dictate").font(.system(size: 13, weight: .bold)).foregroundStyle(ink)
-                    Text("by words, all time").font(.system(size: 11)).foregroundStyle(ink2)
+                    Text("by words").font(.system(size: 11)).foregroundStyle(ink2)
                 }
                 GeometryReader { geo in
                     HStack(spacing: 1.5) {

--- a/native/Sources/OpenVoiceFlow/FeatureStores.swift
+++ b/native/Sources/OpenVoiceFlow/FeatureStores.swift
@@ -237,9 +237,12 @@ final class HistoryStore: ObservableObject {
     @Published private(set) var entries: [HistoryEntry] { didSet { AppSupport.save(entries, to: "history.json") } }
     /// Persisted daily word totals keyed by yyyy-MM-dd (for the week chart + streak).
     @Published private(set) var dailyWords: [String: Int] { didSet { AppSupport.save(dailyWords, to: "stats.json") } }
-    /// Persisted lifetime word totals keyed by app name (for the per-app
+    /// Persisted running word totals keyed by app name (for the per-app
     /// breakdown). Kept separately from `entries` because `entries` is capped at
-    /// `maxEntries`, so it can't hold a lifetime total on its own.
+    /// `maxEntries`; this counter isn't capped, so it keeps accumulating past
+    /// that. Note the initial seed can only cover the entries still on disk (see
+    /// init) — a pre-existing heavy user's discarded takes aren't recoverable, so
+    /// the breakdown is framed as a distribution, not a complete all-time total.
     @Published private(set) var appWords: [String: Int] { didSet { AppSupport.save(appWords, to: "app_stats.json") } }
 
     private static let maxEntries = 500
@@ -248,8 +251,10 @@ final class HistoryStore: ObservableObject {
         let loadedEntries = AppSupport.load([HistoryEntry].self, from: "history.json") ?? []
         entries = loadedEntries
         dailyWords = AppSupport.load([String: Int].self, from: "stats.json") ?? [:]
-        // Seed the lifetime per-app totals from whatever history exists so the
-        // breakdown isn't empty for existing users; from then on it accumulates.
+        // Seed the per-app totals from whatever recent history is still on disk
+        // (entries are capped at maxEntries, so an existing heavy user's older
+        // takes can't be recovered) so the breakdown isn't empty on first run;
+        // from then on it accumulates exactly, take by take.
         if let saved = AppSupport.load([String: Int].self, from: "app_stats.json") {
             appWords = saved
         } else {
@@ -268,9 +273,9 @@ final class HistoryStore: ObservableObject {
 
     func clearAll() { entries = []; dailyWords = [:]; appWords = [:] }
 
-    /// Lifetime word totals per app, largest first, each with its share of the
-    /// grand total. Powers the "Where you dictate" breakdown. Empty until there
-    /// is at least one recorded word.
+    /// Word totals per app (a running count, seeded from recent history),
+    /// largest first, each with its share of the total. Powers the "Where you
+    /// dictate" breakdown. Empty until there is at least one recorded word.
     var appDistribution: [(app: String, words: Int, fraction: Double)] {
         let total = appWords.values.reduce(0, +)
         guard total > 0 else { return [] }


### PR DESCRIPTION
Follow-up to #41. Codex flagged (P2) that the "Where you dictate" breakdown labels its percentages **"all time,"** but the `appWords` seed can only draw from `history.json`, which is **capped at 500 entries** — so a pre-existing heavy user's older takes were already discarded and the seeded baseline is partial. Valid, and it conflicts with the project's no-overclaiming discipline.

## Fix
- **Drop "all time"** from the subtitle → just **"by words"**. The running counter is honest without a completeness claim.
- Reword the `appWords` / seed / `appDistribution` comments: it's a **running** per-app count seeded from recent history, not a recovered lifetime total. The seed's limitation (can't recover takes already evicted past the 500 cap) is now documented at the property.

No behavior change — from the first new dictation onward the counter is exact. The data was always local and never sent.

Queued with the 0.4.2 batch (same as #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_