### PR TITLE
fix(native): recover from failed paste + hot-swap the transcription model

### DIFF
--- a/native/Sources/OpenVoiceFlow/AppController.swift
+++ b/native/Sources/OpenVoiceFlow/AppController.swift
@@ -123,6 +123,16 @@ final class AppController: ObservableObject {
         if isListening { stopListening(); startListening() }
     }
 
+    /// Change the transcription model at runtime so a Settings change takes
+    /// effect without an app restart: the live `Transcriber` drops its loaded
+    /// model and reloads the new one off the hot path.
+    func updateModel(_ name: String) {
+        guard name != settings.whisperModel else { return }
+        settings.whisperModel = name
+        settings.save()
+        Task { await transcriber.setModel(name) }
+    }
+
     // MARK: dictation loop
 
     private func startRecording() {
@@ -206,10 +216,17 @@ final class AppController: ObservableObject {
     /// Paste, log to history, bump stats, and flash the success HUD.
     private func deliver(_ text: String, app: String) {
         let words = text.split(whereSeparator: \.isWhitespace).count
-        if settings.autoPaste { Paster.paste(text) }
+        // Paste (if enabled). If the synthetic ⌘V couldn't be delivered — e.g.
+        // Accessibility was revoked — Paster keeps the text on the clipboard and
+        // returns false, and we nudge the user to paste it manually.
+        let pasted = settings.autoPaste ? Paster.paste(text) : true
         historyStore.record(app: app, text: text, words: words)
         lastError = nil
-        hud.show(.result(words: words), autoHideAfter: 1.8)  // holds ~1.8 s
+        if pasted {
+            hud.show(.result(words: words), autoHideAfter: 1.8)  // holds ~1.8 s
+        } else {
+            hud.show(.error(.pasteBlocked))
+        }
     }
 
     /// Tell the LLM to echo a snippet trigger verbatim so match() can expand it

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -544,7 +544,7 @@ struct DashboardView: View {
 
             settingsCard("TRANSCRIPTION — ON THIS MAC") {
                 settingsRow("Whisper model") {
-                    Picker("", selection: bind(\.whisperModel)) {
+                    Picker("", selection: whisperModelBinding) {
                         ForEach(whisperModelOptions, id: \.0) { Text($0.1).tag($0.0) }
                     }
                     .labelsHidden().pickerStyle(.menu).frame(width: 210)
@@ -664,6 +664,12 @@ struct DashboardView: View {
     /// Hotkey needs the tap restarted, so it goes through the controller.
     private var hotkeyBinding: Binding<Hotkey> {
         Binding(get: { controller.settings.hotkey }, set: { controller.updateHotkey($0) })
+    }
+
+    /// Whisper model swaps the live transcriber, so it goes through the controller
+    /// (a plain `bind` would only persist the value, not reload the model).
+    private var whisperModelBinding: Binding<String> {
+        Binding(get: { controller.settings.whisperModel }, set: { controller.updateModel($0) })
     }
 
     /// Cleanup on/off: off ⇒ `.none` (local raw), on ⇒ Anthropic by default.

--- a/native/Sources/OpenVoiceFlow/Paster.swift
+++ b/native/Sources/OpenVoiceFlow/Paster.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import CoreGraphics
 
 /// Inserts text at the cursor by placing it on the pasteboard and synthesizing
@@ -10,13 +11,27 @@ import CoreGraphics
 enum Paster {
     private static let vKeyCode: CGKeyCode = 0x09  // kVK_ANSI_V
 
-    /// Paste `text` at the current cursor. Preserves the user's clipboard,
-    /// including non-text contents (images/files), by snapshotting and
+    /// Paste `text` at the current cursor and report whether the synthetic paste
+    /// could actually be delivered. Preserves the user's clipboard (including
+    /// non-text contents like images/files) on success by snapshotting and
     /// restoring the pasteboard items.
-    static func paste(_ text: String) {
+    ///
+    /// If the process isn't trusted for Accessibility, `CGEventPost` is silently
+    /// dropped — so rather than paste into the void *and* wipe the clipboard, we
+    /// leave the dictated text on the clipboard (no restore) and return `false`
+    /// so the caller can tell the user to press ⌘V.
+    @discardableResult
+    static func paste(_ text: String) -> Bool {
         let pb = NSPasteboard.general
-        let saved = snapshot(pb)
 
+        guard AXIsProcessTrusted() else {
+            // Can't synthesize ⌘V — keep the text on the clipboard for a manual paste.
+            pb.clearContents()
+            pb.setString(text, forType: .string)
+            return false
+        }
+
+        let saved = snapshot(pb)
         pb.clearContents()
         pb.setString(text, forType: .string)
 
@@ -26,6 +41,7 @@ enum Paster {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             restore(saved, to: pb)
         }
+        return true
     }
 
     private static func sendCommandV() {

--- a/native/Sources/OpenVoiceFlow/Transcriber.swift
+++ b/native/Sources/OpenVoiceFlow/Transcriber.swift
@@ -8,10 +8,23 @@ actor Transcriber {
     typealias DownloadProgressObserver = @Sendable (Double) -> Void
 
     private var kit: WhisperKit?
-    private let modelName: String
+    private var modelName: String
 
     init(model: String = "base.en") {
         self.modelName = model
+    }
+
+    /// Switch the transcription model at runtime so a Settings change takes
+    /// effect without an app restart: drop the loaded model and reload the new
+    /// one. Best-effort — if the reload fails, the next `transcribe` re-tries
+    /// warmUp (and can recover a truncated download). Note the shipped default
+    /// `base.en` is English-only; a non-English language needs a multilingual
+    /// model (the Settings picker offers them).
+    func setModel(_ name: String) async {
+        guard name != modelName else { return }
+        modelName = name
+        kit = nil
+        try? await warmUp()
     }
 
     /// Load the model once (lazily). The observer receives only actual


### PR DESCRIPTION
The two 0.4.2 hardening majors Meeru confirmed still open on `main` (paste data loss; model/language needs a restart). **For Meeru to compile + validate on-device** — this replaces the empty local `fix/native-042-hardening` branch (build from here).

## 1. Paste data loss → graceful recovery
`Paster.paste` unconditionally restored the clipboard even when the synthetic ⌘V couldn't be delivered (e.g. Accessibility revoked), so the dictated text was *both* un-pasted *and* wiped.
- Now gates on `AXIsProcessTrusted()`: if not trusted, it **leaves the text on the clipboard** (no restore) and returns `false`.
- `AppController.deliver` surfaces the **already-wired** HUD `.pasteBlocked` state — *"Copied instead — press ⌘V."* with a **"Grant Access"** button that opens Accessibility settings.
- Net: the text is always recoverable via ⌘V instead of silently lost.

## 2. Model/language hot-swap
`Transcriber` bound the model at `init` with no setter, so a Settings change needed a restart (and the default `base.en` can't transcribe non-English).
- `Transcriber.modelName` is now mutable; `setModel(_:)` drops the loaded model and reloads.
- `AppController.updateModel` routes Settings changes to it; the dashboard's **Whisper-model picker** uses that path (`whisperModelBinding`).
- Language already applied per-transcription — switching to a **multilingual** model (the picker offers tiny/small/medium/large-v3-turbo) now takes effect live.

## On-device checks for Meeru
- Revoke Accessibility → dictate → confirm the HUD shows "Copied instead — press ⌘V", the text is on the clipboard, and "Grant Access" opens the right settings pane. Re-grant → normal paste resumes.
- Switch Whisper model in Settings → next dictation uses it with **no restart**. Pick a multilingual model + a non-English language → confirm non-English transcription.

## Verification
Linux-authored Swift; CI `native-build` compiles it. Single `Paster.paste` call site updated; `.pasteBlocked` HUD wiring already existed. No release/site changes here — those stay gated on the on-device pass + version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_