### PR TITLE
chore(site): canonicalize OpenVoiceFlow custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ speak. The reliable batch recorder is the default.
 
 For the simplest signed install, download OpenVoiceFlow from the website. The source repository is public for anyone who prefers to inspect or install from source.
 
-- **Download page:** <https://openvoiceflow.vercel.app/download.html>
-- **Apple Silicon DMG:** <https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.3.6-arm64.dmg>
-- **Intel DMG:** <https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg>
+- **Download page:** <https://openvoiceflow.com/download.html>
+- **Apple Silicon DMG:** <https://openvoiceflow.com/downloads/OpenVoiceFlow-0.3.6-arm64.dmg>
+- **Intel DMG:** <https://openvoiceflow.com/downloads/OpenVoiceFlow-0.3.6-x86_64.dmg>
 
 Open the website-hosted DMG, drag OpenVoiceFlow to Applications, then launch it.
 

--- a/docs/download.html
+++ b/docs/download.html
@@ -7,12 +7,12 @@
   <meta name="description" content="Download OpenVoiceFlow, the free macOS voice dictation app. Website-hosted DMG links, checksums, source access notes, and platform notes." />
   <meta property="og:title" content="Download OpenVoiceFlow for macOS" />
   <meta property="og:description" content="Website-hosted DMG downloads, SHA-256 checksums, and source access notes for OpenVoiceFlow." />
-  <meta property="og:url" content="https://openvoiceflow.vercel.app/download.html" />
+  <meta property="og:url" content="https://openvoiceflow.com/download.html" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
-  <link rel="canonical" href="https://openvoiceflow.vercel.app/download.html" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/download.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
@@ -24,8 +24,8 @@
     "operatingSystem": "macOS 14+",
     "applicationCategory": "UtilitiesApplication",
     "softwareVersion": "0.4.2",
-    "url": "https://openvoiceflow.vercel.app/download.html",
-    "downloadUrl": "https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.4.2.dmg",
+    "url": "https://openvoiceflow.com/download.html",
+    "downloadUrl": "https://openvoiceflow.com/downloads/OpenVoiceFlow-0.4.2.dmg",
     "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}
   }
   </script>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -7,12 +7,12 @@
   <meta name="description" content="Learn how OpenVoiceFlow records locally, transcribes with on-device WhisperKit, applies voice commands, optionally cleans text with an LLM, and pastes at your cursor." />
   <meta property="og:title" content="How OpenVoiceFlow Works" />
   <meta property="og:description" content="The local-audio-first OpenVoiceFlow dictation pipeline explained." />
-  <meta property="og:url" content="https://openvoiceflow.vercel.app/how-it-works.html" />
+  <meta property="og:url" content="https://openvoiceflow.com/how-it-works.html" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
-  <link rel="canonical" href="https://openvoiceflow.vercel.app/how-it-works.html" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/how-it-works.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,14 +8,14 @@
   <meta name="keywords" content="voice dictation macOS, Wispr Flow alternative, whisper dictation, free voice dictation mac, local transcription" />
   <meta property="og:title" content="OpenVoiceFlow — Free Voice Dictation for macOS" />
   <meta property="og:description" content="Speak. It types. Free forever, and your audio never leaves your Mac. Push-to-talk dictation with local on-device WhisperKit transcription." />
-  <meta property="og:url" content="https://openvoiceflow.vercel.app/" />
+  <meta property="og:url" content="https://openvoiceflow.com/" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="OpenVoiceFlow — Free Voice Dictation for macOS" />
   <meta name="twitter:description" content="Free voice dictation for macOS. $0 forever." />
-  <meta name="twitter:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
-  <link rel="canonical" href="https://openvoiceflow.vercel.app/" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/" />
 
   <!-- Waveform-ring favicon (brand glyph) -->
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
@@ -37,8 +37,8 @@
       "price": "0",
       "priceCurrency": "USD"
     },
-    "url": "https://openvoiceflow.vercel.app/",
-    "downloadUrl": "https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.4.2.dmg"
+    "url": "https://openvoiceflow.com/",
+    "downloadUrl": "https://openvoiceflow.com/downloads/OpenVoiceFlow-0.4.2.dmg"
   }
   </script>
   <script>

--- a/docs/install.html
+++ b/docs/install.html
@@ -7,12 +7,12 @@
   <meta name="description" content="Step-by-step OpenVoiceFlow install guide for macOS, including DMG install, source install, backend setup, permissions, and troubleshooting." />
   <meta property="og:title" content="Install OpenVoiceFlow on macOS" />
   <meta property="og:description" content="DMG install, source install, permissions, backend setup, and troubleshooting." />
-  <meta property="og:url" content="https://openvoiceflow.vercel.app/install.html" />
+  <meta property="og:url" content="https://openvoiceflow.com/install.html" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
-  <link rel="canonical" href="https://openvoiceflow.vercel.app/install.html" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/install.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,12 +4,12 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 
 ## Priority pages
 
