### PR TITLE
First-run field notes: live words, real anchors, engine choice, reboot survival

### DIFF
--- a/native/Sources/OpenVoiceFlow/AppController.swift
+++ b/native/Sources/OpenVoiceFlow/AppController.swift
@@ -94,6 +94,16 @@ final class AppController: ObservableObject {
         try await transcriber.warmUp(progress: progress)
     }
 
+    /// Onboarding's engine choice. Unlike `updateModel` this awaits the swap,
+    /// so the download the caller starts next fetches the chosen model instead
+    /// of racing the transcriber's async set.
+    func selectModel(_ name: String) async {
+        guard name != settings.whisperModel else { return }
+        settings.whisperModel = name
+        settings.save()
+        await transcriber.setModel(name)
+    }
+
     /// Whether the speech model is already resident — lets onboarding skip the
     /// download card on a reinstall.
     func isModelReady() async -> Bool { await transcriber.isReady }

--- a/native/Sources/OpenVoiceFlow/AppController.swift
+++ b/native/Sources/OpenVoiceFlow/AppController.swift
@@ -177,7 +177,7 @@ final class AppController: ObservableObject {
             hud.setMaxSeconds(maxRecordingSeconds)
             hud.setShowChip(shouldShowHotkeyChip)
             hud.show(.recording(hotkey: settings.hotkey))
-            if streamPartials { startPartialStream() }
+            if streamPartials || settings.liveTranscript { startPartialStream() }
             maxRecordTask = Task { [weak self] in
                 try? await Task.sleep(for: .seconds(self?.maxRecordingSeconds ?? 300))
                 if !Task.isCancelled { self?.stopAndProcess() }  // finish + insert, never drop audio
@@ -223,7 +223,15 @@ final class AppController: ObservableObject {
                 let buffer = self.audio.snapshot()
                 guard let text = await self.transcriber.partial(buffer, language: self.settings.language),
                       !text.isEmpty else { continue }
-                if !Task.isCancelled { self.partialTranscript = text }
+                if !Task.isCancelled {
+                    self.partialTranscript = text
+                    // Echo the words into the HUD while the key is held —
+                    // unless the user turned text echo off, which covers the
+                    // dictating-passwords case for live words too.
+                    if self.settings.liveTranscript && self.settings.echoInsertedText {
+                        self.hud.updateLiveTail(text)
+                    }
+                }
             }
         }
     }

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -27,6 +27,8 @@ struct DashboardView: View {
     // window stays key — see Permission.watch.
     @State private var permissionStatus: [Permission: Permission.Status] = [:]
     @State private var permissionWatch: Task<Void, Never>?
+    /// Checked when Home appears; drives the squeezed-out-icon banner.
+    @State private var menuBarIconVisible = true
     @Environment(\.colorScheme) private var scheme
 
     init(controller: AppController) {
@@ -169,6 +171,7 @@ struct DashboardView: View {
 
     private var home: some View {
         VStack(alignment: .leading, spacing: 14) {
+            if !menuBarIconVisible { squeezedIconBanner }
             HStack(alignment: .top, spacing: 14) {
                 timeBackCard.frame(maxWidth: .infinity)
                 firstWordsCard.frame(width: 300)
@@ -184,6 +187,35 @@ struct DashboardView: View {
             .frame(height: 214)
         }
         .padding(.top, 8)
+        .onAppear { menuBarIconVisible = HelloCallout.iconIsVisible }
+    }
+
+    /// macOS hides the leftmost menu-bar items when the bar runs out of room
+    /// (the notch makes this routine on laptops), and no app can claim
+    /// priority — the user's ⌘-drag is the only lever. So when our icon has
+    /// been squeezed out, say so and hand them the lever, instead of leaving
+    /// "the waveform vanished" a mystery.
+    private var squeezedIconBanner: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "menubar.arrow.up.rectangle")
+                .font(.system(size: 16))
+                .foregroundStyle(DT.warnAmber)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Your menu bar is full, so macOS is hiding the waveform.")
+                    .font(.system(size: 13, weight: .semibold)).foregroundStyle(ink)
+                Text("Dictation still works — the hotkey doesn't need the icon. To see it "
+                     + "again, hold ⌘ and drag other icons off the bar, or drag ours toward "
+                     + "the clock: rightmost icons are the last macOS hides. Apps can't "
+                     + "set their own priority; where you drop it is where it stays.")
+                    .font(.system(size: 12)).foregroundStyle(ink2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+        }
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 12).fill(DT.warnAmber.opacity(0.08)))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(DT.warnAmber.opacity(0.35)))
     }
 
     /// Row 1 left — the one number on the pane worth the largest type.
