### PR TITLE
Remove GitHub links from the website; make credit-and-tell-us the reuse ask

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ macOS 12–13 fallback build. New work belongs in `native/` unless you're fixing
 something in the website or docs.
 
 This is a **single-maintainer open-source project**. Issues and PRs get
-best-effort responses on a human schedule. There is no SLA. If you need a fix
-faster than the maintainer can land it, fork freely — that's what MIT is for.
+best-effort responses on a human schedule. There is no SLA. If you build on
+this code in your own project, keep the credit visible and tell us about it
+at shimoverse@gmail.com — we like knowing where the work travels.
 
 ## Working on the native app (the usual case)
 

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ The one-page version: audio on-device always; text to a cloud only if you enable
 
 ## License
 
-[MIT](LICENSE) © Shimoverse Studios and contributors — free for any use, forever; the copyright notice must travel with every copy. The **name and logo** are governed separately by the [brand policy](TRADEMARKS.md): forks and derivatives must rebrand and credit the original. Third-party notices: [docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md).
+[MIT](LICENSE) © Shimoverse Studios and contributors — free for any use, forever; the copyright notice must travel with every copy. **If you use or build on OpenVoiceFlow, credit the project visibly — and email shimoverse@gmail.com to tell us about it.** The **name and logo** are governed separately by the [brand policy](TRADEMARKS.md): derivatives must rebrand and credit the original. Third-party notices: [docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,8 +1,9 @@
 # Brand and trademark policy
 
-The OpenVoiceFlow **code** is MIT-licensed: use it, fork it, build on it,
-ship it — commercially or not. The MIT license already requires that our
-copyright notice travel with every copy.
+The OpenVoiceFlow **code** is MIT-licensed — free for any use, commercially
+or not. The MIT license already requires that our copyright notice travel
+with every copy, and we ask anyone building on the code to keep that credit
+visible and to tell us about it at shimoverse@gmail.com.
 
 The OpenVoiceFlow **name, logo, and visual identity** are a different thing.
 They identify this project, built and maintained by Shimoverse Studios, and

--- a/docs/blog/best-dictation-software-mac.html
+++ b/docs/blog/best-dictation-software-mac.html
@@ -85,7 +85,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -133,7 +132,7 @@
           <h2>OpenVoiceFlow — free, open source, on-device</h2>
           <p><strong>Free forever · MIT-licensed · macOS 14+</strong></p>
           <p>Ours, so judge for yourself: hold a key, talk, release — text lands at your cursor in any app. Whisper runs locally via WhisperKit (pick anything from <code>tiny</code> to <code>large-v3-turbo</code>), audio never leaves the Mac, and there's no account or telemetry. A personal dictionary fixes the names Whisper mangles, snippets expand spoken shortcuts into full text, and per-app styles keep Slack casual and Mail formal. Optional AI cleanup is bring-your-own-key — OpenRouter, OpenAI, Anthropic, Groq, or fully local via Ollama — and touches text only, never audio.</p>
-          <p>The honest costs: it's macOS 14+ only (no Windows; mobile is in development but not out), cleanup means pasting an API key once, and support is GitHub issues rather than a help desk. The <a href="https://github.com/shimoverse/openvoiceflow">source is public</a> if you want to verify any of this.</p>
+          <p>The honest costs: it's macOS 14+ only (no Windows; mobile is in development but not out), cleanup means pasting an API key once, and support is a community rather than a help desk. The source is public if you want to verify any of this.</p>
           <p class="muted"><em>Best for: daily dictation without a subscription; anyone whose audio must stay on the machine.</em></p>
 
           <h2>Wispr Flow — the polished cloud subscription</h2>
@@ -216,7 +215,6 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="index.html">Blog</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/blog/how-to-dictate-on-mac.html
+++ b/docs/blog/how-to-dictate-on-mac.html
@@ -87,7 +87,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -219,7 +218,6 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="index.html">Blog</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -48,7 +48,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -124,7 +123,6 @@
         <a href="../install.html">Install</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/blog/offline-dictation-mac.html
+++ b/docs/blog/offline-dictation-mac.html
@@ -85,7 +85,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -156,7 +155,7 @@
           <h3>Can the AI cleanup step really run offline too?</h3>
           <p>Yes, via Ollama on the same machine. Small instruct models handle grammar-and-filler cleanup well. Cleanup is Off by default anyway, so the out-of-box pipeline is already fully local.</p>
           <h3>Does OpenVoiceFlow phone home at all?</h3>
-          <p>The app has no telemetry and no account system. Auto-update checks fetch a signed feed from this website when online; audio and transcripts are never uploaded, as the <a href="../privacy.html">privacy page</a> spells out — and the <a href="https://github.com/shimoverse/openvoiceflow">source</a> is public if you'd rather verify than trust.</p>
+          <p>The app has no telemetry and no account system. Auto-update checks fetch a signed feed from this website when online; audio and transcripts are never uploaded, as the <a href="../privacy.html">privacy page</a> spells out — and the source is public if you'd rather verify than trust.</p>
 
           <div class="article-cta">
             <h2>Set it up before the flight</h2>
@@ -191,7 +190,6 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="index.html">Blog</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/blog/voice-typing-for-developers.html
+++ b/docs/blog/voice-typing-for-developers.html
@@ -70,7 +70,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -116,7 +115,7 @@
           <h2>The setup that actually sticks</h2>
           <p>OpenVoiceFlow is <a href="../index.html">our app</a>, free and open source, so the specifics below use it — but the principles port anywhere.</p>
           <ol>
-            <li><strong>Push-to-talk on a key you don't fight over.</strong> Default is <code>fn</code>. Hold, talk, release; text lands in whatever has focus — Cursor's chat pane, a GitHub comment box, your terminal. It's a <a href="../how-it-works.html">five-stage local pipeline</a> under the hood, but it feels like a longer spacebar.</li>
+            <li><strong>Push-to-talk on a key you don't fight over.</strong> Default is <code>fn</code>. Hold, talk, release; text lands in whatever has focus — Cursor's chat pane, a code-review comment box, your terminal. It's a <a href="../how-it-works.html">five-stage local pipeline</a> under the hood, but it feels like a longer spacebar.</li>
             <li><strong>Load the dictionary before you judge accuracy.</strong> Whisper has never seen your service names, and no model size fixes that (<a href="whisper-models-for-dictation.html">we explain why</a>). Spend five minutes: <code>kubectl</code>, <code>useEffect</code>, <code>psql</code>, <code>nginx</code>, teammates' names, the staging cluster's cursed codename. Every term is fixed once, forever.</li>
             <li><strong>Per-app styles.</strong> Casual in Slack, imperative-mood in commit messages, formal in email — configured once per app, applied automatically.</li>
             <li><strong>Snippets for the boilerplate.</strong> Spoken shortcuts that expand to full text: your standup preamble, the bug-report template, the "thanks, merging" sign-off.</li>
@@ -124,7 +123,7 @@
           </ol>
 
           <h2>The part your security team will ask about</h2>
-          <p>Speaking your codebase's internals aloud to a cloud transcription service is a genuinely reasonable thing for a security team to veto. The clean answer is architectural: with on-device transcription, the audio never leaves the Mac — there's no server, no account, no retention policy to audit, because there's no upload. OpenVoiceFlow's transcription is local always; with cleanup Off or pointed at Ollama, the entire pipeline is airtight, NDA-code included. The <a href="../privacy.html">privacy page</a> states it plainly, and since the app is MIT-licensed, "trust us" is replaced by <a href="https://github.com/shimoverse/openvoiceflow">"read it"</a> — an argument that tends to end the meeting. It also works offline entirely, as <a href="offline-dictation-mac.html">we've tested with the radios off</a>.</p>
+          <p>Speaking your codebase's internals aloud to a cloud transcription service is a genuinely reasonable thing for a security team to veto. The clean answer is architectural: with on-device transcription, the audio never leaves the Mac — there's no server, no account, no retention policy to audit, because there's no upload. OpenVoiceFlow's transcription is local always; with cleanup Off or pointed at Ollama, the entire pipeline is airtight, NDA-code included. The <a href="../privacy.html">privacy page</a> states it plainly, and since the app is MIT-licensed, "trust us" is replaced by "read it" — an argument that tends to end the meeting. It also works offline entirely, as <a href="offline-dictation-mac.html">we've tested with the radios off</a>.</p>
 
           <h2>A week-long experiment worth running</h2>
           <p>Don't change your workflow; add one held key. For one week, dictate only two things: every AI prompt, and every PR description or review comment. Notice two effects — the obvious one (words per minute) and the sneaky one: your prompts get <em>longer and better</em>, because the cost of context dropped to nearly zero. Most people who try this stop noticing they're doing it by Thursday, which is the highest compliment an input method can earn.</p>
@@ -144,7 +143,7 @@
             <p>Free and open source. Hold a key, describe the bug properly for once, release. The keyboard keeps the semicolons.</p>
             <div class="hero-cta-row">
               <a class="btn btn-primary btn-lg" href="../download.html">Download for Mac — free</a>
-              <a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">Read the source ↗</a>
+              <a class="btn btn-outline btn-lg" href="../how-it-works.html">See how it works</a>
             </div>
           </div>
 
@@ -172,7 +171,6 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="index.html">Blog</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/blog/whisper-models-for-dictation.html
+++ b/docs/blog/whisper-models-for-dictation.html
@@ -72,7 +72,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -104,7 +103,7 @@
           <p>OpenVoiceFlow ships every Whisper size from <code>tiny</code> to <code>large-v3-turbo</code> and lets you switch between them freely, which means we've watched a lot of people pick wrong in both directions: laptops fighting a model far too big for them, and daily dictators tolerating errors a one-notch upgrade would have erased. This is the guide we wish we could hand every one of them. It applies to any Whisper-based tool, not just ours.</p>
 
           <h2>Thirty seconds on what Whisper is</h2>
-          <p>Whisper is a family of open speech-recognition models that OpenAI released in 2022, trained on a huge corpus of audio from the web. The family spans sizes from <code>tiny</code> (about 39 million parameters) to <code>large-v3</code> (about 1.55 billion), all sharing one architecture: an encoder that listens and a decoder that writes. Because the weights are open, apps can run them entirely on your machine — on Macs, typically through <a href="https://github.com/argmaxinc/WhisperKit">WhisperKit</a>, which compiles them for Apple's Neural Engine and GPU. That's what makes private, offline, subscription-free dictation possible at all.</p>
+          <p>Whisper is a family of open speech-recognition models that OpenAI released in 2022, trained on a huge corpus of audio from the web. The family spans sizes from <code>tiny</code> (about 39 million parameters) to <code>large-v3</code> (about 1.55 billion), all sharing one architecture: an encoder that listens and a decoder that writes. Because the weights are open, apps can run them entirely on your machine — on Macs, typically through WhisperKit, which compiles them for Apple's Neural Engine and GPU. That's what makes private, offline, subscription-free dictation possible at all.</p>
 
           <h2>What actually changes as models grow</h2>
           <p>Three things, and they're worth separating:</p>
@@ -184,7 +183,6 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="index.html">Blog</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/blog/wispr-flow-alternative.html
+++ b/docs/blog/wispr-flow-alternative.html
@@ -40,7 +40,7 @@
       {"@type": "Question", "name": "Does OpenVoiceFlow work offline like Wispr Flow?",
        "acceptedAnswer": {"@type": "Answer", "text": "OpenVoiceFlow works offline out of the box because transcription happens on your Mac. Wispr Flow transcribes in the cloud, so it needs a connection. With cleanup Off (the default) or local Ollama cleanup, OpenVoiceFlow needs no internet at all after the one-time model download."}},
       {"@type": "Question", "name": "What does OpenVoiceFlow not do that Wispr Flow does?",
-       "acceptedAnswer": {"@type": "Answer", "text": "As of July 2026 OpenVoiceFlow is macOS-only — no Windows app, and the iOS version is still in development. AI cleanup is bring-your-own-key rather than bundled, and support is community-based via GitHub rather than a paid support team."}},
+       "acceptedAnswer": {"@type": "Answer", "text": "As of July 2026 OpenVoiceFlow is macOS-only — no Windows app, and the iOS version is still in development. AI cleanup is bring-your-own-key rather than bundled, and support is community-based rather than a paid support team."}},
       {"@type": "Question", "name": "Is OpenVoiceFlow affiliated with Wispr Flow?",
        "acceptedAnswer": {"@type": "Answer", "text": "No. OpenVoiceFlow is an independent open-source project by Shimoverse Studios and contributors, with no affiliation to Wispr Flow. Comparison details come from Wispr Flow's published pricing and documentation as of July 2026."}}
     ]
