### PR TITLE
Add a Feedback item to the sidebar, below Settings

### DIFF
--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -20,6 +20,7 @@ struct DashboardView: View {
     @ObservedObject private var updater = UpdaterController.shared
     @State private var pane: Pane = .home
     @State private var showInterview = false
+    @State private var showFeedback = false
     @State private var apiKeyDraft = ""       // mirrors the Keychain key for the selected backend
     @State private var showDeleteHistory = false
     // Live TCC statuses for the Settings permissions card. Polled (not
@@ -105,6 +106,19 @@ struct DashboardView: View {
                 .buttonStyle(.plain)
             }
 
+            Button { showFeedback = true } label: {
+                HStack(spacing: 8) {
+                    Circle().fill(.clear).frame(width: 6, height: 6)
+                    Text("Feedback")
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(ink)
+                    Spacer()
+                }
+                .padding(.vertical, 7)
+                .padding(.horizontal, 10)
+            }
+            .buttonStyle(.plain)
+
             Spacer()
 
             HStack(spacing: 6) {
@@ -140,6 +154,9 @@ struct DashboardView: View {
         }
         .sheet(isPresented: $showInterview) {
             KnowMeInterview(controller: controller)
+        }
+        .sheet(isPresented: $showFeedback) {
+            FeedbackView(controller: controller)
         }
         // The first-words card is the one thing a user is likely to miss, so it
         // is a separate, explicit choice rather than collateral damage.

--- a/native/Sources/OpenVoiceFlow/FeedbackView.swift
+++ b/native/Sources/OpenVoiceFlow/FeedbackView.swift
@@ -1,0 +1,167 @@
+import AppKit
+import SwiftUI
+
+/// "Send Feedback" — a short form presented from the sidebar, below Settings.
+///
+/// OpenVoiceFlow ships no telemetry and no backend (see privacy-architecture
+/// docs), so there is nowhere to POST a submission to. Feedback goes out the
+/// same door the docs already point people to — a `mailto:` to
+/// shimoverse@gmail.com — opened only when the user taps Send. Nothing is
+/// gathered passively or on a timer.
+///
+/// What rides along is a small, aggregate usage snapshot (word/time totals,
+/// streak, first-use date, last 7 days) so a report arrives with context.
+/// It never includes dictation text, snippets, dictionary entries, or the
+/// Know-Me profile — only counters already shown on the dashboard.
+struct FeedbackView: View {
+    @ObservedObject var controller: AppController
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var scheme
+
+    enum Category: String, CaseIterable, Identifiable {
+        case bug = "Something's broken"
+        case idea = "Feature idea"
+        case praise = "Just saying thanks"
+        case other = "Something else"
+        var id: String { rawValue }
+    }
+
+    @State private var category: Category = .idea
+    @State private var message = ""
+    @State private var includeContact = false
+    @State private var contact = ""
+
+    private var dark: Bool { scheme == .dark }
+    private var ink: Color { dark ? DT.inkDark : DT.inkLight }
+    private var ink2: Color { dark ? DT.ink2Dark : DT.ink2Light }
+    private var fill: Color { dark ? .white.opacity(0.06) : .black.opacity(0.05) }
+
+    private var canSend: Bool { !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Send feedback").font(.system(size: 20, weight: .bold)).foregroundStyle(ink)
+                Spacer()
+                Button("Cancel") { dismiss() }.buttonStyle(.plain).foregroundStyle(ink2)
+            }
+
+            Picker("", selection: $category) {
+                ForEach(Category.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .labelsHidden().pickerStyle(.segmented)
+
+            TextEditor(text: $message)
+                .font(.system(size: 13))
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .frame(height: 130)
+                .background(RoundedRectangle(cornerRadius: 8).fill(fill))
+                .overlay(alignment: .topLeading) {
+                    if message.isEmpty {
+                        Text("What happened, or what would help?")
+                            .font(.system(size: 13)).foregroundStyle(ink2)
+                            .padding(.horizontal, 12).padding(.vertical, 14)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+            Toggle("Include my email so you can follow up", isOn: $includeContact)
+                .toggleStyle(.switch).tint(DT.moss)
+                .font(.system(size: 12.5)).foregroundStyle(ink)
+            if includeContact {
+                TextField("you@example.com", text: $contact)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 13))
+            }
+
+            Text("This opens an email with usage totals attached — words dictated, time saved, "
+                 + "your streak, and this week's activity. Never the words themselves, and nothing "
+                 + "is sent unless you hit Send.")
+                .font(.system(size: 11)).foregroundStyle(ink2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Spacer()
+                Button("Send") { send() }
+                    .buttonStyle(.borderedProminent).tint(DT.emberWave)
+                    .disabled(!canSend)
+            }
+        }
+        .padding(24)
+        .frame(width: 440, height: 420)
+    }
+
+    private func send() {
+        let body = Self.emailBody(
+            category: category.rawValue,
+            message: message.trimmingCharacters(in: .whitespacesAndNewlines),
+            contact: includeContact ? contact.trimmingCharacters(in: .whitespaces) : nil,
+            snapshot: UsageSnapshot(controller: controller)
+        )
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = "shimoverse@gmail.com"
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: "OpenVoiceFlow feedback: \(category.rawValue)"),
+            URLQueryItem(name: "body", value: body),
+        ]
+        if let url = components.url {
+            NSWorkspace.shared.open(url)
+        }
+        dismiss()
+    }
+
+    static func emailBody(category: String, message: String, contact: String?, snapshot: UsageSnapshot) -> String {
+        var lines = [message, "", "—"]
+        if let contact, !contact.isEmpty {
+            lines.append("Reply to: \(contact)")
+        }
+        lines.append(contentsOf: [
+            "",
+            "Usage snapshot (aggregate counts only — no dictated text):",
+            "  App version: \(snapshot.appVersion)",
+            "  Using since: \(snapshot.usingSince)",
+            "  Total words dictated: \(snapshot.totalWords)",
+            "  Total time saved: \(snapshot.timeSaved)",
+            "  Current streak: \(snapshot.streakDays) day(s)",
+            "  Last 7 days (minutes returned): \(snapshot.lastWeekMinutes.map(String.init).joined(separator: ", "))",
+            "  Total takes recorded: \(snapshot.totalTakes)",
+        ])
+        return lines.joined(separator: "\n")
+    }
+}
+
+/// A small, aggregate slice of on-device usage stats — the same figures
+/// already shown on the Home pane — bundled into a feedback submission.
+/// No dictation text, snippets, dictionary, or profile data.
+struct UsageSnapshot {
+    let appVersion: String
+    let usingSince: String
+    let totalWords: Int
+    let timeSaved: String
+    let streakDays: Int
+    let lastWeekMinutes: [Int]
+    let totalTakes: Int
+
+    @MainActor
+    init(controller: AppController) {
+        let history = controller.historyStore
+        appVersion = "v\(UpdaterController.shared.appVersion)"
+        if let since = controller.settings.firstUseDate {
+            let f = DateFormatter()
+            f.dateFormat = "MMMM yyyy"
+            usingSince = f.string(from: since)
+        } else {
+            usingSince = "unknown"
+        }
+        totalWords = history.totalWords
+        let minutes = history.totalMinutes
+        timeSaved = minutes >= 60 ? "\(minutes / 60)h \(minutes % 60)m" : "\(minutes)m"
+        streakDays = history.streak
+        lastWeekMinutes = history.minutesLastWeek
+        totalTakes = history.entries.count
+    }
+}


