### PR TITLE
feat(native): automatic background updates + honest in-app update cues

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -20,7 +20,12 @@
     <!-- Sparkle in-app updates. The appcast is served from the website root. -->
     <key>SUFeedURL</key><string>https://openvoiceflow.vercel.app/appcast.xml</string>
     <key>SUEnableInstallerLauncherService</key><false/>
-    <!-- Only check on launch/schedule, never auto-download silently. -->
+    <!-- Keep-me-updated by default: check on launch + once a day, and download
+         AND install new signed builds automatically (applied on the next
+         relaunch) so the user never hunts for a DMG. Sparkle still verifies each
+         build's EdDSA signature + Developer-ID notarization before installing.
+         The user can turn this off in Settings ▸ Automatic updates. -->
+    <key>SUAutomaticallyUpdate</key><true/>
     <key>SUScheduledCheckInterval</key><integer>86400</integer>
     <!--
       SUPublicEDKey: the EdDSA public key that verifies appcast signatures.

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -98,7 +98,10 @@ struct DashboardView: View {
 
             HStack(spacing: 6) {
                 Circle().fill(DT.moss).frame(width: 6, height: 6)
-                Text("v0.4.0 · up to date").font(.system(size: 11)).foregroundStyle(ink2)
+                Text(controller.settings.automaticUpdates
+                     ? "v\(UpdaterController.shared.appVersion) · auto-updating"
+                     : "v\(UpdaterController.shared.appVersion)")
+                    .font(.system(size: 11)).foregroundStyle(ink2)
             }
             .padding(.bottom, 12)
         }
@@ -564,6 +567,12 @@ struct DashboardView: View {
                     .font(.system(size: 12))
                 }
                 settingsToggle("Automatic updates", isOn: autoUpdateBinding)
+                settingsRow("You're on v\(UpdaterController.shared.appVersion)") {
+                    Button("Check for updates now") { UpdaterController.shared.checkForUpdates() }
+                        .buttonStyle(.plain).foregroundStyle(DT.emberLight)
+                        .font(.system(size: 12))
+                        .disabled(!UpdaterController.shared.canCheckForUpdates)
+                }
             }
         }
         .frame(maxWidth: 620, alignment: .leading)

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -15,6 +15,9 @@ struct DashboardView: View {
     @ObservedObject private var snippets: SnippetStore
     @ObservedObject private var styleStore: StyleStore
     @ObservedObject private var profileStore: ProfileStore
+    // Observe the updater so the "Check for updates now" CTA re-enables when a
+    // background check finishes.
+    @ObservedObject private var updater = UpdaterController.shared
     @State private var pane: Pane = .home
     @State private var showInterview = false
     @State private var apiKeyDraft = ""       // mirrors the Keychain key for the selected backend
@@ -99,8 +102,8 @@ struct DashboardView: View {
             HStack(spacing: 6) {
                 Circle().fill(DT.moss).frame(width: 6, height: 6)
                 Text(controller.settings.automaticUpdates
-                     ? "v\(UpdaterController.shared.appVersion) · auto-updating"
-                     : "v\(UpdaterController.shared.appVersion)")
+                     ? "v\(updater.appVersion) · auto-updating"
+                     : "v\(updater.appVersion)")
                     .font(.system(size: 11)).foregroundStyle(ink2)
             }
             .padding(.bottom, 12)
@@ -567,11 +570,11 @@ struct DashboardView: View {
                     .font(.system(size: 12))
                 }
                 settingsToggle("Automatic updates", isOn: autoUpdateBinding)
-                settingsRow("You're on v\(UpdaterController.shared.appVersion)") {
-                    Button("Check for updates now") { UpdaterController.shared.checkForUpdates() }
+                settingsRow("You're on v\(updater.appVersion)") {
+                    Button("Check for updates now") { updater.checkForUpdates() }
                         .buttonStyle(.plain).foregroundStyle(DT.emberLight)
                         .font(.system(size: 12))
-                        .disabled(!UpdaterController.shared.canCheckForUpdates)
+                        .disabled(!updater.canCheckForUpdates)
                 }
             }
         }

--- a/native/Sources/OpenVoiceFlow/Updater.swift
+++ b/native/Sources/OpenVoiceFlow/Updater.swift
@@ -24,18 +24,33 @@ final class UpdaterController {
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
-        // Honor the user's saved preference for background checks.
-        controller.updater.automaticallyChecksForUpdates = Settings.load().automaticUpdates
+        // Honor the user's saved preference for automatic updates.
+        apply(automatic: Settings.load().automaticUpdates)
+    }
+
+    /// The running app's marketing version (e.g. "0.4.2"), read from the bundle
+    /// so the UI never hardcodes it.
+    var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
     }
 
     /// Disabled while a check is already running (drives the menu item's state).
     var canCheckForUpdates: Bool { controller.updater.canCheckForUpdates }
 
-    /// Manual "Check for Updates…" — shows Sparkle's standard UI.
+    /// Manual "Check for Updates…" / "Check for updates now" — shows Sparkle's
+    /// standard UI so an on-demand check always has clear feedback.
     func checkForUpdates() { controller.checkForUpdates(nil) }
 
