### PR TITLE
Mission gets its own page: "Your voice is not a subscription"

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -40,6 +40,7 @@
     <div class="nav-inner container">
       <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
@@ -49,6 +50,7 @@
     </div>
     <div class="nav-drawer" id="navDrawer">
       <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
       <a href="download.html">Download</a>
       <a href="install.html">Install</a>
       <a href="how-it-works.html">How it works</a>
@@ -156,6 +158,7 @@
       <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
       <nav class="footer-links" aria-label="Footer">
         <a href="index.html">Home</a>
+        <a href="mission.html">Mission</a>
         <a href="install.html">Install</a>
         <a href="how-it-works.html">How it works</a>
         <a href="privacy.html">Privacy</a>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -29,6 +29,7 @@
     <div class="nav-inner container">
       <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
@@ -38,6 +39,7 @@
     </div>
     <div class="nav-drawer" id="navDrawer">
       <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
       <a href="download.html">Download</a>
       <a href="install.html">Install</a>
       <a href="how-it-works.html">How it works</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,6 +84,7 @@
     <div class="nav-inner container">
       <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
@@ -93,6 +94,7 @@
     </div>
     <div class="nav-drawer" id="navDrawer">
       <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
       <a href="download.html">Download</a>
       <a href="install.html">Install</a>
       <a href="how-it-works.html">How it works</a>
@@ -235,8 +237,9 @@
       </div>
       <div class="content-card">
         <h2>Our mission</h2>
-        <p class="answer-block">Dictation this good should not cost $144 a year, and it should not require sending your voice to someone's cloud. It is a basic accessibility and productivity need — like copy and paste — and payment should never be the blocker. So OpenVoiceFlow is free, on-device, and MIT-licensed, forever.</p>
+        <p class="answer-block">In the AI era, talking to your computer is a basic need — and basic needs should never be gated by payment. Don't pay companies $144 a year for your own voice: dictation here is free for everyone, on-device, MIT-licensed, forever. The only optional extra, AI cleanup, is bring-your-own-key — pay the model provider cents for tokens, not a middleman for permission.</p>
         <p class="answer-block">Honestly, we think every operating system should ship this as a default feature, and the day that happens well enough, apps like this one become unnecessary. Until then, we build it in the open — and if you are a developer who believes typing shouldn't be a toll booth, <a href="https://github.com/shimoverse/openvoiceflow">join us on GitHub</a>.</p>
+        <p class="answer-block"><a href="mission.html"><strong>Read the full mission →</strong></a></p>
       </div>
     </section>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -29,6 +29,7 @@
     <div class="nav-inner container">
       <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
@@ -38,6 +39,7 @@
     </div>
     <div class="nav-drawer" id="navDrawer">
       <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
       <a href="download.html">Download</a>
       <a href="install.html">Install</a>
       <a href="how-it-works.html">How it works</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,7 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 ## Priority pages
 
 - Homepage: https://openvoiceflow.com/
+- Mission: https://openvoiceflow.com/mission.html
 - Download page: https://openvoiceflow.com/download.html
 - Install guide: https://openvoiceflow.com/install.html
 - How it works: https://openvoiceflow.com/how-it-works.html