@@ -72,7 +72,6 @@
         <li><a href="../how-it-works.html">How it works</a></li>
         <li><a href="../install.html">Install</a></li>
         <li><a href="index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -114,8 +113,8 @@
 
           <h2>What OpenVoiceFlow does differently</h2>
           <p>OpenVoiceFlow keeps the interaction Wispr Flow got right — hold a key, talk, release, text appears at your cursor — and moves everything underneath it onto your own machine.</p>
-          <p><strong>Transcription is local, always.</strong> <a href="https://github.com/argmaxinc/WhisperKit">WhisperKit</a> runs OpenAI's Whisper models directly on your Mac, from <code>tiny</code> to <code>large-v3-turbo</code>. Audio is processed in memory and discarded the moment text exists. There is no server to upload to — we don't run any. Airplane mode works fine. (More on picking a model in <a href="whisper-models-for-dictation.html">our Whisper model guide</a>.)</p>
-          <p><strong>It's free because there's nothing to sell.</strong> No account, no telemetry, no trial that expires. The code is MIT-licensed and <a href="https://github.com/shimoverse/openvoiceflow">public on GitHub</a>, so "your audio never leaves your Mac" isn't a marketing claim you have to trust — it's a code path you can read.</p>
+          <p><strong>Transcription is local, always.</strong> WhisperKit runs OpenAI's Whisper models directly on your Mac, from <code>tiny</code> to <code>large-v3-turbo</code>. Audio is processed in memory and discarded the moment text exists. There is no server to upload to — we don't run any. Airplane mode works fine. (More on picking a model in <a href="whisper-models-for-dictation.html">our Whisper model guide</a>.)</p>
+          <p><strong>It's free because there's nothing to sell.</strong> No account, no telemetry, no trial that expires. The code is MIT-licensed and public, so "your audio never leaves your Mac" isn't a marketing claim you have to trust — it's a code path anyone can read.</p>
           <p><strong>AI cleanup is optional and yours.</strong> Out of the box you get the raw on-device transcript. Flip on cleanup and it polishes grammar and drops the "um"s using a backend <em>you</em> choose: OpenRouter, OpenAI, Anthropic, or Groq with your own API key — or a fully local model through Ollama. You pay the model provider cents for tokens, not a middleman a flat monthly fee. Only cleaned <em>text</em> ever touches an API; audio never does.</p>
           <p><strong>The details that make dictation stick are here too.</strong> A personal dictionary so it stops mangling your coworkers' names. Spoken snippets that expand to full text. Per-app styles, so you sound casual in Slack and buttoned-up in Mail. A live HUD so you can see it hearing you.</p>
 
