### PR TITLE
Fix favicons that regressed to data: URIs on 3 blog posts

### DIFF
--- a/docs/blog/dictation-for-writers.html
+++ b/docs/blog/dictation-for-writers.html
@@ -13,7 +13,10 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/dictation-for-writers.html" />
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="../favicon-48.png" sizes="48x48" type="image/png" />
+  <link rel="icon" href="../favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png" />
   <!-- Hide mobile-only controls before style.css lands: a paint that beats
        the stylesheet would otherwise flash unstyled bordered buttons. The
        media queries in style.css load after this and still reveal them. -->

--- a/docs/blog/is-on-device-dictation-private.html
+++ b/docs/blog/is-on-device-dictation-private.html
@@ -13,7 +13,10 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/is-on-device-dictation-private.html" />
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="../favicon-48.png" sizes="48x48" type="image/png" />
+  <link rel="icon" href="../favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png" />
   <!-- Hide mobile-only controls before style.css lands: a paint that beats
        the stylesheet would otherwise flash unstyled bordered buttons. The
        media queries in style.css load after this and still reveal them. -->

--- a/docs/blog/personal-dictionary-dictation.html
+++ b/docs/blog/personal-dictionary-dictation.html
@@ -13,7 +13,10 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
   <link rel="canonical" href="https://openvoiceflow.com/blog/personal-dictionary-dictation.html" />
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='34' fill='none' stroke='%23E8974E' stroke-width='13' stroke-linecap='round' stroke-dasharray='186 28' transform='rotate(-58 50 50)'/%3E%3C/svg%3E" />
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="../favicon-48.png" sizes="48x48" type="image/png" />
+  <link rel="icon" href="../favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="../apple-touch-icon.png" />
   <!-- Hide mobile-only controls before style.css lands: a paint that beats
        the stylesheet would otherwise flash unstyled bordered buttons. The
        media queries in style.css load after this and still reveal them. -->


### PR DESCRIPTION
## Summary

Found while investigating an unrelated CI failure on #83: `test_favicon_is_a_real_file_not_a_data_uri` (added in #81, which fixed this exact class of bug site-wide) currently fails on `main` too, so it isn't something #83 broke.

Three blog posts still had the pre-#81 stray inline `data:image/svg+xml,...` favicon instead of the real-file favicon block (`favicon.svg` / `favicon-48.png` / `favicon.ico`) every other page uses:

- `docs/blog/dictation-for-writers.html`
- `docs/blog/is-on-device-dictation-private.html`
- `docs/blog/personal-dictionary-dictation.html`

Google's favicon-in-search pipeline fetches the icon as its own crawlable resource and can't do that with a `data:` URI — these three pages would show a generic globe instead of the brand icon in search results. Also added each page's missing `apple-touch-icon` link, matching every sibling blog post.

## Test plan

- [x] `python3 -m pytest tests/test_docs_seo.py -q` — 21 passed (was 1 failed before this fix).
- [x] `grep -rl 'data:image/svg+xml' docs/ --include='*.html'` — no matches remaining.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HmwZZrbgmFxDT8CsaaF96j)_