--- a/docs/mission.html
+++ b/docs/mission.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mission — Why OpenVoiceFlow Is Free Forever</title>
+  <meta name="description" content="Voice input is a basic need in the AI era, and basic needs shouldn't be gated by payment. Why OpenVoiceFlow is free, on-device, and open source — and why it hopes to become unnecessary." />
+  <meta property="og:title" content="Your voice is not a subscription — the OpenVoiceFlow mission" />
+  <meta property="og:description" content="Don't pay $144 a year for a basic need. Free on-device dictation for everyone; bring your own API key only if you want optional AI cleanup." />
+  <meta property="og:url" content="https://openvoiceflow.com/mission.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/mission.html" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <link rel="stylesheet" href="style.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": "The OpenVoiceFlow mission",
+    "url": "https://openvoiceflow.com/mission.html",
+    "description": "Why OpenVoiceFlow is free forever: voice input is a basic need in the AI era and should never be gated by payment. On-device, open source, MIT-licensed, built by Shimoverse Studios and contributors.",
+    "isPartOf": {"@type": "WebSite", "name": "OpenVoiceFlow", "url": "https://openvoiceflow.com/"}
+  }
+  </script>
+  <script>
+    window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+  </script>
+  <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
+</head>
+<body>
+  <nav class="nav" id="nav" aria-label="Main">
+    <div class="nav-inner container">
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
+      <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
+        <li><a href="how-it-works.html">How it works</a></li>
+        <li><a href="install.html">Install</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
+      </ul>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
+    </div>
+    <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
+      <a href="download.html">Download</a>
+      <a href="install.html">Install</a>
+      <a href="how-it-works.html">How it works</a>
+      <a href="download.html" class="btn btn-primary">Download for Mac</a>
+    </div>
+  </nav>
+
+  <main>
+    <section class="page-hero"><div class="container hero-inner">
+      <h1 class="hero-title">Your voice is not<br />a subscription.</h1>
+      <p class="hero-sub answer-block">In the AI era, talking to your computer is a basic need — like copy and paste, like a keyboard. Basic needs should never be gated by payment. That is the whole mission, and everything else follows from it.</p>
+
+      <section class="content-card"><h2>Talking is how humans work. Typing is the workaround.</h2>
+        <p class="answer-block">People speak at roughly 150 words a minute and type at roughly 40. A Stanford study measured speech input at about three times the speed of typing on mobile keyboards. Voice has always been the faster interface — what was missing was software that respects you enough to run on your own machine, for free.</p>
+        <div class="stat-row">
+          <div class="stat-card stat-accent"><div class="stat-value">~150</div><div class="stat-label">Words per minute, speaking</div></div>
+          <div class="stat-card"><div class="stat-value">~40</div><div class="stat-label">Words per minute, typing</div></div>
+          <div class="stat-card"><div class="stat-value">~3×</div><div class="stat-label">Speech vs. keyboard, Stanford study</div></div>
+        </div>
+      </section>
+
+      <section class="content-card"><h2>Pay for tokens, not permission.</h2>
+        <p class="answer-block">Companies charge $144 a year to stand between your voice and your screen — for compute your Mac already has. We think that's backwards. Dictation in OpenVoiceFlow is free for everyone, with no account and no tier: Whisper runs on your machine, your audio never leaves it, and there is nothing to upgrade to.</p>
+        <p class="answer-block">The one optional extra — AI cleanup that polishes grammar and filler words — is bring-your-own-key. Point it at OpenRouter, OpenAI, Anthropic, or Groq and you pay the model provider directly, in cents, for tokens you actually use. Or run Ollama and pay nobody. Your money should buy compute, not permission — go buy tokens, go build something, and keep the $144.</p>
+      </section>
+
+      <section class="content-card"><h2>The best version of this app is the one that becomes unnecessary.</h2>
+        <p class="answer-block">Our goal is not to own a market. It is for voice input this good to be a default feature of every operating system — built in, free, private — so that third-party developers no longer need to build apps like this one. Until that day, we build it in the open: MIT-licensed, source public, every privacy claim checkable in code.</p>
+        <p class="answer-block">If you're a developer who believes typing shouldn't be a toll booth, this is an invitation. File an honest bug report. Add a test. Improve accuracy for your language. <a href="https://github.com/shimoverse/openvoiceflow">Join us on GitHub.</a></p>
+      </section>
+
+      <section class="content-card"><h2>Who builds this</h2>
+        <p class="answer-block">OpenVoiceFlow is built by <strong>Shimoverse Studios</strong> and open-source contributors. The code is <a href="https://github.com/shimoverse/openvoiceflow/blob/main/LICENSE">MIT-licensed</a> — free for any use, with credit required. The name and logo are protected by a <a href="https://github.com/shimoverse/openvoiceflow/blob/main/TRADEMARKS.md">brand policy</a>, so anything wearing the OpenVoiceFlow name keeps the promises on this website: audio on-device, no telemetry, no account, no paid tier. Read the <a href="privacy.html">privacy policy</a> — the short version is that we couldn't sell your data even if we wanted to, because we never have it.</p>
+      </section>
+
+      <div class="hero-cta-row" style="margin-top:26px">
+        <a class="btn btn-primary btn-lg" href="download.html">Download for Mac — free</a>
+        <a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">Star or fork on GitHub</a>
+      </div>
+    </div></section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="mission.html">Mission</a>
+        <a href="install.html">Install</a>
+        <a href="how-it-works.html">How it works</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
+        <a href="llms.txt">llms.txt</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="site.js"></script>
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -26,6 +26,7 @@
     <div class="nav-inner container">
       <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
@@ -35,6 +36,7 @@
     </div>
     <div class="nav-drawer" id="navDrawer">
       <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
       <a href="download.html">Download</a>
       <a href="install.html">Install</a>
       <a href="how-it-works.html">How it works</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://openvoiceflow.com/mission.html</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://openvoiceflow.com/download.html</loc>
     <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/test_docs_distribution.py
+++ b/tests/test_docs_distribution.py
@@ -66,7 +66,7 @@ def test_public_downloads_remain_website_hosted():
 
 
 def test_privacy_friendly_web_observability_is_present_without_native_telemetry():
-    public_pages = ["index.html", "download.html", "install.html", "how-it-works.html", "privacy.html"]
+    public_pages = ["index.html", "download.html", "install.html", "how-it-works.html", "privacy.html", "mission.html"]
     for page in public_pages:
         html = (DOCS / page).read_text(encoding="utf-8")
         assert "va.vercel-scripts.com/v1/script.js" in html


### PR DESCRIPTION
The mission was a homepage section; the owner is right that the strongest
argument deserves a page and a nav slot.

**`mission.html`** — "Your voice is not a subscription":

- Talking to your computer is a basic need in the AI era, and basic needs
  are never gated by payment.
- **Pay for tokens, not permission**: dictation is free for everyone,
  on-device; the one optional extra (AI cleanup) is bring-your-own-key at
  provider cost in cents — or Ollama at none. "Go buy tokens, go build
  something, and keep the $144."
- The best version of this app is the one every OS makes unnecessary.
- Who builds it (Shimoverse Studios + contributors) and under what terms
  (MIT + brand policy + privacy pointers).

Deliberately absent: the "98% of users" figure — invented numbers don't go
on the mission page. The honest version is stronger: core dictation is free
for **100%** of users; only the optional cleanup involves anyone's money,
paid to the model provider directly.

Wiring: Mission in the nav, drawer, and footer of every page; the homepage
section tightened with the payment-gate line and linking through; `AboutPage`
JSON-LD; sitemap entry; `llms.txt` priority link; the analytics-posture test
now covers the new page. All 239 tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_