-    /// Toggle background appcast checks (Settings ▸ Automatic updates).
-    func setAutomaticChecks(_ enabled: Bool) {
-        controller.updater.automaticallyChecksForUpdates = enabled
+    /// Toggle automatic updates (Settings ▸ Automatic updates): both the daily
+    /// scheduled check and the silent background download+install.
+    func setAutomaticChecks(_ enabled: Bool) { apply(automatic: enabled) }
+
+    /// "Automatic" means check on the schedule AND download+install in the
+    /// background (installed on next relaunch). Sparkle requires downloads to be
+    /// gated behind checks, so both flip together. Signature + notarization are
+    /// still verified before any install.
+    private func apply(automatic: Bool) {
+        controller.updater.automaticallyChecksForUpdates = automatic
+        controller.updater.automaticallyDownloadsUpdates = automatic
     }
 }

--- a/native/Sources/OpenVoiceFlow/Updater.swift
+++ b/native/Sources/OpenVoiceFlow/Updater.swift
@@ -1,3 +1,4 @@
+import Combine
 import Sparkle
 
 /// In-app updates via Sparkle 2 with an EdDSA-signed appcast.
@@ -12,10 +13,17 @@ import Sparkle
 /// Store (native/README.md). Until an appcast is hosted and `SUPublicEDKey` is
 /// set, checks simply find nothing — Sparkle refuses unsigned updates by design.
 @MainActor
-final class UpdaterController {
+final class UpdaterController: ObservableObject {
     static let shared = UpdaterController()
 
     private let controller: SPUStandardUpdaterController
+    private var canCheckObservation: NSKeyValueObservation?
+
+    /// Mirrors Sparkle's `canCheckForUpdates` so SwiftUI re-renders the
+    /// "Check for updates now" CTA when a launch/scheduled check finishes —
+    /// otherwise the button, in a persistent window, could stay disabled until
+    /// the view happened to reload.
+    @Published private(set) var canCheckForUpdates = false
 
     private init() {
         // startingUpdater: true → background appcast checks begin immediately.
@@ -26,6 +34,14 @@ final class UpdaterController {
         )
         // Honor the user's saved preference for automatic updates.
         apply(automatic: Settings.load().automaticUpdates)
+        // Keep the published flag in sync with Sparkle's KVO-observable state.
+        canCheckForUpdates = controller.updater.canCheckForUpdates
+        canCheckObservation = controller.updater.observe(
+            \.canCheckForUpdates, options: [.new]
+        ) { [weak self] _, change in
+            guard let value = change.newValue else { return }
+            Task { @MainActor in self?.canCheckForUpdates = value }
+        }
     }
 
     /// The running app's marketing version (e.g. "0.4.2"), read from the bundle
@@ -33,9 +49,6 @@ final class UpdaterController {
     var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
     }
-
-    /// Disabled while a check is already running (drives the menu item's state).
-    var canCheckForUpdates: Bool { controller.updater.canCheckForUpdates }
 
     /// Manual "Check for Updates…" / "Check for updates now" — shows Sparkle's
     /// standard UI so an on-demand check always has clear feedback.


### PR DESCRIPTION
Implements the requested update UX: **keep-me-updated by default** — the user shouldn't have to notice a new DMG and install it by hand. Queued for the **0.4.2** batch.

## What changed
- **Automatic download + install** (`Info.plist` `SUAutomaticallyUpdate = true`; `Updater.swift` wires `automaticallyDownloadsUpdates`). Sparkle now downloads new signed builds in the background and installs them on the next relaunch — no manual step. The **daily** check cadence (86400s) is unchanged. Signature (EdDSA) + Developer-ID notarization are still verified before any install, so "automatic" stays safe.
- **Honest in-app cue.** The sidebar footer was hardcoded `v0.4.0 · up to date` (a literal string — wrong version, fake status). It now shows the **real** `CFBundleShortVersionString` + a subtle **"· auto-updating"** when automatic updates are on.
- **On-demand CTA.** Settings ▸ Privacy + Updates gains **"Check for updates now"** (with the current version), so an on-demand check is always one click away — in addition to the existing menu-bar item.
- **Master toggle** ("Automatic updates") now controls both the scheduled check and the background download+install together.

## Behavior summary
| | Automatic updates ON (default) | OFF |
|---|---|---|
| Daily check | yes | no |
| Download + install | background, applied on relaunch | never |
| On-demand "Check now" | yes | yes |

## Left as on-device polish (for the Mac agent)
A richer custom in-app banner ("update downloaded — relaunch to apply", with progress) needs Sparkle's user-driver callbacks, which want a device to wire + time correctly. Until then, Sparkle's **standard** ready-to-install prompt provides the "what to expect" indication, and the footer cue covers the ambient state.

## Verification
Linux-authored Swift; CI's `native-build` compiles it against real Sparkle (catches any API-shape issue). No change to the dictation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_