### PR TITLE
Start listening at launch; kill the Start Dictation ritual (0.5.1)

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.0</string>
-    <key>CFBundleVersion</key><string>5</string>
+    <key>CFBundleShortVersionString</key><string>0.5.1</string>
+    <key>CFBundleVersion</key><string>6</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a
          regular app would auto-present it at every launch, on top of first-run

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -22,6 +22,11 @@ struct DashboardView: View {
     @State private var showInterview = false
     @State private var apiKeyDraft = ""       // mirrors the Keychain key for the selected backend
     @State private var showDeleteHistory = false
+    // Live TCC statuses for the Settings permissions card. Polled (not
+    // event-driven) because a grant can land in System Settings while this
+    // window stays key — see Permission.watch.
+    @State private var permissionStatus: [Permission: Permission.Status] = [:]
+    @State private var permissionWatch: Task<Void, Never>?
     @Environment(\.colorScheme) private var scheme
 
     init(controller: AppController) {
@@ -698,6 +703,8 @@ struct DashboardView: View {
         VStack(alignment: .leading, spacing: 16) {
             paneTitle("Settings")
 
+            permissionsCard
+
             settingsCard("DICTATION") {
                 settingsRow("Hotkey") {
                     Picker("", selection: hotkeyBinding) {
@@ -757,7 +764,50 @@ struct DashboardView: View {
             }
         }
         .frame(maxWidth: 620, alignment: .leading)
-        .onAppear { reloadAPIKeyDraft() }
+        .onAppear {
+            reloadAPIKeyDraft()
+            permissionWatch = Permission.watch { statuses in
+                permissionStatus = statuses
+                // A revoked permission is also why the key listener would be
+                // down, so the moment the user grants it back, come back to
+                // life rather than waiting for a relaunch.
+                if !controller.isListening && !controller.isPaused {
+                    _ = controller.startListening()
+                }
+            }
+        }
+        .onDisappear {
+            permissionWatch?.cancel()
+            permissionWatch = nil
+        }
+    }
+
+    /// Permissions lived only behind the menu bar's "Setup & Permissions…"
+    /// until 0.5.1; Settings is where people actually look when something
+    /// stops working, so the three grants are visible here too.
+    private var permissionsCard: some View {
+        settingsCard("PERMISSIONS") {
+            ForEach(Permission.allCases, id: \.self) { permission in
+                settingsRow("\(permission.title) — \(permission.why)") {
+                    switch permissionStatus[permission] ?? permission.status {
+                    case .granted:
+                        HStack(spacing: 6) {
+                            Circle().fill(dark ? DT.moss : DT.mossLight).frame(width: 6, height: 6)
+                            Text("Granted").foregroundStyle(ink2)
+                        }
+                        .font(.system(size: 12))
+                    case .undetermined:
+                        Button("Grant…") { permission.request() }
+                            .buttonStyle(.plain).foregroundStyle(DT.emberLight)
+                            .font(.system(size: 12))
+                    case .denied:
+                        Button("Open System Settings") { NSWorkspace.shared.open(permission.settingsURL) }
+                            .buttonStyle(.plain).foregroundStyle(DT.emberLight)
+                            .font(.system(size: 12))
+                    }
+                }
+            }
+        }
     }
 
     // MARK: AI cleanup card (toggle → provider → key → optional model)

--- a/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
+++ b/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
@@ -43,8 +43,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         #else
         let forceOnboarding = false
         #endif
-        guard forceOnboarding || !controller.settings.didOnboard else { return }
-        DispatchQueue.main.async { [weak self] in self?.showOnboarding() }
+        if forceOnboarding || !controller.settings.didOnboard {
+            DispatchQueue.main.async { [weak self] in self?.showOnboarding() }
+        } else {
+            // The hotkey must work from the moment the app is running. Before
+            // 0.5.1 nothing started the listener on relaunch, so every launch
+            // after onboarding came up deaf until the user found Start
+            // Dictation in the menu. If the event tap can't start (a
+            // permission was revoked since last run), the menu header and the
+            // dashboard's Permissions card both show the way back.
+            _ = controller.startListening()
+        }
     }
 
     /// Clicking the Dock icon (or reopening the app) brings up the dashboard —
@@ -135,12 +144,15 @@ private struct MenuContent: View {
         Text(headerSubtitle)
         Divider()
 
-        // 3–4. Primary actions.
-        Button(controller.isListening || controller.isWorking ? "Stop Dictation" : "Start Dictation") {
-            if controller.isListening { controller.stopListening() } else { _ = controller.startListening() }
+        // 3–4. Primary actions. Listening starts itself at launch, so there is
+        // no Start/Stop toggle — Pause is the one deliberate off-switch. The
+        // recovery button appears only in the state that needs it: the tap
+        // failed to start (a permission was revoked), which auto-start can't
+        // fix on its own.
+        if !controller.isListening && !controller.isPaused {
+            Button("Turn On Dictation") { _ = controller.startListening() }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
         }
-        .keyboardShortcut("d", modifiers: [.command, .shift])
-
         Button(controller.isPaused ? "Resume" : "Pause for 1 hour") {
             controller.isPaused ? controller.resume() : controller.pause()
         }
@@ -215,6 +227,8 @@ private struct MenuContent: View {
         }
         if controller.isRecording { return "Listening…" }
         if controller.isWorking { return "Transcribing…" }
+        // Before 0.5.1 this said "Ready" even when the key listener was dead.
+        if !controller.isListening { return "Dictation is off" }
         return "Ready"
     }
 
@@ -223,6 +237,7 @@ private struct MenuContent: View {
         if controller.isPaused { return "Hotkey ignored while paused" }
         if controller.isRecording { return "Release to transcribe" }
         if controller.isWorking { return "On-device Whisper" }
+        if !controller.isListening { return "Check Setup & Permissions below" }
         return "Hold \(controller.settings.hotkey.glyph) to dictate"
     }
 

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,7 +36,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.0
+        MARKETING_VERSION: 0.5.1
         CURRENT_PROJECT_VERSION: 5
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES


### PR DESCRIPTION
The hotkey was dead on every launch after the first. Onboarding started the
key listener on first run, but `applicationDidFinishLaunching` never did on
any later run — the guard at `OpenVoiceFlowApp.swift:46` returned early once
onboarding was complete. So the app came up deaf, said "Ready" in the menu
anyway, and the user had to know to click **Start Dictation**. The owner hit
this and asked the right question: why is that click required at all?

It isn't, now.

## What changed

**Listening starts itself at launch** whenever onboarding is complete. The
only remaining way to be not-listening (outside Pause) is a revoked
permission, which auto-start can't fix on its own — so everything else in
this PR is about making that one state visible and recoverable.

**The Start/Stop toggle is gone from the menu.** *Pause for 1 hour* stays as
the one deliberate off-switch. A **Turn On Dictation** button appears only in
the revoked-permission state — the one place a click genuinely is required —
rather than sitting permanently at the top of the menu implying dictation is
something you must remember to switch on.

**The menu header stops lying.** It said "Ready · Hold fn to dictate" even
when the listener was dead. It now says "Dictation is off — check Setup &amp;
Permissions below" in that state.

**Settings grows a PERMISSIONS card** — the second thing the owner asked
for. Live status per grant (polled via the existing `Permission.watch`,
because a grant made in System Settings lands without our window ever losing
focus), a *Grant…* button when undetermined, a System Settings deep link when
denied. While the card is watching, a re-grant also restarts the listener, so
recovery needs no relaunch.

## Deliberate design divergence

The phase-02 menu design specifies the Start/Stop item. That spec assumed
something had to start listening; once launch does, the item is a ritual with
no purpose, so this diverges on purpose rather than drifting.

## Version

0.5.1, build 6 (appcast ordering requires build &gt; the published 5; CI
enforces this).

Verification is CI's `native-build` (this is Swift UI code with no test
target); the behavior change needs a real Mac to feel — launch, press the
hotkey, no menu visit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_