### PR DESCRIPTION
## What this changes (for the user)

Adds a **Feedback** row to the dashboard sidebar, right below Settings. Tapping it opens a short sheet:

- Category: *Something's broken* / *Feature idea* / *Just saying thanks* / *Something else*
- A free-text message field
- An off-by-default toggle to include a reply email

There's no backend or telemetry in this app (see the privacy-architecture docs, which already say so), so Send does the same thing the docs already point people to: it opens a `mailto:shimoverse@gmail.com` with the message pre-filled — nothing is sent unless the user hits Send.

Riding along in that email is a small aggregate **usage snapshot**, built at submit time from the existing local `HistoryStore`/`Settings` counters that already power the Home pane:

- App version
- "Using since" (first-use month/year)
- Total words dictated
- Total time saved
- Current streak
- Last 7 days, minutes returned per day
- Total takes recorded

It never includes dictation text, snippets, dictionary entries, or the Know-Me profile — only counts already shown on-screen. Nothing is captured or sent passively; it's assembled fresh only when the user presses Send.

New file: `native/Sources/OpenVoiceFlow/FeedbackView.swift`. Sidebar wiring in `native/Sources/OpenVoiceFlow/DashboardView.swift`.

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python) — **not verified locally**: this session runs on Linux without a Swift/AppKit toolchain, so I could not compile the SwiftUI change myself. Relying on CI to confirm the build.
- [ ] Screenshot or recording attached for UI changes — **not available**: no macOS environment to run the app in this session.
- [x] No version bumps or new dependencies

I'll watch this PR's CI and address any build failures once they surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_011HCGgvR3e4YGBr4Kt5nN3N)_