@@ -132,7 +131,7 @@
                 <tr><td>Source code</td><td>Open — MIT</td><td>Closed</td></tr>
                 <tr><td>AI cleanup</td><td>Optional, your key or local Ollama</td><td>Bundled, their pipeline</td></tr>
                 <tr><td>Platforms</td><td>macOS 14+ (Apple Silicon &amp; Intel)</td><td>macOS, Windows, iOS</td></tr>
-                <tr><td>Support</td><td>GitHub issues, community</td><td>Paid product support</td></tr>
+                <tr><td>Support</td><td>Community</td><td>Paid product support</td></tr>
               </tbody>
             </table>
           </div>
@@ -144,7 +143,7 @@
             <li><strong>No Windows app, no phone app today.</strong> OpenVoiceFlow is macOS 14+ only. iOS and Android versions are in development but you cannot download them yet. If you dictate across a Mac and a Windows machine daily, Wispr Flow currently serves you better.</li>
             <li><strong>Cleanup takes five minutes of setup.</strong> Wispr's polish is bundled; ours is bring-your-own-key. Pasting an OpenRouter key into settings is genuinely easy, but it is one more step than a checkout page.</li>
             <li><strong>Your Mac does the work.</strong> On-device Whisper is fast on Apple Silicon and fine on Intel with smaller models — but a cloud GPU farm will always outrun an eight-year-old MacBook Air. If your machine is old, temper expectations or stick with a smaller model.</li>
