### PR TITLE
chore: bump native app to 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7] — 2026-08-28
+
+### Added
+- A Feedback item in the sidebar, below Settings. Opens a short form (bug /
+  idea / praise / other, plus an optional reply email) and, only on Send,
+  opens a `mailto:` with the message and a small aggregate usage snapshot
+  (words dictated, time saved, streak, last 7 days, first-use date) —
+  never dictation text, snippets, dictionary entries, or the Know-Me
+  profile, and nothing is sent until Send is pressed.
+
 ## [0.5.6] — 2026-08-25
 
 ### Added

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.6</string>
-    <key>CFBundleVersion</key><string>11</string>
+    <key>CFBundleShortVersionString</key><string>0.5.7</string>
+    <key>CFBundleVersion</key><string>12</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.6
-        CURRENT_PROJECT_VERSION: 11
+        MARKETING_VERSION: 0.5.7
+        CURRENT_PROJECT_VERSION: 12
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

Version bump only, following the same pattern as #87 (0.5.5 → 0.5.6): `MARKETING_VERSION`/`CFBundleShortVersionString` 0.5.6 → 0.5.7, build 11 → 12, and a CHANGELOG entry covering what shipped since 0.5.6 — the sidebar Feedback item from #90.

- `native/Info.plist`
- `native/project.yml`
- `CHANGELOG.md`

## How it was verified

- [x] No version bumps or new dependencies — N/A, this PR *is* the version bump, per the same pattern as #87.
- [ ] CI green (`native-build` for Swift changes, pytest for website/Python) — pending, no source code touched here.
- [ ] Screenshot or recording attached for UI changes — N/A, no UI change.

This does not create the release tag or trigger the signed/notarized build — that's the separate `Create release tag` → `Release (native app)` dispatch per `.github/workflows/create-release-tag.yml`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011HCGgvR3e4YGBr4Kt5nN3N)_