### PR TITLE
Brand attribution: Shimoverse → Shimoverse Studios

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Shimoverse
+Copyright (c) 2025 Shimoverse Studios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ The one-page version: audio on-device always; text to a cloud only if you enable
 
 ## License
 
-[MIT](LICENSE) © Shimoverse and contributors. Third-party notices: [docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md).
+[MIT](LICENSE) © Shimoverse Studios and contributors. Third-party notices: [docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -175,7 +175,7 @@ GitHub Security Advisory on the repo.
 
 ## Notes for reviewers
 
-- The project is MIT-licensed; the maintainer is Shimoverse (see `LICENSE`).
+- The project is MIT-licensed; the maintainer is Shimoverse Studios (see `LICENSE`).
 - The repo lives at `github.com/shimoverse/openvoiceflow` today and may move to a
   personal account before public release. URLs in this file will be updated if so.
 - This document is part of the v0.3 readiness bundle. Pair reading:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -32,4 +32,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome.
 
 ## Maintainer
 
-Shimoverse.
+Shimoverse Studios.

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -10,7 +10,7 @@
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>CFBundleShortVersionString</key><string>0.5.2</string>
     <key>CFBundleVersion</key><string>7</string>
-    <key>NSHumanReadableCopyright</key><string>© Shimoverse and contributors. MIT License.</string>
+    <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a
          regular app would auto-present it at every launch, on top of first-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "0.3.6"
 description = "Free voice dictation for macOS — local transcription + optional LLM cleanup"
 readme = "README.md"
 license = "MIT"
-authors = [{name = "Shimoverse"}]
+authors = [{name = "Shimoverse Studios"}]
 requires-python = ">=3.9"
 keywords = ["voice", "dictation", "speech-to-text", "whisper", "macos", "openvoiceflow"]
 classifiers = [

--- a/voiceflow/__init__.py
+++ b/voiceflow/__init__.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 __version__ = "0.3.6"
-__author__ = "Shimoverse"
+__author__ = "Shimoverse Studios"
 __app_name__ = "OpenVoiceFlow"


### PR DESCRIPTION
Every place "Shimoverse" appears as a *name*: the LICENSE copyright line,
`NSHumanReadableCopyright`, the README license line, SECURITY.md's
maintainer line, SUPPORT.md's sign-off, and the Python package metadata.

Deliberately **not** changed:

- `github.com/shimoverse` — renaming the org is an owner-only GitHub action
  and moves every URL; the org handle staying lowercase-shimoverse is normal.
- `com.shimoverse.openvoiceflow` — the bundle identifier is load-bearing:
  changing it would orphan every existing install's permission grants,
  Keychain items, settings, and Sparkle update feed. It's an internal ID,
  invisible in normal use.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_