-            <li><strong>Community support.</strong> There's no support team, just maintainers and other users on GitHub. Bug reports get read; SLAs don't exist.</li>
+            <li><strong>Community support only.</strong> There's no support team, just maintainers and a community of users. Bug reports get read; SLAs don't exist.</li>
           </ul>
 
           <h2>Switching takes about ten minutes</h2>
@@ -199,7 +198,6 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="index.html">Blog</a>
         <a href="../privacy.html">Privacy</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/download.html
+++ b/docs/download.html
@@ -44,7 +44,6 @@
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="blog/index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -146,11 +145,9 @@
         <p class="answer-block" style="margin-top:16px">On macOS 12–13? Use the retained <a href="downloads/OpenVoiceFlow-0.3.6-arm64.dmg">OpenVoiceFlow 0.3.6 Apple Silicon fallback</a>. The native 0.5.5 app requires macOS 14.</p>
       </section>
 
-      <section class="content-card"><h2>Install from source</h2><p>The <a href="https://github.com/shimoverse/openvoiceflow">public GitHub repository</a> is MIT licensed. Clone it below if you prefer a source install; use the website-hosted DMGs above for the signed app.</p><code class="code-block">git clone https://github.com/shimoverse/openvoiceflow.git &amp;&amp; cd openvoiceflow &amp;&amp; bash install.sh</code></section>
+      <details class="content-card"><summary><h2>Download notes and limitations</h2></summary><ul class="check-list"><li>The primary website-hosted DMG is the verified OpenVoiceFlow v0.5.5 release build.</li><li>OpenVoiceFlow v0.5.5 supports macOS 14+ on Apple Silicon and Intel. Windows and Linux downloads are not currently available.</li><li>iOS and Android apps are in the works — store links will appear here when they ship. Until then, no mobile version is available.</li><li>For macOS 12–13, the retained <a href="downloads/OpenVoiceFlow-0.3.6-arm64.dmg">OpenVoiceFlow 0.3.6 Apple Silicon fallback</a> remains available.</li></ul></details>
 
-      <details class="content-card"><summary><h2>Download notes and limitations</h2></summary><ul class="check-list"><li>The primary website-hosted DMG is the verified OpenVoiceFlow v0.5.5 GitHub Release asset.</li><li>OpenVoiceFlow v0.5.5 supports macOS 14+ on Apple Silicon and Intel. Windows and Linux downloads are not currently available.</li><li>iOS and Android apps are in the works — store links will appear here when they ship. Until then, no mobile version is available.</li><li>For macOS 12–13, the retained <a href="downloads/OpenVoiceFlow-0.3.6-arm64.dmg">OpenVoiceFlow 0.3.6 Apple Silicon fallback</a> remains available.</li></ul></details>
-
-      <details class="content-card"><summary><h2>Download FAQ</h2></summary><h3>Is the source repository public?</h3><p>Yes. OpenVoiceFlow is MIT-licensed and open source on <a href="https://github.com/shimoverse/openvoiceflow">GitHub</a>. The website-hosted DMGs are the easiest signed install.</p><h3>Does OpenVoiceFlow send audio to the cloud?</h3><p>No. Audio transcription runs locally through on-device WhisperKit. Cleaned transcript text only goes to a cloud LLM if you turn on cloud cleanup.</p><h3>Which backend should I choose?</h3><p>Cleanup is Off by default (raw on-device transcript). Turn it on and pick OpenRouter — one key reaches any model — a direct provider (OpenAI, Anthropic, or Groq) with your own key, or local Ollama to keep cleanup fully on-device.</p></details>
+      <details class="content-card"><summary><h2>Download FAQ</h2></summary><h3>Is OpenVoiceFlow open source?</h3><p>Yes — MIT-licensed, free for any use. The website-hosted DMGs are the easiest signed install.</p><h3>Does OpenVoiceFlow send audio to the cloud?</h3><p>No. Audio transcription runs locally through on-device WhisperKit. Cleaned transcript text only goes to a cloud LLM if you turn on cloud cleanup.</p><h3>Which backend should I choose?</h3><p>Cleanup is Off by default (raw on-device transcript). Turn it on and pick OpenRouter — one key reaches any model — a direct provider (OpenAI, Anthropic, or Groq) with your own key, or local Ollama to keep cleanup fully on-device.</p></details>
     </div></section>
   </main>
 
