### PR TITLE
Dispatchable tag-creation workflow, so releases can be cut without tag-push access

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,51 @@
+name: Create release tag
+
+# Remote Claude Code sessions can merge release PRs but cannot push tags — the
+# session git proxy drops tag pushes and its API token can't write refs. This
+# is the sanctioned route: Actions' own token carries contents:write, so a
+# dispatch here plants the tag, and a second dispatch of release-native.yml
+# with the same tag builds it. (The tag-push event this creates does NOT fire
+# release-native by itself: GitHub suppresses workflows triggered by events
+# the Actions token created, which is why the second dispatch is required,
+# and also why this can never recurse.)
+#
+#   1. Actions ▸ Create release tag ▸ Run  (tag: native-vX.Y.Z, sha: <merge commit>)
+#   2. Actions ▸ Release (native app) ▸ Run  (release_tag: native-vX.Y.Z)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create (native-vX.Y.Z)"
+        required: true
+        type: string
+      sha:
+        description: "Full 40-char commit SHA the tag should point at"
+        required: true
+        type: string
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate inputs and create the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          # Only the native release namespace, and only an exact commit — this
+          # job must never become a generic write-any-ref primitive.
+          [[ "$TAG" =~ ^native-v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+            || { echo "::error::tag '$TAG' is not a native-vX.Y.Z tag"; exit 1; }
+          [[ "$SHA" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "::error::sha must be the full 40-char commit hash"; exit 1; }
+          # Verify the commit is reachable from main so a typo'd SHA (or one
+          # from an unmerged branch) can't become a release.
+          gh api "repos/$GITHUB_REPOSITORY/compare/$SHA...main" --jq '.status' | grep -qE '^(ahead|identical)$' \
+            || { echo "::error::$SHA is not an ancestor of main"; exit 1; }
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$SHA"
+          echo "created refs/tags/$TAG at $SHA"


### PR DESCRIPTION
Remote Claude Code sessions can merge release PRs but **cannot push tags**:
the session git proxy drops tag pushes mid-transfer, and the session's API
token can't write refs. Both releases so far hit this — 0.5.0's tag had to be
pushed by hand from the Mac mini, and 0.5.1's tag is blocked right now.

Actions' own token *can* write refs. So:

1. Dispatch **Create release tag** with `tag: native-vX.Y.Z` and the full
   merge-commit SHA → the tag is planted.
2. Dispatch **Release (native app)** with `release_tag: native-vX.Y.Z` → the
   DMG builds. (`release-native.yml` already supports this input.)

The second dispatch is required because GitHub suppresses workflows fired by
events the Actions token itself created — the same rule that makes this
workflow incapable of recursing.

Guardrails, so this never becomes a generic write-any-ref primitive:

- tag must match `native-vX.Y.Z` (the native release namespace only)
- sha must be a full 40-char commit hash
- the commit must be an ancestor of `main` — a typo'd or unmerged SHA cannot
  become a release

Unblocks the 0.5.1 release immediately; removes the manual tag-push step from
every future one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_