@@ -723,6 +755,8 @@ struct DashboardView: View {
                 }
                 settingsToggle("Sounds", isOn: bind(\.soundFeedback))
                 settingsToggle("Paste automatically", isOn: bind(\.autoPaste))
+                settingsToggle("Show words as you speak", isOn: bind(\.liveTranscript))
+                settingsToggle("Start when you log in", isOn: launchAtLoginBinding)
                 settingsToggle("Show in Dock", isOn: showInDockBinding)
             }
 
@@ -904,6 +938,19 @@ struct DashboardView: View {
                 controller.settings.save()
                 NSApp.setActivationPolicy(show ? .regular : .accessory)
                 if show { NSApp.activate(ignoringOtherApps: true) }
+            }
+        )
+    }
+
+    /// Applies immediately via SMAppService, not just at next launch — a
+    /// toggle that does nothing until a relaunch reads as broken.
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { controller.settings.launchAtLogin },
+            set: { enabled in
+                controller.settings.launchAtLogin = enabled
+                controller.settings.save()
+                LoginItem.apply(enabled)
             }
         )
     }

--- a/native/Sources/OpenVoiceFlow/HUDController.swift
+++ b/native/Sources/OpenVoiceFlow/HUDController.swift
@@ -73,10 +73,18 @@ final class HUDController {
     /// the hotkey was learned (see `Settings.hotkeyLearnedAt`).
     func setShowChip(_ show: Bool) { model.showChip = show }
 
+    /// The words heard so far this take, shown live beside the waveform —
+    /// the strongest possible "yes, I can hear you." Fed from the partial
+    /// stream; the view head-truncates so the newest words always win.
+    func updateLiveTail(_ text: String) { model.liveTail = text }
+
     func show(_ state: State, autoHideAfter seconds: Double? = nil) {
         ensurePanel()
         model.transition(to: state)
-        if case .recording = state { positionOnActiveScreen() }  // re-home between takes, never mid-take
+        if case .recording = state {
+            positionOnActiveScreen()  // re-home between takes, never mid-take
+            model.liveTail = ""       // last take's words must not open this one
+        }
         panel?.orderFrontRegardless()
         summonIfNeeded(state)
         hideTask?.cancel()
@@ -314,6 +322,9 @@ enum HUDGeometry {
 final class HUDModel: ObservableObject {
     @Published var state: HUDController.State = .hidden
     @Published var elapsed: TimeInterval = 0
+    /// Words heard so far this take (live partial). Empty until the first
+    /// partial lands, cleared at the start of every take.
+    @Published var liveTail: String = ""
     /// Per-take ceiling (seconds); drives the amber "time left" countdown.
     var maxSeconds: Double = 300
     /// Chip visibility is decided by the controller from Settings.
@@ -555,16 +566,27 @@ private struct HUDView: View {
         Group {
             switch model.state {
             case .recording:
-                if model.elapsed < primerSeconds {
+                if remaining <= 30 {
+                    // The end-of-take warning always wins the slot.
+                    Text("\(clock(remaining)) left")
+                        .foregroundStyle(DT.warnAmber)
+                        .font(.system(size: 12, weight: .bold).monospacedDigit())
+                } else if !model.liveTail.isEmpty {
+                    // Their own words, arriving as they speak — head-truncated
+                    // so the newest words hold the line. Beats any timer as
+                    // proof the app is hearing them.
+                    Text(model.liveTail)
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(dark ? DT.hudMsgDark : DT.hudMsgLight)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                        .frame(maxWidth: 260, alignment: .trailing)
+                } else if model.elapsed < primerSeconds {
                     // Live cue: encourage the user to keep talking past the
                     // reliable-transcription threshold before releasing.
                     Text("Keep going")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(accent)
-                } else if remaining <= 30 {
-                    Text("\(clock(remaining)) left")
-                        .foregroundStyle(DT.warnAmber)
-                        .font(.system(size: 12, weight: .bold).monospacedDigit())
                 } else if model.elapsed >= 60 {
                     // Long dictation: timer promotes to 14 pt semibold primary.
                     Text(clock(model.elapsed))

--- a/native/Sources/OpenVoiceFlow/HelloCallout.swift
+++ b/native/Sources/OpenVoiceFlow/HelloCallout.swift
@@ -1,0 +1,148 @@
+import AppKit
+import SwiftUI
+
+/// "I live up there" needs a *there*. While the welcome step is on screen,
+/// this hangs a small non-interactive bubble directly beneath the app's own
+/// menu-bar item, so the sentence and the icon connect without the user
+/// having to scan the whole bar. If the item can't be found on screen — a
+/// crowded menu bar or the notch has swallowed it — `show()` returns false
+/// and the welcome step draws a mock menu bar inside the card instead.
+@MainActor
+enum HelloCallout {
+    private static var panel: NSPanel?
+
+    /// Screen frame of this app's status-bar item, if macOS is showing it.
+    ///
+    /// The status item is hosted in a window this process owns, so it appears
+    /// in `NSApp.windows`. Its class (NSStatusBarWindow) is not API, which is
+    /// why this matches the class *name* and then validates that the frame
+    /// really occupies a menu-bar slot before trusting it.
+    private static func anchorFrame() -> NSRect? {
+        for window in NSApp.windows
+        where String(describing: type(of: window)).contains("StatusBarWindow") {
+            let frame = window.frame
+            guard frame.width > 0, frame.height > 0,
+                  let screen = NSScreen.screens.first(where: { $0.frame.intersects(frame) }),
+                  // In the menu-bar band, i.e. above the visible (below-menu) area.
+                  frame.minY >= screen.visibleFrame.maxY - 1
+            else { continue }
+            // On a notched Mac an item can exist yet sit under the notch,
+            // invisible. The auxiliary areas are the two usable strips beside
+            // the notch; an item not inside either is not actually on screen.
+            if let left = screen.auxiliaryTopLeftArea, let right = screen.auxiliaryTopRightArea,
+               !left.contains(frame), !right.contains(frame) {
+                continue
+            }
+            return frame
+        }
+        return nil
+    }
+
+    /// Present the bubble under the live icon. False = caller should fall
+    /// back to an in-window illustration.
+    @discardableResult
+    static func show() -> Bool {
+        dismiss()
+        guard let anchor = anchorFrame(),
+              let screen = NSScreen.screens.first(where: { $0.frame.intersects(anchor) })
+        else { return false }
+
+        // Size the bubble first, then clamp it on screen and aim the arrow
+        // back at the icon so clamping never detaches the two visually.
+        let probe = NSHostingController(rootView: CalloutBubble(arrowX: 0))
+        let size = probe.view.fittingSize
+        let x = min(max(anchor.midX - size.width / 2, screen.visibleFrame.minX + 8),
+                    screen.visibleFrame.maxX - size.width - 8)
+        let host = NSHostingController(rootView: CalloutBubble(arrowX: anchor.midX - x))
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: x, y: anchor.minY - size.height - 2,
+                                width: size.width, height: size.height),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.level = .statusBar
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false  // the bubble draws its own soft shadow
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .transient]
+        panel.contentViewController = host
+        panel.orderFront(nil)
+        Self.panel = panel
+        return true
+    }
+
+    static func dismiss() {
+        panel?.orderOut(nil)
+        panel = nil
+    }
+}
+
+/// The bubble itself: an up-arrow speech shape in system material, so it
+/// reads over any wallpaper in either appearance.
+private struct CalloutBubble: View {
+    /// Arrow tip x, in bubble coordinates — aimed at the icon's midX.
+    var arrowX: CGFloat
+
+    var body: some View {
+        Text("Here — this little waveform.")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .padding(.top, CalloutShape.arrowHeight)
+            .background(
+                CalloutShape(arrowX: arrowX)
+                    .fill(.regularMaterial)
+                    .shadow(color: .black.opacity(0.25), radius: 10, y: 3)
+            )
+            .overlay(CalloutShape(arrowX: arrowX).strokeBorder(.separator, lineWidth: 1))
+            .fixedSize()
+    }
+}
+
+/// Rounded rect with a small triangle on top; one shape so material and
+/// hairline wrap the whole outline seamlessly.
+private struct CalloutShape: InsettableShape {
+    static let arrowHeight: CGFloat = 7
+    static let arrowHalfWidth: CGFloat = 8
+
+    var arrowX: CGFloat
+    var inset: CGFloat = 0
+
+    func inset(by amount: CGFloat) -> CalloutShape {
+        var copy = self
+        copy.inset += amount
+        return copy
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let r: CGFloat = 9 - inset
+        let body = CGRect(x: rect.minX + inset,
+                          y: rect.minY + Self.arrowHeight + inset,
+                          width: rect.width - inset * 2,
+                          height: rect.height - Self.arrowHeight - inset * 2)
+        // Keep the tip clear of the corner arcs however far the bubble slid.
+        let tip = min(max(arrowX, body.minX + r + Self.arrowHalfWidth),
+                      body.maxX - r - Self.arrowHalfWidth)
+
+        var path = Path()
+        path.move(to: CGPoint(x: body.minX + r, y: body.minY))
+        path.addLine(to: CGPoint(x: tip - Self.arrowHalfWidth, y: body.minY))
+        path.addLine(to: CGPoint(x: tip, y: rect.minY + inset))
+        path.addLine(to: CGPoint(x: tip + Self.arrowHalfWidth, y: body.minY))
+        path.addArc(tangent1End: CGPoint(x: body.maxX, y: body.minY),
+                    tangent2End: CGPoint(x: body.maxX, y: body.maxY), radius: r)
+        path.addArc(tangent1End: CGPoint(x: body.maxX, y: body.maxY),
+                    tangent2End: CGPoint(x: body.minX, y: body.maxY), radius: r)
+        path.addArc(tangent1End: CGPoint(x: body.minX, y: body.maxY),
+                    tangent2End: CGPoint(x: body.minX, y: body.minY), radius: r)
+        path.addArc(tangent1End: CGPoint(x: body.minX, y: body.minY),
+                    tangent2End: CGPoint(x: body.maxX, y: body.minY), radius: r)
+        path.closeSubpath()
+        return path
+    }
+}

--- a/native/Sources/OpenVoiceFlow/HelloCallout.swift
+++ b/native/Sources/OpenVoiceFlow/HelloCallout.swift
@@ -11,6 +11,11 @@ import SwiftUI
 enum HelloCallout {
     private static var panel: NSPanel?
 
+    /// Whether macOS is actually showing our menu-bar item right now. False
+    /// means the bar is full (or the notch ate it) — the dashboard uses this
+    /// to explain the disappearance instead of leaving it a mystery.
+    static var iconIsVisible: Bool { anchorFrame() != nil }
+
     /// Screen frame of this app's status-bar item, if macOS is showing it.
     ///
     /// The status item is hosted in a window this process owns, so it appears

--- a/native/Sources/OpenVoiceFlow/OnboardingView.swift
+++ b/native/Sources/OpenVoiceFlow/OnboardingView.swift
@@ -58,11 +58,16 @@ struct OnboardingView: View {
     @State private var permissionWatch: Task<Void, Never>?
     /// The menu-bar glyph waves once per run (T7).
     @State private var helloWaved = false
+    /// "Up there" got no anchor: the wave plays on an icon nobody is looking
+    /// at, and a crowded menu bar may not even be showing it. True when the
+    /// live callout couldn't attach and the card must illustrate instead.
+    @State private var showMockBar = false
     /// How many words of the ink fill have been inked in (T9).
     @State private var revealedWords = 0
     @State private var fillTask: Task<Void, Never>?
     /// Download progress, mirrored up from the step so the footer can show it.
-    @State private var downloadPercent = "0%"
+    /// Starts as a nudge because nothing downloads until an engine is chosen.
+    @State private var downloadPercent = "waiting on your pick"
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var scheme
 
@@ -186,15 +191,52 @@ struct OnboardingView: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 420)
                 .padding(.top, 12)
+            if showMockBar { mockMenuBar.padding(.top, 22) }
             Spacer()
         }
         .frame(maxWidth: .infinity)
-        // Once per run, not once per visit — going Back shouldn't replay it.
         .onAppear {
-            guard !helloWaved else { return }
-            helloWaved = true
-            NotificationCenter.default.post(name: .ovfPlayHello, object: nil)
+            // Once per run, not once per visit — going Back shouldn't replay it.
+            if !helloWaved {
+                helloWaved = true
+                NotificationCenter.default.post(name: .ovfPlayHello, object: nil)
+            }
+            // "Up there" points somewhere real: a callout under the live icon.
+            // When the icon can't be located (crowded bar, notch), the card
+            // illustrates the spot instead — re-tried on every visit, since
+            // menu-bar space can free up between them.
+            showMockBar = !HelloCallout.show()
         }
+        .onDisappear { HelloCallout.dismiss() }
+    }
+
+    /// Fallback anchor: a pretend slice of menu bar with our waveform where
+    /// it will actually sit — right side, near the clock.
+    private var mockMenuBar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 16) {
+                Spacer()
+                Image(systemName: "wifi")
+                Image(systemName: "battery.75")
+                Image(nsImage: StatusIconRenderer.image(for: .idle))
+                    .renderingMode(.template)
+                    .foregroundStyle(p.accent)
+                    .padding(5)
+                    .background(Circle().fill(p.accent.opacity(0.16)))
+                    .overlay(Circle().strokeBorder(p.accent.opacity(0.45), lineWidth: 1))
+                Text("9:41")
+            }
+            .font(.system(size: 12))
+            .foregroundStyle(p.ink2)
+            .padding(.horizontal, 12)
+            .frame(width: 320, height: 34)
+            .background(RoundedRectangle(cornerRadius: 8).fill(p.card))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(p.hairline))
+            Text("Top right of your screen, near the clock.")
+                .font(.system(size: 12)).foregroundStyle(p.ink3)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("The waveform icon sits at the top right of your screen, near the clock.")
     }
 
     /// Step 1 — three permissions, asked one at a time.
@@ -531,6 +573,17 @@ final class DownloadMeter: ObservableObject {
 
     var percentText: String { "\(Int((fraction * 100).rounded()))%" }
 
+    /// Back to zero for a fresh transfer — switching speech engines mid-step
+    /// must not inherit the previous download's bar, rate, or ETA.
+    func reset() {
+        received = 0
+        expected = 0
+        rateText = ""
+        etaText = ""
+        samples = []
+        lastETAUpdate = .distantPast
+    }
+
     /// Land the bar exactly on full when the load finishes, rather than leaving
     /// it wherever the last progress callback happened to fire.
     func complete() {
@@ -580,29 +633,84 @@ private struct KnowMeDownloadStep: View {
     /// True when the model was already on disk, so there is nothing to show.
     @State private var skipProgress = false
     @State private var name = ""
-    @State private var words: [String] = []
-    /// Whether the profile draft has been loaded — see start().
+    /// Whether the profile draft has been loaded — see appear().
     @State private var hydrated = false
+    /// The engine the user tapped. Nothing downloads until this is non-nil:
+    /// the choice is theirs, not a silent default.
+    @State private var selected: String?
+    /// Invalidates a superseded download's callbacks when the user switches
+    /// engines mid-transfer, so the old transfer can't drive the new bar.
+    @State private var generation = 0
 
     private var p: OBPalette { palette }
 
+    /// The engines on offer — size and benefit up front, decision theirs.
+    /// Same ids the dashboard and menu speak.
+    private static let engines: [(id: String, name: String, size: String, benefit: String, recommended: Bool)] = [
+        ("tiny", "Tiny", "39 MB", "Fastest. Fine for quick notes.", false),
+        ("small", "Small", "466 MB", "Everyday dictation on any Mac.", true),
+        ("medium", "Medium", "1.5 GB", "Hears more, asks more of your Mac.", false),
+        ("large-v3-turbo", "Large turbo", "1.6 GB", "Hears the most. Best on Apple Silicon.", false),
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(skipProgress ? "Who am I typing for?" : "While that downloads — who am I typing for?")
+            Text(skipProgress ? "Who am I typing for?" : "Pick your speech engine.")
                 .font(.system(size: 25, weight: .bold)).kerning(-0.625)
                 .foregroundStyle(p.ink)
-            Text("Two answers, and your name comes out spelled right the first time.")
+            Text(skipProgress
+                 ? "One answer, and your name comes out spelled right the first time."
+                 : "Each one runs on this Mac, offline. Bigger hears better — your call.")
                 .font(.system(size: 13)).foregroundStyle(p.ink2)
                 .padding(.top, 6)
 
-            interviewCard.padding(.top, 18)
-            if !skipProgress {
+            if !skipProgress { engineCard.padding(.top, 16) }
+            interviewCard.padding(.top, 14)
+            if selected != nil && !skipProgress {
                 progressCard.padding(.top, 14)
             }
             Spacer()
         }
-        .onAppear(perform: start)
+        .onAppear(perform: appear)
         .onDisappear(perform: persist)
+    }
+
+    private var engineCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(Self.engines.enumerated()), id: \.element.id) { index, engine in
+                if index > 0 { Divider().overlay(p.hairline) }
+                Button { choose(engine.id) } label: {
+                    HStack(spacing: 12) {
+                        Circle()
+                            .strokeBorder(selected == engine.id ? p.accent : p.ink3, lineWidth: 1.5)
+                            .background(Circle().fill(selected == engine.id ? p.accent : .clear).padding(3.5))
+                            .frame(width: 15, height: 15)
+                        Text(engine.name)
+                            .font(.system(size: 13, weight: .semibold)).foregroundStyle(p.ink)
+                        if engine.recommended {
+                            Text("POPULAR")
+                                .font(.system(size: 9, weight: .bold)).kerning(0.5)
+                                .foregroundStyle(p.accent)
+                                .padding(.horizontal, 6).padding(.vertical, 2)
+                                .background(Capsule().fill(p.accent.opacity(0.14)))
+                        }
+                        Text(engine.benefit)
+                            .font(.system(size: 12)).foregroundStyle(p.ink2)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(engine.size)
+                            .font(.system(size: 11.5)).monospacedDigit().foregroundStyle(p.ink3)
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 10)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(engine.name), \(engine.size). \(engine.benefit)")
+                .accessibilityAddTraits(selected == engine.id ? .isSelected : [])
+            }
+        }
+        .background(RoundedRectangle(cornerRadius: DT.rCard).fill(p.card))
+        .overlay(RoundedRectangle(cornerRadius: DT.rCard).strokeBorder(p.hairline))
     }
 
     private var interviewCard: some View {
@@ -614,12 +722,6 @@ private struct KnowMeDownloadStep: View {
                 ink: p.ink, ink2: p.ink2,
                 fill: p.ink.opacity(0.06),
                 accent: p.accent)
-            KnowMeTokenRow(
-                label: "Any names or words I'd get wrong?",
-                tokens: $words,
-                ink2: p.ink2, ink3: p.ink3,
-                chipInk: scheme_chipInk,
-                chipFill: p.ink.opacity(0.07))
         }
         .padding(18)
         .background(RoundedRectangle(cornerRadius: DT.rCard).fill(p.card))
@@ -669,7 +771,7 @@ private struct KnowMeDownloadStep: View {
                     .font(.system(size: 12.5)).foregroundStyle(Color(hex: 0xC9C3B4))
                     .padding(.top, 9)
                 HStack(spacing: 14) {
-                    Button("Try again") { start() }
+                    Button("Try again") { if let selected { download(engine: selected) } }
                         .buttonStyle(.plain)
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(p.onAccent)
@@ -709,40 +811,67 @@ private struct KnowMeDownloadStep: View {
         Text("·").font(.system(size: 11.5)).foregroundStyle(p.ink3)
     }
 
-    private func start() {
-        // Hydrate the draft from the saved profile once, not on every entry.
-        // "Try again" after a failed download comes back through here, and
-        // persist() only runs when the step is left — so re-reading the profile
-        // would replace the name the user just typed with the empty value still
-        // on disk, as a reward for retrying.
+    private func appear() {
+        // Hydrate the draft from the saved profile once, not on every entry —
+        // persist() only runs when the step is left, so re-reading on every
+        // visit would replace a just-typed name with the stale value on disk.
         if !hydrated {
             hydrated = true
             name = controller.profileStore.profile.name
-            if words.isEmpty { words = controller.profileStore.profile.technicalTerms }
         }
-        guard !done else { return }
+        guard !done, selected == nil else { return }
+        // A reinstall already has an engine on disk: no choice to re-litigate,
+        // no bar for something instant — straight to the name.
+        Task {
+            if await controller.isModelReady() {
+                skipProgress = true
+                done = true
+            }
+        }
+    }
+
+    private func choose(_ id: String) {
+        guard id != selected else { return }
+        selected = id
+        download(engine: id)
+    }
+
+    private func download(engine: String) {
+        // A switch mid-transfer supersedes the old download; its straggling
+        // callbacks must not touch the new bar or declare the step done.
+        generation += 1
+        let gen = generation
+        done = false
         failed = false
         failureDetail = nil
         showDetail = false
+        meter.reset()
+        percent = "0%"
 
         Task {
-            // A reinstall already has the model: no bar, no wait, straight to
-            // "Try it" — showing 0→100% for something instant is theatre.
+            await controller.selectModel(engine)
+            guard gen == generation else { return }
+            // Switching back to an engine that already finished downloading:
+            // land the bar, no second transfer.
             if await controller.isModelReady() {
-                skipProgress = true
+                guard gen == generation else { return }
+                meter.complete()
                 done = true
                 return
             }
             do {
                 try await controller.prepareModelForOnboarding { received, expected in
                     Task { @MainActor in
+                        guard gen == generation else { return }
                         meter.update(received: received, expected: expected)
                         percent = meter.percentText
                     }
                 }
+                guard gen == generation else { return }
                 meter.complete()
                 done = true
             } catch {
+                guard gen == generation else { return }
                 failed = true
                 failureDetail = error.localizedDescription
             }
@@ -750,11 +879,12 @@ private struct KnowMeDownloadStep: View {
     }
 
     /// Answers are written when the step is left, so a user who types and moves
-    /// on doesn't lose them to a missing Save button.
+    /// on doesn't lose them to a missing Save button. Words-they'd-get-wrong
+    /// moved out of onboarding entirely (it was one ask too many); existing
+    /// terms on disk pass through untouched.
     private func persist() {
         var profile = controller.profileStore.profile
         profile.name = name.trimmingCharacters(in: .whitespaces)
-        profile.technicalTerms = words
         controller.profileStore.profile = profile
         controller.dictionaryStore.seed(with: controller.profileStore.dictionaryWords)
     }

--- a/native/Sources/OpenVoiceFlow/OnboardingView.swift
+++ b/native/Sources/OpenVoiceFlow/OnboardingView.swift
@@ -133,7 +133,13 @@ struct OnboardingView: View {
                 controller.settings.didOnboard = true
                 controller.settings.save()
                 _ = controller.startListening()
+                LoginItem.apply(controller.settings.launchAtLogin)
                 NSApplication.shared.keyWindow?.close()
+                // Land somewhere, not nowhere: a menu-bar app whose onboarding
+                // just closed leaves a desktop with no visible change. The
+                // dashboard is the room they were just promised.
+                NotificationCenter.default.post(name: .ovfOpenDashboard, object: nil)
+                NSApp.activate(ignoringOtherApps: true)
             }
         }
     }
@@ -412,7 +418,10 @@ struct OnboardingView: View {
                 suggestion: Self.suggestion,
                 spoken: spokenText,
                 revealedWords: revealedWords,
-                idleHint: controller.isRecording ? nil : "Waiting for you…",
+                idleHint: controller.isRecording
+                    ? nil
+                    : "Hold \(controller.settings.hotkey.glyph) and read the grey line out loud.",
+                isRecording: controller.isRecording,
                 palette: p)
                 .padding(.top, 18)
 
@@ -908,6 +917,10 @@ private struct InkFillView: View {
     let revealedWords: Int
     /// Shown before anything has been heard.
     let idleHint: String?
+    /// The key is down right now — the card acknowledges it instantly, before
+    /// the first partial can possibly arrive. Whisper needs a second or two of
+    /// audio; without this the user reads that gap as "it can't hear me."
+    let isRecording: Bool
     let palette: OBPalette
 
     @Environment(\.colorScheme) private var scheme
@@ -962,16 +975,34 @@ private struct InkFillView: View {
                         .padding(.leading, 3)
                 }
             }
-            if let idleHint, spokenWords.isEmpty {
-                Text(idleHint)
-                    .font(.system(size: 11.5)).foregroundStyle(palette.ink3)
+            if spokenWords.isEmpty {
+                if isRecording {
+                    // Instant acknowledgement, ahead of the first partial.
+                    HStack(spacing: 6) {
+                        Circle().fill(caret).frame(width: 6, height: 6)
+                        Text("Listening — go on.")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(caret)
+                    }
                     .padding(.top, 10)
+                } else if let idleHint {
+                    // The instruction is the point of this card — accent
+                    // weight, not a footnote (the grey line alone read as
+                    // decoration, and users waited for something to happen).
+                    Text(idleHint)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(palette.accent)
+                        .padding(.top, 10)
+                }
             }
         }
         .frame(maxWidth: .infinity, minHeight: 64, alignment: .topLeading)
         .padding(16)
         .background(RoundedRectangle(cornerRadius: DT.rCard).fill(palette.card))
-        .overlay(RoundedRectangle(cornerRadius: DT.rCard).strokeBorder(palette.hairline))
+        .overlay(RoundedRectangle(cornerRadius: DT.rCard)
+            .strokeBorder(isRecording ? caret.opacity(0.55) : palette.hairline,
+                          lineWidth: isRecording ? 1.5 : 1))
+        .animation(.easeOut(duration: 0.15), value: isRecording)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(spokenWords.isEmpty ? (idleHint ?? suggestion) : spoken)
     }

--- a/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
+++ b/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
@@ -1,5 +1,27 @@
 import AppKit
+import ServiceManagement
 import SwiftUI
+
+/// Launch-at-login via SMAppService. Register/unregister are status-guarded
+/// so applying an unchanged setting at every launch stays a no-op instead of
+/// an error or a duplicate registration.
+@MainActor
+enum LoginItem {
+    static func apply(_ enabled: Bool) {
+        let service = SMAppService.mainApp
+        do {
+            if enabled, service.status != .enabled {
+                try service.register()
+            } else if !enabled, service.status == .enabled {
+                try service.unregister()
+            }
+        } catch {
+            // Not worth an alert: the user can flip the Settings toggle again,
+            // and System Settings ▸ Login Items always shows the truth.
+            NSLog("LoginItem: \(error.localizedDescription)")
+        }
+    }
+}
 
 /// Entry point. A menu-bar (`LSUIElement`) app: no Dock icon by default, a
 /// `MenuBarExtra` for control (design phase 02), a dashboard window (phase
@@ -53,6 +75,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // permission was revoked since last run), the menu header and the
             // dashboard's Permissions card both show the way back.
             _ = controller.startListening()
+            // Survive reboots: a menu-bar utility that vanishes on restart
+            // reads as broken. Status-guarded, so this is a no-op when the
+            // registration already matches the setting.
+            LoginItem.apply(controller.settings.launchAtLogin)
         }
     }
 

--- a/native/Sources/OpenVoiceFlow/Settings.swift
+++ b/native/Sources/OpenVoiceFlow/Settings.swift
@@ -11,7 +11,16 @@ struct Settings: Codable, Equatable {
     var style: Style = .default
     var autoPaste: Bool = true
     var soundFeedback: Bool = true
-    var launchAtLogin: Bool = false
+    /// Registered via SMAppService at launch and from the Settings toggle. A
+    /// menu-bar utility that vanishes on reboot reads as broken, so this
+    /// defaults on; macOS posts its own "added as a login item" notice.
+    var launchAtLogin: Bool = true
+    /// One-time flip for installs that predate the login-item UI: their stored
+    /// `false` was a silent default nobody chose, not a decision to honor.
+    var loginItemMigrated: Bool = false
+    /// Words appear in the HUD as they're spoken — proof of hearing, live.
+    /// Costs a re-transcription pass every 300 ms while the key is held.
+    var liveTranscript: Bool = true
     /// Show a Dock icon (clicking it opens the dashboard). Off ⇒ menu-bar only.
     var showInDock: Bool = true
     var didOnboard: Bool = false
@@ -46,7 +55,9 @@ struct Settings: Codable, Equatable {
         style = try c.decodeIfPresent(Style.self, forKey: .style) ?? .default
         autoPaste = try c.decodeIfPresent(Bool.self, forKey: .autoPaste) ?? true
         soundFeedback = try c.decodeIfPresent(Bool.self, forKey: .soundFeedback) ?? true
-        launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? false
+        launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? true
+        loginItemMigrated = try c.decodeIfPresent(Bool.self, forKey: .loginItemMigrated) ?? false
+        liveTranscript = try c.decodeIfPresent(Bool.self, forKey: .liveTranscript) ?? true
         showInDock = try c.decodeIfPresent(Bool.self, forKey: .showInDock) ?? true
         didOnboard = try c.decodeIfPresent(Bool.self, forKey: .didOnboard) ?? false
         maxRecordingSeconds = try c.decodeIfPresent(Double.self, forKey: .maxRecordingSeconds) ?? 300
@@ -67,8 +78,13 @@ struct Settings: Codable, Equatable {
 
     static func load() -> Settings {
         guard let data = try? Data(contentsOf: url),
-              let decoded = try? JSONDecoder().decode(Settings.self, from: data)
+              var decoded = try? JSONDecoder().decode(Settings.self, from: data)
         else { return Settings() }
+        if !decoded.loginItemMigrated {
+            decoded.launchAtLogin = true
+            decoded.loginItemMigrated = true
+            decoded.save()
+        }
         return decoded
     }
 


### PR DESCRIPTION
The owner ran the redesigned onboarding on a real Mac and sent field notes.
Two commits, six changes, all of them "the app should show me, not make me
guess":

## "I live up there" now points somewhere (commit 1)

A callout bubble hangs beneath the app's **actual menu-bar item** during the
welcome step — located via our own status window, validated against the
menu-bar band and the notch's auxiliary areas. When the icon can't be found
(crowded bar, notch), the card draws a mock slice of menu bar showing where
the waveform will sit. New file `HelloCallout.swift`.

## The speech engine is a choice, not a default (commit 1)

Step 2 leads with four engines — size and one-line benefit each, POPULAR chip
on Small, **nothing preselected and nothing downloading until the user taps
one**. Switching mid-transfer supersedes the old download (generation
counter), and the new `selectModel` awaits the transcriber swap so the
download can't race it. The "names I'd get wrong" question is gone from
onboarding — one ask too many; Know-Me still owns it.

## Your words, live in the HUD (commit 2)

The partial-transcription stream existed but was gated to onboarding. It now
runs during normal dictation: the recording HUD shows the words heard so far,
head-truncated so the newest hold the line. Settings toggle "Show words as
you speak" (default on); respects the existing echo-off privacy setting; the
end-of-take countdown still outranks it.

## The try-it card answers key-down instantly (commit 2)

Whisper needs a second or two before the first partial — a gap users read as
"it can't hear me." The card border flips to caret color and shows
"Listening — go on." the moment the key goes down, and the read-this-line
instruction is accent-weight instead of a footnote.

## Onboarding lands somewhere (commit 2)

"Start using it" now opens the dashboard instead of closing onto an
unchanged desktop.

## Reboot survival + the vanished-icon mystery (commit 2)

`launchAtLogin` existed in Settings but nothing applied or exposed it. Now
applied via `SMAppService` at launch and from a new Settings toggle, default
on, with a one-time migration for stored-but-never-chosen `false`. And when
macOS squeezes the icon out of a full menu bar, dashboard Home explains it
and hands over the one real lever (⌘-drag) — apps cannot claim menu-bar
priority, and the banner is honest about that.

## Verification

CI `native-build` compiles it; the behaviors need a real Mac. This is
app-code only — no version bump, no release. It ships as 0.5.2 together with
whatever Meeru's device pass finds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_