@@ -165,7 +162,6 @@
         <a href="how-it-works.html">How it works</a>
         <a href="privacy.html">Privacy</a>
         <a href="blog/index.html">Blog</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -33,7 +33,6 @@
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="blog/index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -80,7 +79,6 @@
         <a href="install.html">Install</a>
         <a href="privacy.html">Privacy</a>
         <a href="blog/index.html">Blog</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,6 @@
     "name": "OpenVoiceFlow",
     "url": "https://openvoiceflow.com/",
     "logo": "https://openvoiceflow.com/assets/og-card.png",
-    "sameAs": ["https://github.com/shimoverse/openvoiceflow"],
     "description": "Open-source, free-forever voice dictation for macOS with on-device transcription. Mission: voice input as a basic feature for everyone, never gated by payment."
   }
   </script>
@@ -102,7 +101,6 @@
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="blog/index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -201,7 +199,7 @@
           <div class="privacy-copy">
             <div class="privacy-title">Your voice never leaves your&nbsp;Mac.</div>
             <div class="privacy-body">Not &ldquo;encrypted.&rdquo; Not &ldquo;anonymized.&rdquo; <b>Not sent.</b> Audio is transcribed on your Mac and discarded the moment text exists.</div>
-            <div class="privacy-note">Don't take our word for it — <a href="https://github.com/shimoverse/openvoiceflow">read the source</a>.</div>
+            <div class="privacy-note">Not a promise — an architecture. The code is MIT-licensed open source.</div>
           </div>
           <div class="privacy-box">
             <div class="privacy-box-label">YOUR MAC — AUDIO NEVER LEAVES THIS BOX</div>
@@ -268,7 +266,7 @@
       <div class="content-card">
         <h2>Our mission</h2>
         <p class="answer-block">In the AI era, talking to your computer is a basic need — and basic needs should never be gated by payment. Don't pay companies $144 a year for your own voice: dictation here is free for everyone, on-device, MIT-licensed, forever. The only optional extra, AI cleanup, is bring-your-own-key — pay the model provider cents for tokens, not a middleman for permission.</p>
-        <p class="answer-block">Honestly, we think every operating system should ship this as a default feature, and the day that happens well enough, apps like this one become unnecessary. Until then, we build it in the open — and if you are a developer who believes typing shouldn't be a toll booth, <a href="https://github.com/shimoverse/openvoiceflow">join us on GitHub</a>.</p>
+        <p class="answer-block">Honestly, we think every operating system should ship this as a default feature, and the day that happens well enough, apps like this one become unnecessary. Until then, we build it in the open — MIT-licensed and free for everyone, forever.</p>
         <p class="answer-block"><a href="mission.html"><strong>Read the full mission →</strong></a></p>
       </div>
     </section>
@@ -370,7 +368,6 @@
         <a href="how-it-works.html">How it works</a>
         <a href="privacy.html">Privacy</a>
         <a href="blog/index.html">Blog</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/install.html
+++ b/docs/install.html
@@ -33,7 +33,6 @@
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="blog/index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -54,13 +53,11 @@
       <span class="mono-kicker">Install guide · macOS 14+</span>
       <h1 class="hero-title">Install OpenVoiceFlow on macOS</h1>
       <p class="hero-sub answer-block">Install OpenVoiceFlow by downloading the signed macOS DMG from this website. The app transcribes locally with on-device WhisperKit; if you turn on cleanup it sends only text to your chosen cloud LLM — OpenRouter (one key, any model), or OpenAI / Anthropic / Groq with your own key — or runs cleanup locally with Ollama, or you can leave cleanup Off. The MIT-licensed source is also public.</p>
