### PR TITLE
Stop mobile-only controls flashing before the stylesheet loads

### DIFF
--- a/docs/blog/best-dictation-software-mac.html
+++ b/docs/blog/best-dictation-software-mac.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/best-dictation-software-mac.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/blog/how-to-dictate-on-mac.html
+++ b/docs/blog/how-to-dictate-on-mac.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/how-to-dictate-on-mac.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/blog/offline-dictation-mac.html
+++ b/docs/blog/offline-dictation-mac.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/offline-dictation-mac.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/blog/voice-typing-for-developers.html
+++ b/docs/blog/voice-typing-for-developers.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/voice-typing-for-developers.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/blog/whisper-models-for-dictation.html
+++ b/docs/blog/whisper-models-for-dictation.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/whisper-models-for-dictation.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/blog/wispr-flow-alternative.html
+++ b/docs/blog/wispr-flow-alternative.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/wispr-flow-alternative.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/accuracy.html
+++ b/docs/docs/accuracy.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/accuracy.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/ai-cleanup.html
+++ b/docs/docs/ai-cleanup.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/ai-cleanup.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/api-keys.html
+++ b/docs/docs/api-keys.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/api-keys.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/backends.html
+++ b/docs/docs/backends.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/backends.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/dashboard.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/dictation-basics.html
+++ b/docs/docs/dictation-basics.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/dictation-basics.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/dictionary.html
+++ b/docs/docs/dictionary.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/dictionary.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/faq.html
+++ b/docs/docs/faq.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/faq.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/hotkeys.html
+++ b/docs/docs/hotkeys.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/hotkeys.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/how-transcription-works.html
+++ b/docs/docs/how-transcription-works.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/how-transcription-works.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/installation.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/languages.html
+++ b/docs/docs/languages.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/languages.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/models.html
+++ b/docs/docs/models.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/models.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/permissions.html
+++ b/docs/docs/permissions.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/permissions.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/privacy-architecture.html
+++ b/docs/docs/privacy-architecture.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/privacy-architecture.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/profile.html
+++ b/docs/docs/profile.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/profile.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/quickstart.html
+++ b/docs/docs/quickstart.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/quickstart.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/settings.html
+++ b/docs/docs/settings.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/settings.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/snippets.html
+++ b/docs/docs/snippets.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/snippets.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/styles.html
+++ b/docs/docs/styles.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/styles.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/text-insertion.html
+++ b/docs/docs/text-insertion.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/text-insertion.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/troubleshooting.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/uninstall.html
+++ b/docs/docs/uninstall.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/uninstall.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/docs/updates.html
+++ b/docs/docs/updates.html
@@ -14,6 +14,7 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/docs/updates.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="../style.css" />
   <script type="application/ld+json">
   {

--- a/docs/download.html
+++ b/docs/download.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/download.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/how-it-works.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is OpenVoiceFlow?","acceptedAnswer":{"@type":"Answer","text":"OpenVoiceFlow is a free push-to-talk voice dictation app for macOS."}},{"@type":"Question","name":"Does OpenVoiceFlow run locally?","acceptedAnswer":{"@type":"Answer","text":"Audio transcription runs locally with on-device WhisperKit. Cleanup text may go to a cloud LLM if the user chooses one."}},{"@type":"Question","name":"What platforms does OpenVoiceFlow support?","acceptedAnswer":{"@type":"Answer","text":"OpenVoiceFlow supports macOS 14+ on Apple Silicon and Intel Macs."}}]}

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,10 @@
   <!-- Waveform-ring favicon (brand glyph) -->
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
 
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="style.css" />
 
   <!-- Structured Data: SoftwareApplication -->

--- a/docs/install.html
+++ b/docs/install.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/install.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"HowTo","name":"How to install OpenVoiceFlow on macOS","description":"Install OpenVoiceFlow from a DMG or from source on macOS.","totalTime":"PT5M","step":[{"@type":"HowToStep","name":"Download","text":"Download the matching Apple Silicon or Intel DMG from the OpenVoiceFlow download page."},{"@type":"HowToStep","name":"Install","text":"Open the DMG and drag OpenVoiceFlow into Applications."},{"@type":"HowToStep","name":"Configure","text":"Grant macOS permissions and choose OpenRouter, another provider, Ollama, or no cleanup backend."}]}

