### PR TITLE
The RECOMMENDED chip earns its adjective

### DIFF
--- a/native/Sources/OpenVoiceFlow/OnboardingView.swift
+++ b/native/Sources/OpenVoiceFlow/OnboardingView.swift
@@ -672,15 +672,37 @@ private struct KnowMeDownloadStep: View {
 
     /// The engines on offer — size and benefit up front, decision theirs.
     /// Same ids the dashboard and menu speak.
-    private static let engines: [(id: String, name: String, size: String, benefit: String, recommended: Bool)] = [
-        ("tiny", "Tiny", "39 MB", "Fastest. Fine for quick notes.", false),
-        ("small", "Small", "466 MB", "Everyday dictation on any Mac.", true),
-        ("medium", "Medium", "1.5 GB", "Hears more, asks more of your Mac.", false),
+    private static let engines: [(id: String, name: String, size: String, benefit: String)] = [
+        ("tiny", "Tiny", "39 MB", "Fastest. Fine for quick notes."),
+        ("small", "Small", "466 MB", "Everyday dictation on any Mac."),
+        ("medium", "Medium", "1.5 GB", "Hears more, asks more of your Mac."),
         // The id is the WhisperKit repo folder suffix (openai_whisper-…);
         // "large-v3-turbo" shipped in 0.5.2 and matched NOTHING — every user
         // who picked it hit a guaranteed "no models found" failure.
-        ("large-v3-v20240930", "Large turbo", "1.6 GB", "Hears the most. Best on Apple Silicon.", false),
+        ("large-v3-v20240930", "Large turbo", "1.6 GB", "Hears the most. Best on Apple Silicon."),
     ]
+
+    /// Which engine the RECOMMENDED chip sits on, decided from this Mac —
+    /// no permissions involved: chip type and free disk are plain reads.
+    /// Apple Silicon absorbs Large turbo easily and its accuracy is what
+    /// people keep once they've heard it; Intel gets Small, and so does any
+    /// Mac without real headroom past the 1.6 GB download.
+    private static let recommendedEngineID: String = {
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        let machine = withUnsafeBytes(of: &sysinfo.machine) { buf in
+            String(decoding: buf.prefix(while: { $0 != 0 }), as: UTF8.self)
+        }
+        let appleSilicon = machine.hasPrefix("arm64")
+
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let free = (try? home.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        ))?.volumeAvailableCapacityForImportantUsage ?? 0
+        let roomy = free > 5_000_000_000  // model + working headroom
+
+        return (appleSilicon && roomy) ? "large-v3-v20240930" : "small"
+    }()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -716,8 +738,8 @@ private struct KnowMeDownloadStep: View {
                             .frame(width: 15, height: 15)
                         Text(engine.name)
                             .font(.system(size: 13, weight: .semibold)).foregroundStyle(p.ink)
-                        if engine.recommended {
-                            Text("POPULAR")
+                        if engine.id == Self.recommendedEngineID {
+                            Text("RECOMMENDED")
                                 .font(.system(size: 9, weight: .bold)).kerning(0.5)
                                 .foregroundStyle(p.accent)
                                 .padding(.horizontal, 6).padding(.vertical, 2)


### PR DESCRIPTION
The owner's verdict after dictating with all four engines on a real Mac:
Large turbo's accuracy is what people keep once they've heard it.

So the chip stops being a popularity claim ("POPULAR" on Small) and becomes
a **recommendation computed from the Mac it's on**:

- **Apple Silicon with &gt;5 GB free disk** → RECOMMENDED sits on Large turbo
- **Intel, or a tight disk** → RECOMMENDED stays on Small (turbo genuinely
  chugs on Intel, and pushing a 1.6 GB download at a nearly-full disk is
  hostile)

Both signals — `uname` machine arch and
`volumeAvailableCapacityForImportantUsage` — are plain reads with **zero
permission prompts**, which was the owner's condition for doing this at all.

The explicit-choice design stands: nothing is preselected, nothing downloads
until a tap, only the badge moves.

Rides the next release with the rest of the cold-run findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USxiqDqgco9GEoKCv1DL9Y)_