-      <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">View source ↗</a></div>
+      <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a></div>
 
       <section class="content-card"><h2>Fast path: DMG install</h2><ol class="step-list"><li>Open <a href="download.html">the download page</a> and pick Apple Silicon or Intel.</li><li>Download the DMG from this website.</li><li>Open the DMG and drag OpenVoiceFlow into Applications.</li><li>Launch OpenVoiceFlow. First launch runs a one-time setup (~5 minutes: on-device WhisperKit model download) with a progress dialog — grant Microphone, Accessibility, and Input Monitoring permissions when prompted.</li><li>OpenVoiceFlow appears in the <strong>Dock</strong> (click it any time to open the dashboard) and as a monochrome <strong>waveform menu-bar icon</strong> at the top-right. Prefer menu-bar only? Turn off <strong>Show in Dock</strong> in Settings.</li><li>Click in any text field, hold the <strong>fn / 🌐 Globe</strong> key, speak, then release it to paste the transcription. You can change the key in Settings.</li><li>Use the same menu to pause listening, change the dictation shortcut, open permission settings, or check for updates.</li></ol></section>
 
       <section class="content-card"><h2>First-run onboarding</h2><p>There is nothing to configure by hand. When you open OpenVoiceFlow for the first time, the built-in onboarding walks you through it:</p><ol class="step-list"><li>Grant <strong>Microphone</strong> access so the app can capture audio while you hold the hotkey.</li><li>Grant <strong>Accessibility</strong> so the cleaned text can be pasted at your cursor.</li><li>Grant <strong>Input Monitoring</strong> so the push-to-talk hotkey works in every app.</li><li>Let the app download the on-device WhisperKit speech model (a one-time download).</li></ol><p>Cleanup starts <strong>Off</strong> (raw on-device transcript). To enable it later, open the menu-bar settings and pick OpenRouter (or another cloud provider) with your key, or local Ollama. Keys are stored in the macOS Keychain.</p></section>
-
-      <section class="content-card"><h2>Build the app yourself</h2><p>The <a href="https://github.com/shimoverse/openvoiceflow">public GitHub repository</a> is MIT licensed. Clone it and build the native macOS app from source (the Xcode project lives under <code>native/</code>); use the signed website-hosted DMG for the easiest install.</p><code class="code-block">git clone https://github.com/shimoverse/openvoiceflow.git</code></section>
 
       <section class="content-card"><h2>Troubleshooting</h2><ul class="check-list"><li>If macOS still blocks launch, delete any older unsigned copy and re-download the current signed, Apple-notarized v0.5.5 DMG from this website.</li><li>If the waveform changes to a warning symbol, open <strong>Advanced</strong> in the menu and use the direct Microphone, Accessibility, or Input Monitoring settings links.</li><li>If transcription does not start, confirm microphone permission in macOS System Settings.</li><li>If paste fails, grant Accessibility permission to OpenVoiceFlow in System Settings.</li><li>If cloud cleanup fails, verify your OpenRouter key; OpenRouter uses its own key, not a provider-specific API key.</li><li>If you need a fully local flow, choose Ollama or leave cleanup <strong>Off</strong>.</li></ul></section>
     </div></section>
@@ -76,7 +73,6 @@
         <a href="how-it-works.html">How it works</a>
         <a href="privacy.html">Privacy</a>
         <a href="blog/index.html">Blog</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 
 - Voice dictation is a basic accessibility and productivity need; payment should never be the blocker. OpenVoiceFlow is free and MIT-licensed, forever.
 - People speak roughly 150 words per minute and type roughly 40; a Stanford study measured speech input at about three times keyboard speed.
-- The project's stated goal is for voice input to become a default operating-system feature; until then it is built in the open and welcomes contributors at https://github.com/shimoverse/openvoiceflow.
+- The project's stated goal is for voice input to become a default operating-system feature; until then it is built in the open and welcomes contributors.
 
 ## Priority pages
 
@@ -17,7 +17,6 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 - How it works: https://openvoiceflow.com/how-it-works.html
 - Website-hosted universal macOS DMG (v0.5.5): https://openvoiceflow.com/downloads/OpenVoiceFlow-0.5.5.dmg
 - Website-hosted macOS 12–13 fallback (v0.3.6 Apple Silicon): https://openvoiceflow.com/downloads/OpenVoiceFlow-0.3.6-arm64.dmg
-- Public MIT source repository: https://github.com/shimoverse/openvoiceflow
 - Product film (52-second MP4, original score, captioned): https://openvoiceflow.com/assets/openvoiceflow-demo.mp4
 
 ## Guides and articles
@@ -33,11 +32,11 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 ## Key facts
 
 - Category: macOS push-to-talk voice dictation.
-- Source repository: public and MIT licensed.
+- License: MIT, open source. Anyone using or building on OpenVoiceFlow must keep the credit visible, and the maintainers ask to be told about such use at shimoverse@gmail.com.
 - Platforms: macOS 14+ on Apple Silicon and Intel Macs.
 - Audio transcription: on-device WhisperKit.
 - Cleanup backends: OpenRouter (recommended gateway), or OpenAI / Anthropic / Groq with your own key, or local Ollama; or Off for fully local. Default is Off.
-- Download path: one website-hosted universal DMG (v0.5.5); a v0.3.6 fallback remains for macOS 12–13; source install is public.
+- Download path: one website-hosted universal DMG (v0.5.5); a v0.3.6 fallback remains for macOS 12–13.
 
 ## Do not claim
 
