### PR TITLE
Finish the 0.5.1 release: sync CURRENT_PROJECT_VERSION, let unreleased tags move

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -47,5 +47,20 @@ jobs:
           # from an unmerged branch) can't become a release.
           gh api "repos/$GITHUB_REPOSITORY/compare/$SHA...main" --jq '.status' | grep -qE '^(ahead|identical)$' \
             || { echo "::error::$SHA is not an ancestor of main"; exit 1; }
-          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$SHA"
-          echo "created refs/tags/$TAG at $SHA"
+          # A tag that already exists may be MOVED only while unreleased —
+          # i.e. its build failed before a GitHub Release was published. The
+          # moment a Release exists, the tag is immutable here: users may hold
+          # the artifact it named, and this job must never rewrite that.
+          if EXISTING="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null)"; then
+            if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" >/dev/null 2>&1; then
+              echo "::error::$TAG already has a published Release; refusing to move it"; exit 1
+            fi
+            if [[ "$EXISTING" == "$SHA" ]]; then
+              echo "refs/tags/$TAG already at $SHA — nothing to do"; exit 0
+            fi
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG" -f sha="$SHA" -F force=true
+            echo "moved refs/tags/$TAG: $EXISTING -> $SHA (unreleased tag)"
+          else
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$SHA"
+            echo "created refs/tags/$TAG at $SHA"
+          fi

--- a/native/project.yml
+++ b/native/project.yml
@@ -37,7 +37,7 @@ targets:
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
         MARKETING_VERSION: 0.5.1
-        CURRENT_PROJECT_VERSION: 5
+        CURRENT_PROJECT_VERSION: 6
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
The 0.5.1 release build failed **exactly as designed**: the classify guard
caught `Info.plist` CFBundleVersion (6) disagreeing with `project.yml`
CURRENT_PROJECT_VERSION (still 5). The 0.5.1 bump touched three of the four
version fields; this syncs the fourth. One line.

The knock-on: `native-v0.5.1` now points at the failed commit, and the tag
workflow from #55 could only *create* refs. It can now **move** an existing
tag, under one hard rule: **a tag with a published GitHub Release is
immutable**. A failed build's tag never produced a Release, so it can move to
the fixed commit; the moment a Release exists, users may hold the artifact
that tag named, and this job will refuse to rewrite it. The existing
guardrails (native-v namespace, full SHA, ancestor-of-main) still apply to
both paths.

After merge: dispatch **Create release tag** to move `native-v0.5.1` here,
then dispatch **Release (native app)** to rebuild.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_