### PR TITLE
Brand policy: the code is anyone's, the name is ours

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ The one-page version: audio on-device always; text to a cloud only if you enable
 
 ## License
 
-[MIT](LICENSE) © Shimoverse Studios and contributors. Third-party notices: [docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md).
+[MIT](LICENSE) © Shimoverse Studios and contributors — free for any use, forever; the copyright notice must travel with every copy. The **name and logo** are governed separately by the [brand policy](TRADEMARKS.md): forks and derivatives must rebrand and credit the original. Third-party notices: [docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,41 @@
+# Brand and trademark policy
+
+The OpenVoiceFlow **code** is MIT-licensed: use it, fork it, build on it,
+ship it — commercially or not. The MIT license already requires that our
+copyright notice travel with every copy.
+
+The OpenVoiceFlow **name, logo, and visual identity** are a different thing.
+They identify this project, built and maintained by Shimoverse Studios, and
+this policy governs their use. (These marks are claimed under common law;
+absence of a registration symbol does not waive our rights.)
+
+## You may, without asking
+
+- Say your project **is based on, forked from, or compatible with
+  OpenVoiceFlow** — truthful nominative references are always fine.
+- Use the name in articles, reviews, videos, benchmarks, package manifests,
+  and academic work.
+- Keep the name in an unmodified redistribution of an official release
+  (e.g. mirroring the DMG, packaging for a package manager) as long as it is
+  clearly the unmodified official build.
+
+## You may not
+
+- Name a **fork, derivative, or modified build** "OpenVoiceFlow" or anything
+  confusingly similar, or ship one under our logo. Rename your fork, and
+  state clearly: *"Based on OpenVoiceFlow by Shimoverse Studios"* with a
+  link to this repository.
+- Use the name or logo in a way that implies Shimoverse Studios endorses,
+  maintains, or is affiliated with your product or service when it isn't.
+- Register domains, app-store listings, or social accounts designed to be
+  mistaken for the official project.
+
+## Why both things are true at once
+
+The code being free is the mission. The name staying honest is how users
+know whether the thing they downloaded is the project with this repo's
+privacy promises behind it — audio on-device, no telemetry, no account.
+A fork can change any of that, which is exactly why it must not wear our
+name while doing so.
+
+Questions or edge cases: open an issue.


### PR DESCRIPTION
MIT stays — free for any use including commercial, credit required via the
license notice, and the launch keeps the words "open source" truthfully.

`TRADEMARKS.md` adds the protection the owner actually wanted when asking
for "credits": a fork or derivative must **rebrand** and state it is *based
on OpenVoiceFlow by Shimoverse Studios*, and nothing may wear the name or
logo while changing what the name promises (on-device audio, no telemetry,
no account). Truthful nominative use — "based on", reviews, packaging the
unmodified official build — stays explicitly free. Marks claimed under
common law; no registration implied.

README's License section now explains the split in one sentence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_