### PR TITLE
chore(native): bump version to 0.4.2 (build 3)

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.4.1</string>
-    <key>CFBundleVersion</key><string>2</string>
+    <key>CFBundleShortVersionString</key><string>0.4.2</string>
+    <key>CFBundleVersion</key><string>3</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Menu-bar agent: no Dock icon, no main window on launch. -->
     <key>LSUIElement</key><true/>

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.4.1
-        CURRENT_PROJECT_VERSION: 2
+        MARKETING_VERSION: 0.4.2
+        CURRENT_PROJECT_VERSION: 3
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
Prepares the **0.4.2** release. All the 0.4.2 code is already merged (#41–#44); this is the version stamp the release + appcast agreement guard requires.

- `native/project.yml`: `MARKETING_VERSION 0.4.2`, `CURRENT_PROJECT_VERSION 3`
- `native/Info.plist`: `CFBundleShortVersionString 0.4.2`, `CFBundleVersion 3`

Build **3** > the live appcast's build 2, so existing 0.4.1 installs will see 0.4.2 as an update. No behavior change.

After this merges, pushing the `native-v0.4.2` tag triggers `release-native.yml`, which builds the signed/notarized DMG + signed appcast using the repo's existing Apple + Sparkle secrets (no local credentials needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_