### PR TITLE
chore: release native app 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] — 2026-08-25
+
 ### Added
 - The language picker now offers all 99 languages in Whisper's multilingual
   set (previously eleven), including Ukrainian. Tiny, Small, Medium, and

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.5</string>
-    <key>CFBundleVersion</key><string>10</string>
+    <key>CFBundleShortVersionString</key><string>0.5.6</string>
+    <key>CFBundleVersion</key><string>11</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.5
-        CURRENT_PROJECT_VERSION: 10
+        MARKETING_VERSION: 0.5.6
+        CURRENT_PROJECT_VERSION: 11
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## Summary
- bump the native app from 0.5.5/build 10 to 0.5.6/build 11
- move the full Whisper language-list entry into the dated 0.5.6 changelog section

## Verification
- `python3 -m pytest -q` — 262 passed, 1 skipped
- universal unsigned native build — succeeded
- `plutil -lint native/Info.plist` — OK
- `git diff --check` — clean