@@ -45,4 +44,4 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 - iOS and Android versions are in development but NOT yet available; do not claim they can be downloaded today.
 - Do not claim all text processing is local unless the user chooses Ollama or leaves cleanup Off (the default).
 - Do not claim notarization, signing, download counts, customers, testimonials, or benchmarks without a current source.
-- Do not claim affiliation with Wispr Flow, Superwhisper, VoiceInk, Apple, or GitHub.
+- Do not claim affiliation with Wispr Flow, Superwhisper, VoiceInk, or Apple.

--- a/docs/mission.html
+++ b/docs/mission.html
@@ -40,7 +40,6 @@
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="blog/index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -77,16 +76,16 @@
 
       <section class="content-card"><h2>The best version of this app is the one that becomes unnecessary.</h2>
         <p class="answer-block">Our goal is not to own a market. It is for voice input this good to be a default feature of every operating system — built in, free, private — so that third-party developers no longer need to build apps like this one. Until that day, we build it in the open: MIT-licensed, source public, every privacy claim checkable in code.</p>
-        <p class="answer-block">If you're a developer who believes typing shouldn't be a toll booth, this is an invitation. File an honest bug report. Add a test. Improve accuracy for your language. <a href="https://github.com/shimoverse/openvoiceflow">Join us on GitHub.</a></p>
+        <p class="answer-block">If you're a developer who believes typing shouldn't be a toll booth, this is an invitation. Try the app, file honest feedback, improve accuracy for your language — this project is built for you.</p>
       </section>
 
       <section class="content-card"><h2>Who builds this</h2>
-        <p class="answer-block">OpenVoiceFlow is built by <strong>Shimoverse Studios</strong> and open-source contributors. The code is <a href="https://github.com/shimoverse/openvoiceflow/blob/main/LICENSE">MIT-licensed</a> — free for any use, with credit required. The name and logo are protected by a <a href="https://github.com/shimoverse/openvoiceflow/blob/main/TRADEMARKS.md">brand policy</a>, so anything wearing the OpenVoiceFlow name keeps the promises on this website: audio on-device, no telemetry, no account, no paid tier. Read the <a href="privacy.html">privacy policy</a> — the short version is that we couldn't sell your data even if we wanted to, because we never have it.</p>
+        <p class="answer-block">OpenVoiceFlow is built by <strong>Shimoverse Studios</strong> and open-source contributors. The code is MIT-licensed — free for any use, with credit required. If you build on OpenVoiceFlow, keep that credit visible, and tell us about it at <a href="mailto:shimoverse@gmail.com">shimoverse@gmail.com</a> — we love knowing where the work travels. The name and logo are protected by a brand policy, so anything wearing the OpenVoiceFlow name keeps the promises on this website: audio on-device, no telemetry, no account, no paid tier. Read the <a href="privacy.html">privacy policy</a> — the short version is that we couldn't sell your data even if we wanted to, because we never have it.</p>
       </section>
 
       <div class="hero-cta-row" style="margin-top:26px">
         <a class="btn btn-primary btn-lg" href="download.html">Download for Mac — free</a>
-        <a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow">Star or fork on GitHub</a>
+        <a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a>
       </div>
     </div></section>
   </main>
@@ -102,7 +101,6 @@
         <a href="how-it-works.html">How it works</a>
         <a href="privacy.html">Privacy</a>
         <a href="blog/index.html">Blog</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -30,7 +30,6 @@
         <li><a href="how-it-works.html">How it works</a></li>
         <li><a href="install.html">Install</a></li>
         <li><a href="blog/index.html">Blog</a></li>
-        <li><a href="https://github.com/shimoverse/openvoiceflow">GitHub ↗</a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -50,8 +49,8 @@
     <section class="page-hero"><div class="container hero-inner">
       <span class="mono-kicker">Privacy · what stays on your Mac</span>
       <h1 class="hero-title">OpenVoiceFlow privacy</h1>
-      <p class="hero-sub answer-block">OpenVoiceFlow is a native macOS app that runs on your Mac. Your voice is transcribed on-device with WhisperKit and never uploaded. There are no OpenVoiceFlow servers, no accounts, and no telemetry inside the app. This page is the plain-language summary; the full policy lives in <a href="https://github.com/shimoverse/openvoiceflow/blob/main/PRIVACY.md">PRIVACY.md</a>.</p>
-      <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow/blob/main/PRIVACY.md">Read the full policy ↗</a></div>
+      <p class="hero-sub answer-block">OpenVoiceFlow is a native macOS app that runs on your Mac. Your voice is transcribed on-device with WhisperKit and never uploaded. There are no OpenVoiceFlow servers, no accounts, and no telemetry inside the app. This page is the plain-language summary of the project's privacy policy.</p>
+      <div class="page-link-row"><a class="btn btn-primary btn-lg" href="download.html">Download for macOS</a><a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a></div>
 
       <section class="content-card">
         <h2>The short version</h2>
@@ -98,12 +97,12 @@
 
       <section class="content-card">
         <h2>This website</h2>