-- Homepage: https://openvoiceflow.vercel.app/
-- Download page: https://openvoiceflow.vercel.app/download.html
-- Install guide: https://openvoiceflow.vercel.app/install.html
-- How it works: https://openvoiceflow.vercel.app/how-it-works.html
-- Website-hosted universal macOS DMG (v0.4.2): https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.4.2.dmg
-- Website-hosted macOS 12–13 fallback (v0.3.6 Apple Silicon): https://openvoiceflow.vercel.app/downloads/OpenVoiceFlow-0.3.6-arm64.dmg
+- Homepage: https://openvoiceflow.com/
+- Download page: https://openvoiceflow.com/download.html
+- Install guide: https://openvoiceflow.com/install.html
+- How it works: https://openvoiceflow.com/how-it-works.html
+- Website-hosted universal macOS DMG (v0.4.2): https://openvoiceflow.com/downloads/OpenVoiceFlow-0.4.2.dmg
+- Website-hosted macOS 12–13 fallback (v0.3.6 Apple Silicon): https://openvoiceflow.com/downloads/OpenVoiceFlow-0.3.6-arm64.dmg
 - Public MIT source repository: https://github.com/shimoverse/openvoiceflow
 
 ## Key facts

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -7,12 +7,12 @@
   <meta name="description" content="OpenVoiceFlow privacy policy: on-device WhisperKit transcription, API keys in the macOS Keychain, cleanup Off by default, and what leaves your Mac only if you turn on cloud cleanup." />
   <meta property="og:title" content="OpenVoiceFlow Privacy" />
   <meta property="og:description" content="On-device transcription, Keychain-stored keys, cleanup Off by default. What stays on your Mac and what leaves only when you choose." />
-  <meta property="og:url" content="https://openvoiceflow.vercel.app/privacy.html" />
+  <meta property="og:url" content="https://openvoiceflow.com/privacy.html" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://openvoiceflow.vercel.app/assets/og-card.png" />
-  <link rel="canonical" href="https://openvoiceflow.vercel.app/privacy.html" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/privacy.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="style.css" />
   <script>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://openvoiceflow.vercel.app/sitemap.xml
+Sitemap: https://openvoiceflow.com/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://openvoiceflow.vercel.app/</loc>
+    <loc>https://openvoiceflow.com/</loc>
     <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://openvoiceflow.vercel.app/download.html</loc>
+    <loc>https://openvoiceflow.com/download.html</loc>
     <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://openvoiceflow.vercel.app/install.html</loc>
+    <loc>https://openvoiceflow.com/install.html</loc>
     <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://openvoiceflow.vercel.app/how-it-works.html</loc>
+    <loc>https://openvoiceflow.com/how-it-works.html</loc>
     <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://openvoiceflow.vercel.app/privacy.html</loc>
+    <loc>https://openvoiceflow.com/privacy.html</loc>
     <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ dev = [
 openvoiceflow = "voiceflow.__main__:main"
 
 [project.urls]
-Homepage = "https://openvoiceflow.vercel.app/"
-Download = "https://openvoiceflow.vercel.app/download.html"
+Homepage = "https://openvoiceflow.com/"
+Download = "https://openvoiceflow.com/download.html"
 Source = "https://github.com/shimoverse/openvoiceflow"
 Issues = "https://github.com/shimoverse/openvoiceflow/issues"
 

--- a/tests/test_docs_distribution.py
+++ b/tests/test_docs_distribution.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
-CANONICAL = "https://openvoiceflow.vercel.app"
+CANONICAL = "https://openvoiceflow.com"
 RELEASE_VERSION = "0.4.2"
 UNIVERSAL_SHA256 = "6a4bbbf78e131653039432f9e31e4df3d33599f6630866a314ddcd7e552fa811"
 FALLBACK = "OpenVoiceFlow-0.3.6-arm64.dmg"

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,17 @@
   "installCommand": "npm install --ignore-scripts",
   "redirects": [
     {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.openvoiceflow.com"
+        }
+      ],
+      "destination": "https://openvoiceflow.com/$1",
+      "permanent": true
+    },
+    {
       "source": "/downloads/OpenVoiceFlow-0.2.0-arm64.dmg",
       "destination": "/downloads/OpenVoiceFlow-0.4.2.dmg",
       "permanent": true


### PR DESCRIPTION
## Summary
- makes https://openvoiceflow.com the human-facing canonical URL
- redirects www.openvoiceflow.com to the apex
- preserves legacy Vercel-hosted Sparkle feed and download paths

## Verification
- distribution assertions passed via direct Python execution (pytest shim is unavailable locally)
- git diff --check passed
- custom-domain DNS configured in Porkbun and attached to the existing Vercel project