### PR TITLE
The engine that could never download, and the browsing that downloaded too much

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-07-27
+
+### Fixed
+- **Large turbo could never download.** Its model id didn't exist in the
+  WhisperKit repo; every user who chose it hit "no models found" disguised as
+  a connection error. Correct id shipped, saved settings migrate silently.
+- Browsing the engine chooser no longer starts a download per click: a 1.5 s
+  grace window ("Starting in a moment — switch engines freely") starts the
+  transfer only once the choice rests, and switching cancels the superseded
+  download outright. Model loads are single-flight, so overlapping transfers
+  can no longer corrupt each other's cache.
+- Download failure copy points at Details instead of guessing "check your
+  connection" — the guess was wrong exactly when it mattered.
+
 ## [0.5.2] — 2026-07-26
 
 The first-run field-notes release.

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.2</string>
-    <key>CFBundleVersion</key><string>7</string>
+    <key>CFBundleShortVersionString</key><string>0.5.3</string>
+    <key>CFBundleVersion</key><string>8</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/Sources/OpenVoiceFlow/AppController.swift
+++ b/native/Sources/OpenVoiceFlow/AppController.swift
@@ -163,7 +163,9 @@ final class AppController: ObservableObject {
         guard name != settings.whisperModel else { return }
         settings.whisperModel = name
         settings.save()
-        Task { await transcriber.setModel(name) }
+        // setModel no longer loads (onboarding needs the swap and the download
+        // decoupled); the Settings path still wants the hot-swap immediately.
+        Task { await transcriber.setModel(name); try? await transcriber.warmUp() }
     }
 
     // MARK: dictation loop

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -721,7 +721,7 @@ struct DashboardView: View {
         ("tiny", "Tiny — 39 MB"),
         ("small", "Small — 466 MB"),
         ("medium", "Medium — 1.5 GB"),
-        ("large-v3-turbo", "Large v3 turbo — 1.6 GB"),
+        ("large-v3-v20240930", "Large v3 turbo — 1.6 GB"),
     ]
     static let languages: [(String, String)] = [
         ("en", "English"), ("es", "Spanish"), ("fr", "French"), ("de", "German"),

--- a/native/Sources/OpenVoiceFlow/OnboardingView.swift
+++ b/native/Sources/OpenVoiceFlow/OnboardingView.swift
@@ -650,6 +650,12 @@ private struct KnowMeDownloadStep: View {
     /// Invalidates a superseded download's callbacks when the user switches
     /// engines mid-transfer, so the old transfer can't drive the new bar.
     @State private var generation = 0
+    /// The pending/running download task, cancelled whenever a newer choice
+    /// supersedes it — cancellation reaches all the way into the transfer.
+    @State private var pending: Task<Void, Never>?
+    /// True during the grace window between tapping an engine and the
+    /// download actually starting — browsing must not start four downloads.
+    @State private var debouncing = false
 
     private var p: OBPalette { palette }
 
@@ -659,7 +665,10 @@ private struct KnowMeDownloadStep: View {
         ("tiny", "Tiny", "39 MB", "Fastest. Fine for quick notes.", false),
         ("small", "Small", "466 MB", "Everyday dictation on any Mac.", true),
         ("medium", "Medium", "1.5 GB", "Hears more, asks more of your Mac.", false),
-        ("large-v3-turbo", "Large turbo", "1.6 GB", "Hears the most. Best on Apple Silicon.", false),
+        // The id is the WhisperKit repo folder suffix (openai_whisper-…);
+        // "large-v3-turbo" shipped in 0.5.2 and matched NOTHING — every user
+        // who picked it hit a guaranteed "no models found" failure.
+        ("large-v3-v20240930", "Large turbo", "1.6 GB", "Hears the most. Best on Apple Silicon.", false),
     ]
 
     var body: some View {
@@ -776,11 +785,13 @@ private struct KnowMeDownloadStep: View {
             .padding(.top, 11)
 
             if failed {
-                Text("That stopped. Check your connection?")
+                // Not "check your connection" — the 0.5.2 model-id bug proved
+                // that guessing a cause gaslights the user when it's wrong.
+                Text("That stopped — Details has the reason.")
                     .font(.system(size: 12.5)).foregroundStyle(Color(hex: 0xC9C3B4))
                     .padding(.top, 9)
                 HStack(spacing: 14) {
-                    Button("Try again") { if let selected { download(engine: selected) } }
+                    Button("Try again") { if let selected { restart(engine: selected, delayMilliseconds: 0) } }
                         .buttonStyle(.plain)
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(p.onAccent)
@@ -802,7 +813,11 @@ private struct KnowMeDownloadStep: View {
                         .padding(.top, 6)
                 }
             } else {
-                Text("Downloaded once. After this, everything runs offline on this Mac.")
+                // The grace window says so out loud — a bar that sits at zero
+                // for a second with no explanation reads as broken.
+                Text(debouncing
+                     ? "Starting in a moment — switch engines freely."
+                     : "Downloaded once. After this, everything runs offline on this Mac.")
                     .font(.system(size: 11)).foregroundStyle(p.ink3)
                     .padding(.top, 9)
             }
@@ -842,48 +857,63 @@ private struct KnowMeDownloadStep: View {
     private func choose(_ id: String) {
         guard id != selected else { return }
         selected = id
-        download(engine: id)
+        restart(engine: id, delayMilliseconds: 1500)
     }
 
-    private func download(engine: String) {
-        // A switch mid-transfer supersedes the old download; its straggling
-        // callbacks must not touch the new bar or declare the step done.
+    /// Supersede whatever the previous tap started — pending or mid-transfer —
+    /// and begin `engine` after the grace window (zero for Try again). The
+    /// window is what makes browsing safe: compare all four options and only
+    /// the one your choice rests on downloads.
+    private func restart(engine: String, delayMilliseconds: Int) {
         generation += 1
         let gen = generation
+        pending?.cancel()
         done = false
         failed = false
         failureDetail = nil
         showDetail = false
         meter.reset()
-        percent = "0%"
+        percent = "starting…"
+        debouncing = delayMilliseconds > 0
 
-        Task {
-            await controller.selectModel(engine)
+        pending = Task {
+            if delayMilliseconds > 0 {
+                try? await Task.sleep(for: .milliseconds(delayMilliseconds))
+                guard !Task.isCancelled, gen == generation else { return }
+                debouncing = false
+            }
+            await download(engine: engine, gen: gen)
+        }
+    }
+
+    private func download(engine: String, gen: Int) async {
+        await controller.selectModel(engine)
+        guard gen == generation else { return }
+        // Switching back to an engine that already finished downloading:
+        // land the bar, no second transfer.
+        if await controller.isModelReady() {
             guard gen == generation else { return }
-            // Switching back to an engine that already finished downloading:
-            // land the bar, no second transfer.
-            if await controller.isModelReady() {
-                guard gen == generation else { return }
-                meter.complete()
-                done = true
-                return
-            }
-            do {
-                try await controller.prepareModelForOnboarding { received, expected in
-                    Task { @MainActor in
-                        guard gen == generation else { return }
-                        meter.update(received: received, expected: expected)
-                        percent = meter.percentText
-                    }
+            meter.complete()
+            done = true
+            return
+        }
+        do {
+            try await controller.prepareModelForOnboarding { received, expected in
+                Task { @MainActor in
+                    guard gen == generation else { return }
+                    meter.update(received: received, expected: expected)
+                    percent = meter.percentText
                 }
-                guard gen == generation else { return }
-                meter.complete()
-                done = true
-            } catch {
-                guard gen == generation else { return }
-                failed = true
-                failureDetail = error.localizedDescription
             }
+            guard gen == generation else { return }
+            meter.complete()
+            done = true
+        } catch is CancellationError {
+            // Superseded by a newer choice — the new download owns the UI.
+        } catch {
+            guard gen == generation else { return }
+            failed = true
+            failureDetail = error.localizedDescription
         }
     }
 

--- a/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
+++ b/native/Sources/OpenVoiceFlow/OpenVoiceFlowApp.swift
@@ -163,7 +163,7 @@ private struct MenuContent: View {
         ("tiny", "tiny — 39 MB"),
         ("small", "small — 466 MB"),
         ("medium", "medium — 1.5 GB"),
-        ("large-v3-turbo", "large-v3-turbo — 1.6 GB"),
+        ("large-v3-v20240930", "large-v3-turbo — 1.6 GB"),
     ]
 
     var body: some View {

--- a/native/Sources/OpenVoiceFlow/Settings.swift
+++ b/native/Sources/OpenVoiceFlow/Settings.swift
@@ -85,6 +85,12 @@ struct Settings: Codable, Equatable {
             decoded.loginItemMigrated = true
             decoded.save()
         }
+        // 0.5.2 offered a model id that doesn't exist in the WhisperKit repo;
+        // anyone who saved it was stuck failing every download. Idempotent.
+        if decoded.whisperModel == "large-v3-turbo" {
+            decoded.whisperModel = "large-v3-v20240930"
+            decoded.save()
+        }
         return decoded
     }
 

--- a/native/Sources/OpenVoiceFlow/Transcriber.swift
+++ b/native/Sources/OpenVoiceFlow/Transcriber.swift
@@ -19,6 +19,9 @@ actor Transcriber {
     /// downloads plus the purge-and-retry path deleting the cache folder the
     /// other is writing into produced the cold-run "That stopped" failures.
     private var loadTask: Task<WhisperKit, Error>?
+    /// Identity for the task above — Task is a struct, so ownership of the
+    /// slot is tracked by token, not by reference comparison.
+    private var loadToken = UUID()
     private let log = Logger(subsystem: "app.openvoiceflow", category: "transcriber")
 
     init(model: String = "base.en") {
@@ -79,8 +82,12 @@ actor Transcriber {
                 return try await self.downloadAndLoad(model: model, progress: observer)
             }
         }
+        let token = UUID()
+        loadToken = token
         loadTask = task
-        defer { if loadTask === task { loadTask = nil } }
+        // Clear only our own slot: a setModel during the await may already
+        // have replaced it with a newer load that must not be evicted.
+        defer { if loadToken == token { loadTask = nil } }
 
         let loaded = try await task.value
         // A setModel that raced this load already cancelled the task; this

--- a/native/Sources/OpenVoiceFlow/Transcriber.swift
+++ b/native/Sources/OpenVoiceFlow/Transcriber.swift
@@ -13,23 +13,29 @@ actor Transcriber {
 
     private var kit: WhisperKit?
     private var modelName: String
+    /// The one in-flight download+load. Single-flight is the whole point:
+    /// onboarding's engine chooser can fire warmUp while another warmUp is
+    /// mid-download (actor re-entrancy at the awaits), and two concurrent
+    /// downloads plus the purge-and-retry path deleting the cache folder the
+    /// other is writing into produced the cold-run "That stopped" failures.
+    private var loadTask: Task<WhisperKit, Error>?
     private let log = Logger(subsystem: "app.openvoiceflow", category: "transcriber")
 
     init(model: String = "base.en") {
         self.modelName = model
     }
 
-    /// Switch the transcription model at runtime so a Settings change takes
-    /// effect without an app restart: drop the loaded model and reload the new
-    /// one. Best-effort — if the reload fails, the next `transcribe` re-tries
-    /// warmUp (and can recover a truncated download). Note the shipped default
-    /// `base.en` is English-only; a non-English language needs a multilingual
-    /// model (the Settings picker offers them).
+    /// Switch the transcription model: drop the loaded model, cancel any
+    /// in-flight load of the old one, and leave loading to the next warmUp —
+    /// callers decide when the download starts (onboarding debounces it; the
+    /// Settings path warms up immediately). Note the shipped default `base.en`
+    /// is English-only; a non-English language needs a multilingual model.
     func setModel(_ name: String) async {
         guard name != modelName else { return }
         modelName = name
         kit = nil
-        try? await warmUp()
+        loadTask?.cancel()
+        loadTask = nil
     }
 
     /// True once the model is loaded in memory — lets onboarding skip the
@@ -48,25 +54,50 @@ actor Transcriber {
             return
         }
 
-        do {
-            kit = try await downloadAndLoad(progress: observer)
-        } catch {
-            // The first failure must leave a trace: without it, a machine
-            // that fails twice presents only the second error, and the
-            // truncated-download recovery path is invisible in the log.
-            log.error("model \(self.modelName, privacy: .public) load failed, purging and retrying: \(error.localizedDescription, privacy: .public)")
-            purgeDownloadedModel()
-            kit = try await downloadAndLoad(progress: observer)
+        // Join the in-flight load rather than starting a second one. The
+        // joiner gets no byte progress (rare path — e.g. transcribe racing
+        // onboarding); correctness over cosmetics.
+        if let inFlight = loadTask {
+            kit = try await inFlight.value
+            observer(1, 1)
+            return
         }
+
+        let model = modelName
+        let task = Task { () throws -> WhisperKit in
+            do {
+                return try await self.downloadAndLoad(model: model, progress: observer)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // The first failure must leave a trace: without it, a machine
+                // that fails twice presents only the second error, and the
+                // truncated-download recovery path is invisible in the log.
+                self.log.error("model \(model, privacy: .public) load failed, purging and retrying: \(error.localizedDescription, privacy: .public)")
+                self.purgeDownloadedModel(matching: model)
+                try Task.checkCancellation()
+                return try await self.downloadAndLoad(model: model, progress: observer)
+            }
+        }
+        loadTask = task
+        defer { if loadTask === task { loadTask = nil } }
+
+        let loaded = try await task.value
+        // A setModel that raced this load already cancelled the task; this
+        // guard covers the narrow window where the swap lands between the
+        // last await and here — a stale model must never become `kit`.
+        guard model == modelName else { throw CancellationError() }
+        kit = loaded
         // No synthetic final callback: tracking the running total in a captured
         // var races WhisperKit's progress thread (a hard error under Swift 6).
         // The caller lands the bar on full instead — see DownloadMeter.complete().
     }
 
-    private func downloadAndLoad(progress observer: @escaping DownloadProgressObserver) async throws -> WhisperKit {
-        let modelFolder = try await WhisperKit.download(variant: modelName) { progress in
+    private func downloadAndLoad(model: String, progress observer: @escaping DownloadProgressObserver) async throws -> WhisperKit {
+        let modelFolder = try await WhisperKit.download(variant: model) { progress in
             observer(progress.completedUnitCount, progress.totalUnitCount)
         }
+        try Task.checkCancellation()
         return try await WhisperKit(
             WhisperKitConfig(
                 modelFolder: modelFolder.path,
@@ -78,16 +109,18 @@ actor Transcriber {
         )
     }
 
-    /// Remove every on-disk variant of this model from WhisperKit's default
-    /// download location so the retry starts with fresh model files.
-    private func purgeDownloadedModel() {
+    /// Remove every on-disk variant of one model from WhisperKit's default
+    /// download location so the retry starts with fresh model files. Takes the
+    /// model explicitly so a purge can never race a swap and delete the folder
+    /// a *different* model's download is writing into.
+    private func purgeDownloadedModel(matching model: String) {
         let fm = FileManager.default
         let repo = fm.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appending(path: "huggingface/models/argmaxinc/whisperkit-coreml")
         guard let variants = try? fm.contentsOfDirectory(
             at: repo, includingPropertiesForKeys: nil
         ) else { return }
-        for variant in variants where variant.lastPathComponent.hasSuffix(modelName) {
+        for variant in variants where variant.lastPathComponent.hasSuffix(model) {
             try? fm.removeItem(at: variant)
         }
     }

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.2
-        CURRENT_PROJECT_VERSION: 7
+        MARKETING_VERSION: 0.5.3
+        CURRENT_PROJECT_VERSION: 8
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
The owner's cold-run test, minutes into onboarding, found both bugs in the
engine chooser.

## Large turbo could never download — for anyone

It shipped with model id `large-v3-turbo`, which **does not exist** in the
WhisperKit repo. The matcher globs `*openai*{id}/*`, so tiny/small/medium
worked and this one produced `No models found matching "*openai*large-v3-turbo/*"`
— dressed up by our own copy as *"Check your connection?"*. The real id for
OpenAI's turbo model is `large-v3-v20240930` (verified against the live
`argmaxinc/whisperkit-coreml` tree; full size ≈ 1.6 GB, matching our label).

Fixed in all three pickers (onboarding, dashboard, menu), with an idempotent
settings migration for anyone who saved the broken value, and failure copy
that points at **Details** instead of guessing a cause — the guess was wrong
exactly when it mattered.

## Browsing the options started a download per click

And the failure path purged the very cache folder a superseded download
could still be writing into — overlapping transfers self-interfered. Now:

- `Transcriber` loads are **single-flight**: an in-flight load is joined,
  never duplicated; `setModel` cancels the old load instead of starting its
  own; purge only touches the model that actually failed.
- The chooser waits a **1.5 s grace window** before starting anything —
  "Starting in a moment — switch engines freely" — and a newer tap cancels
  the superseded transfer outright rather than just muting its callbacks.
  Try again skips the window.

## Verification

CI compiles it; the behavior fix needs the owner's next cold-run pass —
which is exactly the test that caught this. Ships as 0.5.3.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_