-        <p>The download site uses privacy-friendly <a href="https://vercel.com/docs/analytics/privacy-policy">Vercel Analytics</a> for anonymous page views, aggregated visitor/referrer/geography trends, and selected website actions such as download, install-guide, navigation, and GitHub-source clicks. It also uses Vercel Speed Insights for aggregated real-user page-performance measurement. These services set no advertising cookies, build no cross-site profile, and never link a visit to an individual. This is website measurement only — the app itself contains no analytics or telemetry.</p>
+        <p>The download site uses privacy-friendly <a href="https://vercel.com/docs/analytics/privacy-policy">Vercel Analytics</a> for anonymous page views, aggregated visitor/referrer/geography trends, and selected website actions such as download, install-guide, and navigation clicks. It also uses Vercel Speed Insights for aggregated real-user page-performance measurement. These services set no advertising cookies, build no cross-site profile, and never link a visit to an individual. This is website measurement only — the app itself contains no analytics or telemetry.</p>
       </section>
 
       <section class="content-card">
         <h2>Open source</h2>
-        <p>OpenVoiceFlow is MIT-licensed and fully open source. If anything on this page does not match what the code actually does, that is a bug — read the <a href="https://github.com/shimoverse/openvoiceflow">source</a> or open a <a href="https://github.com/shimoverse/openvoiceflow/discussions">GitHub Discussion</a>. Security reports go through the process in <a href="https://github.com/shimoverse/openvoiceflow/blob/main/SECURITY.md">SECURITY.md</a>.</p>
+        <p>OpenVoiceFlow is MIT-licensed and fully open source, so every claim on this page is checkable against the code itself. If anything here does not match what the app actually does, that is a bug we want fixed.</p>
       </section>
     </div></section>
   </main>
@@ -118,7 +117,6 @@
         <a href="install.html">Install</a>
         <a href="how-it-works.html">How it works</a>
         <a href="blog/index.html">Blog</a>
-        <a href="https://github.com/shimoverse/openvoiceflow">Source</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -185,6 +185,22 @@ def test_the_product_film_ships_with_its_plumbing():
     assert "demo_play" in site_js, "film plays must be visible in analytics"
 
 
+def test_the_website_ui_carries_no_github_links():
+    """Maintainer decision (July 2026): the website should not send visitors
+    to GitHub — no nav item, no footer Source link, no in-prose repo links,
+    and no fork-promotion copy. The project stays MIT/open-source and the
+    site still says so; only the links and CTAs were removed. site.js keeps
+    its inert github_click handler for the observability contract."""
+    for rel in ALL_PAGES:
+        html = read(rel)
+        assert "github" not in html.lower(), f"{rel}: GitHub reference present"
+    llms = read("llms.txt")
+    assert "github" not in llms.lower(), "llms.txt: GitHub reference present"
+    # the credit-and-tell-us ask replaces the repo link as the reuse policy
+    assert "shimoverse@gmail.com" in llms
+    assert "shimoverse@gmail.com" in read("mission.html")
+
+
 def test_articles_keep_the_competitor_claims_hedged():
     # AGENTS.md: claims on the website must be true of the shipped app, and
     # competitor claims must be dated. Comparison pages carry the hedge line


### PR DESCRIPTION
## What this changes (for the user)

Maintainer request, two parts:

**1. The website no longer links to GitHub anywhere.** The nav "GitHub ↗" item, footer "Source" links, in-prose repo links, the "Install from source" / "Build the app yourself" cards (with their `git clone` commands), and GitHub-pointing CTA buttons are removed from all 13 pages. Sentences that leaned on a link are rewritten so nothing reads broken — e.g. the homepage privacy panel's "read the source" becomes "Not a promise — an architecture. The code is MIT-licensed open source." The open-source *claims* stay throughout (they remain true); only links and CTAs left. Replaced buttons point at internal pages instead.

**2. Fork promotion is replaced by a credit-and-tell-us ask.** In `README.md`, `CONTRIBUTING.md`, and `TRADEMARKS.md`, celebratory fork language ("fork freely — that's what MIT is for", "use it, fork it") is rewritten to foreground what the maintainer wants: keep the project's credit visible, and email shimoverse@gmail.com when you build on it. Credit is already a real requirement (MIT notice + brand policy); the email is phrased as a request, not a license condition, so MIT stays intact and nothing claims more than the license allows. The mission page and `llms.txt` carry the same policy so visitors and AI assistants both see it.

Mechanics:
- `site.js` keeps its now-inert `github_click` handler so the observability contract in `test_docs_distribution.py` holds.
- New contract test `test_the_website_ui_carries_no_github_links` pins zero GitHub references across every page + `llms.txt`, and the presence of the credit ask — so a future template can't quietly reintroduce the links.

## How it was verified

- [x] CI green (`native-build` for Swift changes, pytest for website/Python) — 22 website tests pass locally, including the new no-GitHub contract; no Swift/Python app changes
- [x] Screenshot or recording attached for UI changes — nav verified headlessly against the Vercel build output (Mission · How it works · Install · Blog · Download)
- [x] No version bumps or new dependencies (discuss those in an issue first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXXBMNrEhG47269GXftDyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXXBMNrEhG47269GXftDyB)_