### PR TITLE
Add Ukrainian and Whisper's full multilingual language set to the picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The language picker now offers all 99 languages in Whisper's multilingual
+  set (previously eleven), including Ukrainian. Tiny, Small, Medium, and
+  Large turbo all share the same tokenizer, so the list applies to every
+  engine offered in Settings.
+
 ## [0.5.5] — 2026-07-27
 
 ### Fixed

--- a/docs/docs/faq.html
+++ b/docs/docs/faq.html
@@ -68,7 +68,7 @@
       {"@type": "Question", "name": "Why is my dictionary not working?",
        "acceptedAnswer": {"@type": "Answer", "text": "The personal dictionary, Know-Me profile, and per-app styles are all applied during AI cleanup. With cleanup set to None, which is the default, they have no effect. Turn cleanup on, or use local Ollama if you want that behaviour without sending text to a cloud."}},
       {"@type": "Question", "name": "Which languages does it support?",
-       "acceptedAnswer": {"@type": "Answer", "text": "Eleven in the picker: English, Spanish, French, German, Italian, Portuguese, Dutch, Hindi, Japanese, Chinese, and Korean. Accuracy outside English depends heavily on model size, so use the largest model your Mac handles comfortably."}},
+       "acceptedAnswer": {"@type": "Answer", "text": "All 99 languages in Whisper's multilingual set, including Ukrainian, Arabic, Hindi, and Chinese — see the full list on the Languages page. Accuracy outside English depends heavily on model size, so use the largest model your Mac handles comfortably."}},
       {"@type": "Question", "name": "What happens if the AI cleanup service fails?",
        "acceptedAnswer": {"@type": "Answer", "text": "You get your raw transcript. Cleanup is designed to fail open: on a missing key, an error, a timeout, or an unparseable response, the app inserts the on-device transcription rather than losing your words."}},
       {"@type": "Question", "name": "Does it collect any analytics?",
@@ -204,7 +204,7 @@
         <h3>Why is my dictionary not working?</h3>
         The personal dictionary, Know-Me profile, and per-app styles are all applied during AI cleanup. With cleanup set to None, which is the default, they have no effect. Turn cleanup on, or use local Ollama if you want that behaviour without sending text to a cloud.
         <h3>Which languages does it support?</h3>
-        Eleven in the picker: English, Spanish, French, German, Italian, Portuguese, Dutch, Hindi, Japanese, Chinese, and Korean. Accuracy outside English depends heavily on model size, so use the largest model your Mac handles comfortably.
+        All 99 languages in Whisper's multilingual set, including Ukrainian, Arabic, Hindi, and Chinese — see the full list on the <a href="languages.html">Languages</a> page. Accuracy outside English depends heavily on model size, so use the largest model your Mac handles comfortably.
         <h3>What happens if the AI cleanup service fails?</h3>
         You get your raw transcript. Cleanup is designed to fail open: on a missing key, an error, a timeout, or an unparseable response, the app inserts the on-device transcription rather than losing your words.
         <h3>Does it collect any analytics?</h3>

--- a/docs/docs/languages.html
+++ b/docs/docs/languages.html
@@ -144,23 +144,68 @@
       <article class="docs-main">
       <div class="docs-breadcrumb"><a href="../index.html">Home</a><span class="sep">/</span><a href="index.html">Docs</a><span class="sep">/</span><span>Languages</span></div>
         <h1 class="docs-title">Languages</h1>
-        <p class="docs-lede">Whisper is multilingual, and OpenVoiceFlow exposes eleven languages in its picker. Which model you run matters more here than anywhere else in the app.</p>
+        <p class="docs-lede">Whisper is multilingual, and OpenVoiceFlow exposes its full 99-language picker. Which model you run matters more here than anywhere else in the app.</p>
 
         <div class="docs-body">
 
         <h2 id="supported">Languages in the picker</h2>
-        <p><strong>Dashboard ▸ Settings ▸ Transcription — on this Mac ▸ Language</strong> offers:</p>
+        <p><strong>Dashboard ▸ Settings ▸ Transcription — on this Mac ▸ Language</strong> offers every language Whisper's multilingual models are trained on:</p>
         <table>
           <thead><tr><th scope="col">Language</th><th scope="col">Code</th><th scope="col">Language</th><th scope="col">Code</th></tr></thead>
           <tbody>
-            <tr><td>English</td><td><code>en</code></td><td>Dutch</td><td><code>nl</code></td></tr>
-            <tr><td>Spanish</td><td><code>es</code></td><td>Hindi</td><td><code>hi</code></td></tr>
-            <tr><td>French</td><td><code>fr</code></td><td>Japanese</td><td><code>ja</code></td></tr>
-            <tr><td>German</td><td><code>de</code></td><td>Chinese</td><td><code>zh</code></td></tr>
-            <tr><td>Italian</td><td><code>it</code></td><td>Korean</td><td><code>ko</code></td></tr>
-            <tr><td>Portuguese</td><td><code>pt</code></td><td></td><td></td></tr>
+            <tr><td>English</td><td><code>en</code></td><td>Afrikaans</td><td><code>af</code></td></tr>
+            <tr><td>Albanian</td><td><code>sq</code></td><td>Amharic</td><td><code>am</code></td></tr>
+            <tr><td>Arabic</td><td><code>ar</code></td><td>Armenian</td><td><code>hy</code></td></tr>
+            <tr><td>Assamese</td><td><code>as</code></td><td>Azerbaijani</td><td><code>az</code></td></tr>
+            <tr><td>Bashkir</td><td><code>ba</code></td><td>Basque</td><td><code>eu</code></td></tr>
+            <tr><td>Belarusian</td><td><code>be</code></td><td>Bengali</td><td><code>bn</code></td></tr>
+            <tr><td>Bosnian</td><td><code>bs</code></td><td>Breton</td><td><code>br</code></td></tr>
+            <tr><td>Bulgarian</td><td><code>bg</code></td><td>Burmese</td><td><code>my</code></td></tr>
+            <tr><td>Catalan</td><td><code>ca</code></td><td>Chinese</td><td><code>zh</code></td></tr>
+            <tr><td>Croatian</td><td><code>hr</code></td><td>Czech</td><td><code>cs</code></td></tr>
+            <tr><td>Danish</td><td><code>da</code></td><td>Dutch</td><td><code>nl</code></td></tr>
+            <tr><td>Estonian</td><td><code>et</code></td><td>Faroese</td><td><code>fo</code></td></tr>
+            <tr><td>Finnish</td><td><code>fi</code></td><td>French</td><td><code>fr</code></td></tr>
+            <tr><td>Galician</td><td><code>gl</code></td><td>Georgian</td><td><code>ka</code></td></tr>
+            <tr><td>German</td><td><code>de</code></td><td>Greek</td><td><code>el</code></td></tr>
+            <tr><td>Gujarati</td><td><code>gu</code></td><td>Haitian Creole</td><td><code>ht</code></td></tr>
+            <tr><td>Hausa</td><td><code>ha</code></td><td>Hawaiian</td><td><code>haw</code></td></tr>
+            <tr><td>Hebrew</td><td><code>he</code></td><td>Hindi</td><td><code>hi</code></td></tr>
+            <tr><td>Hungarian</td><td><code>hu</code></td><td>Icelandic</td><td><code>is</code></td></tr>
+            <tr><td>Indonesian</td><td><code>id</code></td><td>Italian</td><td><code>it</code></td></tr>
+            <tr><td>Japanese</td><td><code>ja</code></td><td>Javanese</td><td><code>jw</code></td></tr>
+            <tr><td>Kannada</td><td><code>kn</code></td><td>Kazakh</td><td><code>kk</code></td></tr>
+            <tr><td>Khmer</td><td><code>km</code></td><td>Korean</td><td><code>ko</code></td></tr>
+            <tr><td>Lao</td><td><code>lo</code></td><td>Latin</td><td><code>la</code></td></tr>
+            <tr><td>Latvian</td><td><code>lv</code></td><td>Lingala</td><td><code>ln</code></td></tr>
+            <tr><td>Lithuanian</td><td><code>lt</code></td><td>Luxembourgish</td><td><code>lb</code></td></tr>
+            <tr><td>Macedonian</td><td><code>mk</code></td><td>Malagasy</td><td><code>mg</code></td></tr>
+            <tr><td>Malay</td><td><code>ms</code></td><td>Malayalam</td><td><code>ml</code></td></tr>
+            <tr><td>Maltese</td><td><code>mt</code></td><td>Maori</td><td><code>mi</code></td></tr>
+            <tr><td>Marathi</td><td><code>mr</code></td><td>Mongolian</td><td><code>mn</code></td></tr>
+            <tr><td>Nepali</td><td><code>ne</code></td><td>Norwegian</td><td><code>no</code></td></tr>
+            <tr><td>Norwegian Nynorsk</td><td><code>nn</code></td><td>Occitan</td><td><code>oc</code></td></tr>
+            <tr><td>Pashto</td><td><code>ps</code></td><td>Persian</td><td><code>fa</code></td></tr>
+            <tr><td>Polish</td><td><code>pl</code></td><td>Portuguese</td><td><code>pt</code></td></tr>
+            <tr><td>Punjabi</td><td><code>pa</code></td><td>Romanian</td><td><code>ro</code></td></tr>
+            <tr><td>Russian</td><td><code>ru</code></td><td>Sanskrit</td><td><code>sa</code></td></tr>
+            <tr><td>Serbian</td><td><code>sr</code></td><td>Shona</td><td><code>sn</code></td></tr>
+            <tr><td>Sindhi</td><td><code>sd</code></td><td>Sinhala</td><td><code>si</code></td></tr>
+            <tr><td>Slovak</td><td><code>sk</code></td><td>Slovenian</td><td><code>sl</code></td></tr>
+            <tr><td>Somali</td><td><code>so</code></td><td>Spanish</td><td><code>es</code></td></tr>
+            <tr><td>Sundanese</td><td><code>su</code></td><td>Swahili</td><td><code>sw</code></td></tr>
+            <tr><td>Swedish</td><td><code>sv</code></td><td>Tagalog</td><td><code>tl</code></td></tr>
+            <tr><td>Tajik</td><td><code>tg</code></td><td>Tamil</td><td><code>ta</code></td></tr>
+            <tr><td>Tatar</td><td><code>tt</code></td><td>Telugu</td><td><code>te</code></td></tr>
+            <tr><td>Thai</td><td><code>th</code></td><td>Tibetan</td><td><code>bo</code></td></tr>
+            <tr><td>Turkish</td><td><code>tr</code></td><td>Turkmen</td><td><code>tk</code></td></tr>
+            <tr><td>Ukrainian</td><td><code>uk</code></td><td>Urdu</td><td><code>ur</code></td></tr>
+            <tr><td>Uzbek</td><td><code>uz</code></td><td>Vietnamese</td><td><code>vi</code></td></tr>
+            <tr><td>Welsh</td><td><code>cy</code></td><td>Yiddish</td><td><code>yi</code></td></tr>
+            <tr><td>Yoruba</td><td><code>yo</code></td><td></td><td></td></tr>
           </tbody>
         </table>
+        <p>That's every language in Whisper's standard 99-language set. (Large turbo also recognizes Cantonese under the hood, but that language token doesn't exist in Tiny, Small, or Medium's vocabulary, so it's left out of the shared picker above.)</p>
 
         <div class="callout warn">
           <span class="callout-label">Pair the language with a multilingual model</span>

--- a/docs/docs/settings.html
+++ b/docs/docs/settings.html
@@ -166,7 +166,7 @@
           <thead><tr><th scope="col">Setting</th><th scope="col">Default</th><th scope="col">What it does</th></tr></thead>
           <tbody>
             <tr><td>Whisper model</td><td>Chosen during onboarding</td><td>Which engine transcribes your speech. Changing it here loads the new model immediately — see <a href="models.html">Whisper models</a>.</td></tr>
-            <tr><td>Language</td><td>English</td><td>The language you dictate in. Eleven options — see <a href="languages.html">Languages</a>.</td></tr>
+            <tr><td>Language</td><td>English</td><td>The language you dictate in. All 99 languages in Whisper's multilingual set, including Ukrainian — see <a href="languages.html">Languages</a>.</td></tr>
           </tbody>
         </table>
 

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -723,10 +723,38 @@ struct DashboardView: View {
         ("medium", "Medium — 1.5 GB"),
         ("large-v3-v20240930", "Large v3 turbo — 1.6 GB"),
     ]
+    // Whisper's standard 99-language multilingual set — shared by tiny, small,
+    // medium, and large-v3-turbo, since all four ship the same tokenizer's
+    // language tokens. (large-v3 also added Cantonese as an unofficial 100th,
+    // but tiny/small/medium have no token for it, so it's left off this
+    // shared list.)
     static let languages: [(String, String)] = [
-        ("en", "English"), ("es", "Spanish"), ("fr", "French"), ("de", "German"),
-        ("it", "Italian"), ("pt", "Portuguese"), ("nl", "Dutch"), ("hi", "Hindi"),
-        ("ja", "Japanese"), ("zh", "Chinese"), ("ko", "Korean"),
+        ("en", "English"),
+        ("af", "Afrikaans"), ("sq", "Albanian"), ("am", "Amharic"), ("ar", "Arabic"),
+        ("hy", "Armenian"), ("as", "Assamese"), ("az", "Azerbaijani"), ("ba", "Bashkir"),
+        ("eu", "Basque"), ("be", "Belarusian"), ("bn", "Bengali"), ("bs", "Bosnian"),
+        ("br", "Breton"), ("bg", "Bulgarian"), ("my", "Burmese"), ("ca", "Catalan"),
+        ("zh", "Chinese"), ("hr", "Croatian"), ("cs", "Czech"), ("da", "Danish"),
+        ("nl", "Dutch"), ("et", "Estonian"), ("fo", "Faroese"), ("fi", "Finnish"),
+        ("fr", "French"), ("gl", "Galician"), ("ka", "Georgian"), ("de", "German"),
+        ("el", "Greek"), ("gu", "Gujarati"), ("ht", "Haitian Creole"), ("ha", "Hausa"),
+        ("haw", "Hawaiian"), ("he", "Hebrew"), ("hi", "Hindi"), ("hu", "Hungarian"),
+        ("is", "Icelandic"), ("id", "Indonesian"), ("it", "Italian"), ("ja", "Japanese"),
+        ("jw", "Javanese"), ("kn", "Kannada"), ("kk", "Kazakh"), ("km", "Khmer"),
+        ("ko", "Korean"), ("lo", "Lao"), ("la", "Latin"), ("lv", "Latvian"),
+        ("ln", "Lingala"), ("lt", "Lithuanian"), ("lb", "Luxembourgish"), ("mk", "Macedonian"),
+        ("mg", "Malagasy"), ("ms", "Malay"), ("ml", "Malayalam"), ("mt", "Maltese"),
+        ("mi", "Maori"), ("mr", "Marathi"), ("mn", "Mongolian"), ("ne", "Nepali"),
+        ("no", "Norwegian"), ("nn", "Norwegian Nynorsk"), ("oc", "Occitan"), ("ps", "Pashto"),
+        ("fa", "Persian"), ("pl", "Polish"), ("pt", "Portuguese"), ("pa", "Punjabi"),
+        ("ro", "Romanian"), ("ru", "Russian"), ("sa", "Sanskrit"), ("sr", "Serbian"),
+        ("sn", "Shona"), ("sd", "Sindhi"), ("si", "Sinhala"), ("sk", "Slovak"),
+        ("sl", "Slovenian"), ("so", "Somali"), ("es", "Spanish"), ("su", "Sundanese"),
+        ("sw", "Swahili"), ("sv", "Swedish"), ("tl", "Tagalog"), ("tg", "Tajik"),
+        ("ta", "Tamil"), ("tt", "Tatar"), ("te", "Telugu"), ("th", "Thai"),
+        ("bo", "Tibetan"), ("tr", "Turkish"), ("tk", "Turkmen"), ("uk", "Ukrainian"),
+        ("ur", "Urdu"), ("uz", "Uzbek"), ("vi", "Vietnamese"), ("cy", "Welsh"),
+        ("yi", "Yiddish"), ("yo", "Yoruba"),
     ]
     /// Cleanup providers offered when cleanup is on (excludes `.none`).
     static let cleanupProviders: [Backend] = [.anthropic, .openai, .groq, .openrouter, .ollama]

--- a/scripts/docs_content.py
+++ b/scripts/docs_content.py
@@ -524,21 +524,66 @@ PAGES["languages"] = {
     "head_title": "Dictation Languages in OpenVoiceFlow — Whisper Multilingual Support",
     "title": "Languages",
     "description": "The languages OpenVoiceFlow supports for dictation, how to change the language, and why model choice matters more outside English.",
-    "lede": "Whisper is multilingual, and OpenVoiceFlow exposes eleven languages in its picker. Which model you run matters more here than anywhere else in the app.",
+    "lede": "Whisper is multilingual, and OpenVoiceFlow exposes its full 99-language picker. Which model you run matters more here than anywhere else in the app.",
     "body": """
         <h2 id="supported">Languages in the picker</h2>
-        <p><strong>Dashboard ▸ Settings ▸ Transcription — on this Mac ▸ Language</strong> offers:</p>
+        <p><strong>Dashboard ▸ Settings ▸ Transcription — on this Mac ▸ Language</strong> offers every language Whisper's multilingual models are trained on:</p>
         <table>
           <thead><tr><th scope="col">Language</th><th scope="col">Code</th><th scope="col">Language</th><th scope="col">Code</th></tr></thead>
           <tbody>
-            <tr><td>English</td><td><code>en</code></td><td>Dutch</td><td><code>nl</code></td></tr>
-            <tr><td>Spanish</td><td><code>es</code></td><td>Hindi</td><td><code>hi</code></td></tr>
-            <tr><td>French</td><td><code>fr</code></td><td>Japanese</td><td><code>ja</code></td></tr>
-            <tr><td>German</td><td><code>de</code></td><td>Chinese</td><td><code>zh</code></td></tr>
-            <tr><td>Italian</td><td><code>it</code></td><td>Korean</td><td><code>ko</code></td></tr>
-            <tr><td>Portuguese</td><td><code>pt</code></td><td></td><td></td></tr>
+            <tr><td>English</td><td><code>en</code></td><td>Afrikaans</td><td><code>af</code></td></tr>
+            <tr><td>Albanian</td><td><code>sq</code></td><td>Amharic</td><td><code>am</code></td></tr>
+            <tr><td>Arabic</td><td><code>ar</code></td><td>Armenian</td><td><code>hy</code></td></tr>
+            <tr><td>Assamese</td><td><code>as</code></td><td>Azerbaijani</td><td><code>az</code></td></tr>
+            <tr><td>Bashkir</td><td><code>ba</code></td><td>Basque</td><td><code>eu</code></td></tr>
+            <tr><td>Belarusian</td><td><code>be</code></td><td>Bengali</td><td><code>bn</code></td></tr>
+            <tr><td>Bosnian</td><td><code>bs</code></td><td>Breton</td><td><code>br</code></td></tr>
+            <tr><td>Bulgarian</td><td><code>bg</code></td><td>Burmese</td><td><code>my</code></td></tr>
+            <tr><td>Catalan</td><td><code>ca</code></td><td>Chinese</td><td><code>zh</code></td></tr>
+            <tr><td>Croatian</td><td><code>hr</code></td><td>Czech</td><td><code>cs</code></td></tr>
+            <tr><td>Danish</td><td><code>da</code></td><td>Dutch</td><td><code>nl</code></td></tr>
+            <tr><td>Estonian</td><td><code>et</code></td><td>Faroese</td><td><code>fo</code></td></tr>
+            <tr><td>Finnish</td><td><code>fi</code></td><td>French</td><td><code>fr</code></td></tr>
+            <tr><td>Galician</td><td><code>gl</code></td><td>Georgian</td><td><code>ka</code></td></tr>
+            <tr><td>German</td><td><code>de</code></td><td>Greek</td><td><code>el</code></td></tr>
+            <tr><td>Gujarati</td><td><code>gu</code></td><td>Haitian Creole</td><td><code>ht</code></td></tr>
+            <tr><td>Hausa</td><td><code>ha</code></td><td>Hawaiian</td><td><code>haw</code></td></tr>
+            <tr><td>Hebrew</td><td><code>he</code></td><td>Hindi</td><td><code>hi</code></td></tr>
+            <tr><td>Hungarian</td><td><code>hu</code></td><td>Icelandic</td><td><code>is</code></td></tr>
+            <tr><td>Indonesian</td><td><code>id</code></td><td>Italian</td><td><code>it</code></td></tr>
+            <tr><td>Japanese</td><td><code>ja</code></td><td>Javanese</td><td><code>jw</code></td></tr>
+            <tr><td>Kannada</td><td><code>kn</code></td><td>Kazakh</td><td><code>kk</code></td></tr>
+            <tr><td>Khmer</td><td><code>km</code></td><td>Korean</td><td><code>ko</code></td></tr>
+            <tr><td>Lao</td><td><code>lo</code></td><td>Latin</td><td><code>la</code></td></tr>
+            <tr><td>Latvian</td><td><code>lv</code></td><td>Lingala</td><td><code>ln</code></td></tr>
+            <tr><td>Lithuanian</td><td><code>lt</code></td><td>Luxembourgish</td><td><code>lb</code></td></tr>
+            <tr><td>Macedonian</td><td><code>mk</code></td><td>Malagasy</td><td><code>mg</code></td></tr>
+            <tr><td>Malay</td><td><code>ms</code></td><td>Malayalam</td><td><code>ml</code></td></tr>
+            <tr><td>Maltese</td><td><code>mt</code></td><td>Maori</td><td><code>mi</code></td></tr>
+            <tr><td>Marathi</td><td><code>mr</code></td><td>Mongolian</td><td><code>mn</code></td></tr>
+            <tr><td>Nepali</td><td><code>ne</code></td><td>Norwegian</td><td><code>no</code></td></tr>
+            <tr><td>Norwegian Nynorsk</td><td><code>nn</code></td><td>Occitan</td><td><code>oc</code></td></tr>
+            <tr><td>Pashto</td><td><code>ps</code></td><td>Persian</td><td><code>fa</code></td></tr>
+            <tr><td>Polish</td><td><code>pl</code></td><td>Portuguese</td><td><code>pt</code></td></tr>
+            <tr><td>Punjabi</td><td><code>pa</code></td><td>Romanian</td><td><code>ro</code></td></tr>
+            <tr><td>Russian</td><td><code>ru</code></td><td>Sanskrit</td><td><code>sa</code></td></tr>
+            <tr><td>Serbian</td><td><code>sr</code></td><td>Shona</td><td><code>sn</code></td></tr>
+            <tr><td>Sindhi</td><td><code>sd</code></td><td>Sinhala</td><td><code>si</code></td></tr>
+            <tr><td>Slovak</td><td><code>sk</code></td><td>Slovenian</td><td><code>sl</code></td></tr>
+            <tr><td>Somali</td><td><code>so</code></td><td>Spanish</td><td><code>es</code></td></tr>
+            <tr><td>Sundanese</td><td><code>su</code></td><td>Swahili</td><td><code>sw</code></td></tr>
+            <tr><td>Swedish</td><td><code>sv</code></td><td>Tagalog</td><td><code>tl</code></td></tr>
+            <tr><td>Tajik</td><td><code>tg</code></td><td>Tamil</td><td><code>ta</code></td></tr>
+            <tr><td>Tatar</td><td><code>tt</code></td><td>Telugu</td><td><code>te</code></td></tr>
+            <tr><td>Thai</td><td><code>th</code></td><td>Tibetan</td><td><code>bo</code></td></tr>
+            <tr><td>Turkish</td><td><code>tr</code></td><td>Turkmen</td><td><code>tk</code></td></tr>
+            <tr><td>Ukrainian</td><td><code>uk</code></td><td>Urdu</td><td><code>ur</code></td></tr>
+            <tr><td>Uzbek</td><td><code>uz</code></td><td>Vietnamese</td><td><code>vi</code></td></tr>
+            <tr><td>Welsh</td><td><code>cy</code></td><td>Yiddish</td><td><code>yi</code></td></tr>
+            <tr><td>Yoruba</td><td><code>yo</code></td><td></td><td></td></tr>
           </tbody>
         </table>
+        <p>That's every language in Whisper's standard 99-language set. (Large turbo also recognizes Cantonese under the hood, but that language token doesn't exist in Tiny, Small, or Medium's vocabulary, so it's left out of the shared picker above.)</p>
 
         <div class="callout warn">
           <span class="callout-label">Pair the language with a multilingual model</span>
@@ -929,7 +974,7 @@ PAGES["settings"] = {
           <thead><tr><th scope="col">Setting</th><th scope="col">Default</th><th scope="col">What it does</th></tr></thead>
           <tbody>
             <tr><td>Whisper model</td><td>Chosen during onboarding</td><td>Which engine transcribes your speech. Changing it here loads the new model immediately — see <a href="models.html">Whisper models</a>.</td></tr>
-            <tr><td>Language</td><td>English</td><td>The language you dictate in. Eleven options — see <a href="languages.html">Languages</a>.</td></tr>
+            <tr><td>Language</td><td>English</td><td>The language you dictate in. All 99 languages in Whisper's multilingual set, including Ukrainian — see <a href="languages.html">Languages</a>.</td></tr>
           </tbody>
         </table>
 
@@ -1310,7 +1355,7 @@ PAGES["faq"] = {
         ("Why is my dictionary not working?",
          "The personal dictionary, Know-Me profile, and per-app styles are all applied during AI cleanup. With cleanup set to None, which is the default, they have no effect. Turn cleanup on, or use local Ollama if you want that behaviour without sending text to a cloud."),
         ("Which languages does it support?",
-         "Eleven in the picker: English, Spanish, French, German, Italian, Portuguese, Dutch, Hindi, Japanese, Chinese, and Korean. Accuracy outside English depends heavily on model size, so use the largest model your Mac handles comfortably."),
+         "All 99 languages in Whisper's multilingual set, including Ukrainian, Arabic, Hindi, and Chinese — see the full list on the <a href=\"languages.html\">Languages</a> page. Accuracy outside English depends heavily on model size, so use the largest model your Mac handles comfortably."),
         ("What happens if the AI cleanup service fails?",
          "You get your raw transcript. Cleanup is designed to fail open: on a missing key, an error, a timeout, or an unparseable response, the app inserts the on-device transcription rather than losing your words."),
         ("Does it collect any analytics?",


### PR DESCRIPTION
## What this changes (for the user)

Prompted by a user feature request for Ukrainian, since it's natively supported by Whisper.

**Dashboard ▸ Settings ▸ Transcription ▸ Language** offered only eleven curated languages. Whisper's Tiny, Small, Medium, and Large turbo checkpoints (the four engines this app offers) all share the same multilingual tokenizer, so there's no per-model reason to keep the list short — every language any of them can transcribe, the others can too. The picker now offers all 99 languages in that shared set, including Ukrainian, Arabic, Hindi, Vietnamese, etc.

One deliberate omission: Large turbo can additionally recognize Cantonese (`yue`), added when large-v3's tokenizer grew a 100th language token — but Tiny/Small/Medium have no embedding for that token, and the list is shared across all four models, so it's left out rather than silently failing on three of the four engines.

Also updated (to keep website claims true of the shipped app, per `AGENTS.md`):
- `docs/docs/languages.html` — full 99-language table, replaces the old "eleven" table
- `docs/docs/settings.html` and `docs/docs/faq.html` — "Eleven options" / "Eleven in the picker" language mentions
- `CHANGELOG.md` — `[Unreleased]` entry

All of the above are generated from `scripts/docs_content.py` via `python3 scripts/build_docs.py` (re-run as part of this change) rather than hand-edited in `docs/docs/`.

**Out of scope / not done here:** cutting an actual release. Per `RELEASE.md`, shipping this to existing users needs the four version fields bumped, a signed+notarized build via the release workflow (Apple signing secrets + `SPARKLE_ED_PRIVATE_KEY`, which I don't have), and a separate publish PR that updates `docs/appcast.xml` — that's a maintainer-only step. This PR is the code change; someone with those credentials still needs to run the release pipeline for it to reach installed users via Sparkle auto-update.

## How it was verified

- [x] CI green (`native-build` for Swift changes, pytest for website/Python) — verified `python3 -m pytest tests/test_docs_distribution.py tests/test_docs_seo.py -q` locally (31 passed); full `pytest -q` shows the same 14 pre-existing failures/17 errors as `main` (missing `numpy` in this sandbox for the legacy Python app, unrelated to this change). The Swift change is compile-checked by eye only — no Mac available in this environment to build/run the app; CI's `native-build` still needs to confirm it compiles.
- [ ] Screenshot or recording attached for UI changes — not available; no macOS device in this environment to run the Settings UI
- [x] No version bumps or new dependencies


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tn4drnzTHfxCWur3agPrPL)_