### PR TITLE
Sign the DMG itself, so the 0.5.0 release can build

### DIFF
--- a/native/design/MEERU_0.5.0_HANDOFF.md
+++ b/native/design/MEERU_0.5.0_HANDOFF.md
@@ -1,0 +1,168 @@
+# 0.5.0 release — handoff to Meeru
+
+**Written 2026-07-26.** Read the "Where things stand" section first; some of
+this is mid-flight and the state matters.
+
+## What 0.5.0 is
+
+The phase-06 design redesign of the native macOS app: first-run onboarding, the
+dictation HUD, and the dashboard Home pane. Nine work items (T1–T9), merged to
+`main` as commit `112607d` via PR #51.
+
+The important property for you: **it was written entirely on a Linux machine.**
+The Swift compiles — GitHub's macOS runners verified every commit — but nothing
+in it has ever been *run*. For a release whose whole point is how it looks, that
+is the gap you're being asked to close.
+
+## Where things stand
+
+| Step | State |
+| --- | --- |
+| Code merged to `main` | Done — `112607d` |
+| Tag `native-v0.5.0` pushed | Done — points at `112607d` |
+| Release build (signed DMG + appcast) | **FAILED**, then fixed; needs a re-run |
+| Website updated to 0.5.0 | Not started — blocked on the DMG existing |
+| The nine visual checks | Not started — needs a Mac |
+
+### Why the release build failed
+
+`spctl -a -vvv -t install` rejected the DMG with `no usable signature`.
+
+The cause is a real, pre-existing gap, not a fluke. The pipeline signed the
+`.app`, notarized it, notarized the DMG, and stapled a ticket to the DMG — but
+it **never code-signed the DMG itself**. `spctl -t install` evaluates a disk
+image against its own signature, and a stapled ticket is not a signature.
+
+This went unnoticed through 0.4.1, 0.4.2 and 0.4.3 because that check ended in
+`|| true` and silently swallowed the rejection. Phase 06 made the check
+blocking, which is what surfaced it — the check is doing its job; the pipeline
+was the thing that was wrong.
+
+**This did not harm users.** The app inside the DMG was always properly signed
+and notarized, which is why 0.4.3 gives the mild "downloaded from the
+Internet → Open" prompt rather than a hard refusal. The fix closes a real gap,
+it doesn't repair a shipped defect.
+
+The fix adds `codesign --force --timestamp --sign "$OVF_SIGN_IDENTITY"` to the
+DMG, **before** notarization — signing after stapling would invalidate the
+ticket.
+
+## Task A — get the release built
+
+By the time you read this the fix may already be merged and the tag moved. Check
+first:
+
+```bash
+gh run list --workflow=release-native.yml --limit 3
+gh release view native-v0.5.0
+```
+
+If a green run and a release with an attached DMG exist, skip to Task B.
+
+If not, the fix is in `native/scripts/build-app.sh`. The tag must point at a
+commit that *contains* the fix, because the workflow checks out the tag:
+
+```bash
+git fetch origin main && git checkout main && git pull
+git tag -f native-v0.5.0 && git push -f origin native-v0.5.0
+```
+
+### If it fails again
+
+The signing step is the only untested part — nobody has run `codesign` against
+a DMG in this pipeline before. Two plausible failures:
+
+- **`codesign` can't find the identity.** The keychain is unlocked earlier in
+  the workflow for the app signing, so the identity is present; if this fails,
+  print `security find-identity -v -p codesigning` in the step to see what the
+  runner actually has.
+- **`spctl` still rejects it.** Then the assertion is stricter than this
+  distribution model supports, and the honest fix is to drop the `spctl` check
+  and keep `stapler validate` — which is what actually governs the user-facing
+  prompt. Do **not** restore `|| true`; that hides failures rather than
+  deciding about them. Say which you did and why.
+
+## Task B — the nine things only eyes can check
+
+This is the part that genuinely needs you, and it matters more than Task A.
+
+Build and run the app locally:
+
+```bash
+git clone https://github.com/shimoverse/openvoiceflow.git ~/ovf-test \
+  && cd ~/ovf-test && bash native/scripts/run-local.sh
+```
+
+Then work through **`native/design/PHASE06_TRY_IT.md`**, which lists the nine
+checks in the order you hit them, phrased as what to look for. The two highest
+value:
+
+1. **Light mode.** The old build forced a dark window regardless of system
+   appearance. Log in with Appearance: Light and confirm nothing stayed dark and
+   no text is too faint. This is the single most likely place for a missed
+   hardcoded colour.
+2. **A live permission grant.** At the permissions step, grant Accessibility in
+   System Settings while leaving the onboarding window frontmost, and *do not*
+   click back into it. The dot should turn green within ~1 s on its own. The old
+   build only noticed on refocus, so it looked frozen.
+
+`native/design/PHASE06_ACCEPTANCE.md` has all 19 checks with what backs each —
+ten are settled by source or CI, nine are yours.
+
+Report findings in plain language. Anything that looks wrong is worth saying
+even if you're unsure it's a bug.
+
+## Task C — the website
+
+**Do not start this until the release exists and has a real DMG.** The download
+page must never point at a missing file, and the sha256 must be computed from
+the published artifact — never hand-written.
+
+The page also carries three "what happens next" cards added in this release
+(drag to Applications / open it yourself / macOS will warn you once). Those are
+version-independent — leave them alone.
+
+What changes: the DMG in `docs/downloads/`, the sha256 (appears twice — the
+displayed line and the copy button's `data-copy`), the version strings in
+`docs/download.html`, `docs/appcast.xml`, and `RELEASE_VERSION` /
+`UNIVERSAL_SHA256` in `tests/test_docs_distribution.py`. That test asserts the
+checksum matches the file on disk, so it will catch a mismatch — run
+`pytest tests/test_docs_distribution.py` before pushing.
+
+Verify the digest against what GitHub published rather than trusting a local
+copy:
+
+```bash
+gh release download native-v0.5.0 --pattern '*.dmg' --dir /tmp/rel
+shasum -a 256 /tmp/rel/OpenVoiceFlow-0.5.0.dmg
+```
+
+I can do this part from here once the release exists — coordinate so we don't
+both do it.
+
+## Two hard constraints
+
+**Never regenerate the Sparkle keypair.** `SUPublicEDKey` in
+`native/Info.plist` is live. The private half is the repo secret
+`SPARKLE_ED_PRIVATE_KEY`. Every shipped install verifies updates against that
+public key, so a new keypair permanently breaks auto-update for everyone who
+already has the app. There is no recovery path. If anything suggests
+regenerating it, stop and ask.
+
+**The build number must keep climbing.** Sparkle orders updates by
+`CFBundleVersion`, not the marketing version. 0.5.0 is build 5; the live
+appcast is build 4. If you cut another build, increment it — an equal or lower
+number means clients never see the update, with no error to explain why.
+
+## One thing to weigh before releasing
+
+Once the release publishes, existing 0.4.3 installs auto-update to 0.5.0 within
+about a day. That happens whether or not anyone has looked at the redesign.
+
+If the visual checks in Task B haven't been done, consider doing them before
+the release publishes rather than after. The build finishing is not the same as
+it reaching people, and deleting an unreleased GitHub Release is cheap;
+recalling an auto-update is not.
+
+Owner's call, not yours or mine — but say so if you're being asked to publish
+before anyone has seen it.

--- a/native/scripts/build-app.sh
+++ b/native/scripts/build-app.sh
@@ -121,6 +121,22 @@ ln -s /Applications "$STAGE/Applications"
 hdiutil create -volname "OpenVoiceFlow $VERSION" \
   -srcfolder "$STAGE" -ov -format UDZO "$DMG"
 
+# ── sign the DMG itself ─────────────────────────────────────────────────────
+#
+# Not the same as signing the app inside it. Until 0.4.3 only the .app was
+# signed; the DMG carried a stapled notarization ticket but no signature of its
+# own, and `spctl -a -t install` evaluates the disk image against its own
+# signature — a ticket is not one. That went unnoticed because the spctl check
+# ended in `|| true` and swallowed the rejection.
+#
+# Must happen BEFORE notarizing: notarization staples a ticket to this exact
+# artifact, and signing afterwards would invalidate it.
+if [[ "$NOTARIZE" == "1" ]]; then
+  echo "▸ Signing the DMG"
+  codesign --force --timestamp --sign "$OVF_SIGN_IDENTITY" "$DMG" \
+    || { echo "::error::could not sign the DMG with $OVF_SIGN_IDENTITY"; exit 1; }
+fi
+
 # ── notarize + staple the DMG (offline Gatekeeper for the download) ─────────
 if [[ "$NOTARIZE" == "1" ]]; then
   echo "▸ Notarizing the DMG"


### PR DESCRIPTION
The `native-v0.5.0` release build failed:

```
dist/OpenVoiceFlow-0.5.0.dmg: rejected
source=no usable signature
::error::Gatekeeper rejected the DMG; it would not offer an Open button
```

## What's actually wrong

The rejection is correct. The pipeline signs the `.app`, notarizes it,
notarizes the DMG, and staples a ticket to the DMG — but never **code-signs the
DMG itself**. `spctl -a -t install` evaluates a disk image against its own
signature, and a stapled notarization ticket is not a signature.

This has been true since 0.4.1. It went unnoticed because the check ended in
`|| true` and swallowed the rejection every time. Phase 06 made the check
blocking, which is what surfaced it.

**No shipped release was harmed.** The app inside the DMG was always signed and
notarized — that's why 0.4.3 shows the mild "downloaded from the Internet →
Open" prompt rather than a hard refusal. This closes a gap; it doesn't repair a
user-facing defect.

## The fix

`codesign --force --timestamp --sign "$OVF_SIGN_IDENTITY"` on the DMG, placed
**before** notarization — notarization staples to that exact artifact, so
signing afterwards would invalidate the ticket.

## A correction to PR #51

I described this check there as one that "was lying." That was wrong, and worth
stating plainly: the check was failing *honestly* and being ignored. Making it
blocking didn't fix a lie — it exposed an unsigned artifact. The assertion could
not have passed on any release before this change.

## Also here

`native/design/MEERU_0.5.0_HANDOFF.md` — the current release state, how to
re-run it, what to try if the new signing step fails on the runner (nobody has
run `codesign` against a DMG in this pipeline yet), the nine acceptance checks
that need a real Mac, and two constraints worth having in writing: never
regenerate the Sparkle keypair, and never let `CFBundleVersion` stall.

## Note

The `spctl` step is the one part of this that cannot be verified from Linux. If
it still rejects the DMG after signing, the assertion is stricter than this
distribution model supports and the right move is to drop `spctl` and keep
`stapler validate` — not to restore `|| true`, which hides the answer instead
of deciding it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_