### PR TITLE
fix(site): show Fn as the default dictation key

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,7 @@
         <div class="typed-box"><span id="typedDemo">Ship the beta tonight — the release notes are already in the doc.</span><span class="caret"></span></div>
         <div class="hero-cap-row">
           <div class="hero-cap">
-            <span class="hero-chip" id="heroChip">⌘<small>HELD</small></span>
+            <span class="hero-chip" id="heroChip">fn<small>HELD</small></span>
             <canvas data-wf="hero"></canvas>
             <span class="hero-status" id="heroStatus">listening</span>
           </div>
@@ -148,8 +148,8 @@
       <div class="card-grid">
         <div class="card">
           <span class="mono-kicker">01 · Hold</span>
-          <span class="key-chip">⌘ <small>right</small></span>
-          <div class="card-body">One key, any app.</div>
+          <span class="key-chip">fn <small>Globe</small></span>
+          <div class="card-body">Hold, speak, release. One key, any app.</div>
         </div>
         <div class="card">
           <span class="mono-kicker">02 · Speak</span>


### PR DESCRIPTION
## Summary
- replace stale Command-key imagery on the homepage with the shipped Fn / Globe default
- clarify the hold, speak, release interaction

## Verification
- ran all 8 `tests/test_docs_distribution.py` contracts directly with Homebrew Python
- verified homepage HTML parses and contains the Fn / Globe copy
- `git diff --check` clean

The local `native/OpenVoiceFlow.xcodeproj/project.pbxproj` edit was preserved in its separate worktree and is not part of this PR.