--- a/docs/mission.html
+++ b/docs/mission.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/mission.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -14,6 +14,10 @@
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/privacy.html" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <!-- Hide mobile-only controls before style.css lands: a paint that beats
+       the stylesheet would otherwise flash unstyled bordered buttons. The
+       media queries in style.css load after this and still reveal them. -->
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
   <link rel="stylesheet" href="style.css" />
   <script>
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -74,6 +74,14 @@ FAVICON = (
     "stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E"
 )
 
+# Mobile-only controls are hidden by style.css, which is a separate request.
+# When the browser paints before that stylesheet applies — it occasionally
+# does on same-site navigation with a revalidating cache — the unstyled
+# buttons flash as bordered rectangles in the top-left. Hiding them from an
+# inline block that ships with the HTML closes that window. The media
+# queries in style.css load after this and still reveal them on phones.
+CRITICAL_CSS = "  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>"
+
 ANALYTICS = """  <script>
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>
@@ -235,6 +243,7 @@ def render(slug: str, page: dict) -> str:
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="{url}" />
   <link rel="icon" href="{FAVICON}" />
+{CRITICAL_CSS}
   <link rel="stylesheet" href="../style.css" />
 {chr(10).join(schemas)}
 {ANALYTICS}

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -189,6 +189,24 @@ def test_the_docs_stylesheet_and_sidebar_script_are_present():
     assert "docs_nav_click" in site_js, "docs nav analytics missing"
 
 
+def test_mobile_only_controls_cannot_flash_before_the_stylesheet():
+    """The hamburger and the docs sidebar toggle are hidden on desktop by
+    style.css — a separate request. A paint that beats that stylesheet (the
+    browser occasionally does this on same-site navigation with a
+    revalidating cache) flashed them as bordered rectangles in the top-left.
+    An inline rule shipped with the HTML closes that window, and it must
+    stay BEFORE the stylesheet link so the mobile media queries, which come
+    later in style.css, still win and reveal the controls on phones."""
+    inline = ".nav-hamburger,.docs-sidebar-toggle{display:none}"
+    for rel in ALL_PAGES:
+        html = read(rel)
+        assert inline in html, f"{rel}: missing the anti-flash inline style"
+        assert html.index(inline) < html.index('rel="stylesheet"'), (
+            f"{rel}: inline style must precede the stylesheet link, or the "
+            f"mobile media queries can no longer override it"
+        )
+
+
 def test_manual_internal_links_all_resolve():
     """A manual that links to its own 404s is worse than no manual."""
     import re as _re


### PR DESCRIPTION
## What this changes (for the user)

**Reported:** navigating between docs pages sometimes flashes a small black-bordered rectangle in the top-left corner for a few milliseconds. Intermittent, never on every navigation.

**Root cause, reproduced not guessed.** I blocked `style.css` and photographed the resulting paint. Exactly two elements render with a browser-default `2px outset` border at the left edge:

| Element | Size | Notes |
|---|---|---|
| `.docs-sidebar-toggle` | 153 × 21 px, reads "Documentation menu ▾" | the rectangle you're seeing |
| `.nav-hamburger` | 16 × 6 px | same defect, easy to miss |

Both are hidden on desktop **only** by `style.css`, which is a separate request. When the browser paints before that stylesheet applies — which it occasionally does on same-site navigation when the cached stylesheet is being revalidated — the unstyled buttons appear, then vanish the instant CSS lands. That explains all three characteristics of the report: intermittent, milliseconds long, and top-left.

**Fix.** Hide both from a small inline `<style>` that ships with the HTML, so there is no window in which they can paint. It is placed **before** the stylesheet link deliberately: the media queries that reveal these controls on phones live later in `style.css` and therefore still win the cascade. No `!important`, no `hidden` attribute (which would muddy the accessibility semantics on mobile where the controls are real, interactive UI).

Applied site-wide, not just to the docs, since the hamburger has the identical defect on every page.

**Verified both directions:**
- Stylesheet fully blocked → neither element is visible on docs, homepage, or blog (previously both were).
- 390 px viewport with CSS applied → toggle is `display: block`, hamburger is `display: flex`, mobile nav still functional.

A test pins both the presence of the rule *and* its position before the stylesheet link — getting the order wrong would silently break the mobile navigation rather than the flash, which is the more expensive failure.

## How it was verified

- [x] CI green (`native-build` for Swift changes, pytest for website/Python) — 28 website tests pass locally, `ruff check .` clean; no Swift or Python app changes
- [x] Screenshot or recording attached for UI changes — before/after captured headlessly with the stylesheet blocked, plus a mobile computed-style check
- [x] No version bumps or new dependencies (discuss those in an issue first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXXBMNrEhG47269GXftDyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXXBMNrEhG47269GXftDyB)_