### PR TITLE
feat(site): expand privacy-friendly observability

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -115,7 +115,7 @@ Anything you've already sent to OpenRouter lives by that provider's retention po
 
 ## 7. This website
 
-The download site (`openvoiceflow.vercel.app`) uses **Vercel Analytics**, a privacy-friendly measurement product, to count anonymous page views and download/install-guide events. It sets no advertising cookies, builds no cross-site profile, and does not link a visit to an individual. This is **website** measurement only and is separate from the app, which contains no analytics. Vercel's analytics privacy notice: <https://vercel.com/docs/analytics/privacy-policy>.
+The download site (`openvoiceflow.com`) uses **Vercel Analytics** and **Vercel Speed Insights**. Analytics measures anonymous page views, aggregated visitor/referrer/geography trends, and selected website actions such as download, install-guide, navigation, and GitHub-source clicks. Speed Insights measures aggregated real-user page performance. These services set no advertising cookies, build no cross-site profile, and do not link a visit to an individual. This is **website** measurement only and is separate from the app, which contains no analytics. Vercel's analytics privacy notice: <https://vercel.com/docs/analytics/privacy-policy>.
 
 ---
 

--- a/docs/download.html
+++ b/docs/download.html
@@ -33,6 +33,7 @@
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body>
   <nav class="nav" id="nav" aria-label="Main">

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -22,6 +22,7 @@
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body>
   <nav class="nav" id="nav" aria-label="Main">

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,6 +45,7 @@
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -22,6 +22,7 @@
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body>
   <nav class="nav" id="nav" aria-label="Main">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -19,6 +19,7 @@
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body>
   <nav class="nav" id="nav" aria-label="Main">
@@ -93,7 +94,7 @@
 
       <section class="content-card">
         <h2>This website</h2>
-        <p>The download site uses privacy-friendly <a href="https://vercel.com/docs/analytics/privacy-policy">Vercel Analytics</a> to count anonymous page views and download events. It sets no advertising cookies, builds no cross-site profile, and never links a visit to an individual. This is website measurement only — the app itself contains no analytics or telemetry.</p>
+        <p>The download site uses privacy-friendly <a href="https://vercel.com/docs/analytics/privacy-policy">Vercel Analytics</a> for anonymous page views, aggregated visitor/referrer/geography trends, and selected website actions such as download, install-guide, navigation, and GitHub-source clicks. It also uses Vercel Speed Insights for aggregated real-user page-performance measurement. These services set no advertising cookies, build no cross-site profile, and never link a visit to an individual. This is website measurement only — the app itself contains no analytics or telemetry.</p>
       </section>
 
       <section class="content-card">

--- a/docs/site.js
+++ b/docs/site.js
@@ -245,6 +245,30 @@
       track('install_guide_click', { source_path: pathname() });
     });
   });
+
+  document.querySelectorAll('.nav a[href]').forEach(link => {
+    link.addEventListener('click', () => {
+      track('navigation_click', {
+        destination: link.getAttribute('href') || '',
+        source_path: pathname(),
+      });
+    });
+  });
+
+  document.querySelectorAll('.hero-cta-row a[href]').forEach(link => {
+    link.addEventListener('click', () => {
+      track('hero_cta_click', {
+        destination: link.getAttribute('href') || '',
+        source_path: pathname(),
+      });
+    });
+  });
+
+  document.querySelectorAll('a[href*="github.com/shimoverse/openvoiceflow"]').forEach(link => {
+    link.addEventListener('click', () => {
+      track('github_click', { source_path: pathname() });
+    });
+  });
 })();
 
 /* ── Waveform identity ──────────────────────────────────────────────────

--- a/tests/test_docs_distribution.py
+++ b/tests/test_docs_distribution.py
@@ -57,3 +57,19 @@ def test_public_downloads_remain_website_hosted():
     combined = "\n".join((DOCS / name).read_text(encoding="utf-8") for name in pages)
     assert "github.com/shimoverse/openvoiceflow/releases/download" not in combined
     assert CANONICAL in (DOCS / "download.html").read_text(encoding="utf-8")
+
+
+def test_privacy_friendly_web_observability_is_present_without_native_telemetry():
+    public_pages = ["index.html", "download.html", "install.html", "how-it-works.html", "privacy.html"]
+    for page in public_pages:
+        html = (DOCS / page).read_text(encoding="utf-8")
+        assert "va.vercel-scripts.com/v1/script.js" in html
+        assert "/_vercel/speed-insights/script.js" in html
+
+    site_js = (DOCS / "site.js").read_text(encoding="utf-8")
+    for event in ["download_click", "install_guide_click", "navigation_click", "hero_cta_click", "github_click"]:
+        assert event in site_js
+
+    privacy = (ROOT / "PRIVACY.md").read_text(encoding="utf-8")
+    assert "No in-app telemetry" in privacy
+    assert "Vercel Speed Insights" in privacy


### PR DESCRIPTION
## Summary
- adds Vercel Speed Insights to every public page
- expands existing Vercel Analytics coverage for navigation, hero CTA, and GitHub clicks
- keeps native macOS telemetry and crash reporting disabled
- updates privacy disclosures and regression coverage

## Verification
- `npm run vercel-build` passed
- all distribution assertions passed through direct Python execution
- `git diff --check` passed