### PR TITLE
0.5.2, build 7

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.1</string>
-    <key>CFBundleVersion</key><string>6</string>
+    <key>CFBundleShortVersionString</key><string>0.5.2</string>
+    <key>CFBundleVersion</key><string>7</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a
          regular app would auto-present it at every launch, on top of first-run

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.1
-        CURRENT_PROJECT_VERSION: 6
+        MARKETING_VERSION: 0.5.2
+        CURRENT_PROJECT_VERSION: 7
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
Version bump for the first-run field-notes release (#58): live words in the
HUD, the anchored welcome callout, the engine choice, launch at login, the
squeezed-icon banner, and onboarding that lands in the dashboard.

All four version fields — `project.yml` MARKETING_VERSION + 
CURRENT_PROJECT_VERSION, `Info.plist` short version + build — the 0.5.1
release taught that lesson once, and the classify guard is watching.

After merge: dispatch **Create release tag** → **Release (native app)** →
website publish, same pipeline as 0.5.1.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_