### PR TITLE
Add private analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ htmlcov/
 public/
 node_modules/
 .ruff_cache/
+.analytics-dashboard/
 .idea/
 .vscode/
 *.swp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,27 @@ They pin download filenames, checksums, appcast integrity, and the
 Gatekeeper-warning cards. If your change breaks one, read the test — each one
 documents the support question or invariant it protects.
 
+## Maintainer analytics dashboard
+
+Repository traffic and aggregate website analytics can be combined into a
+private local dashboard:
+
+```bash
+gh auth status
+vercel whoami
+python3 scripts/analytics_dashboard.py --open
+```
+
+The generated HTML and normalized snapshot live in `.analytics-dashboard/`,
+use owner-only file permissions, and are ignored by Git. The dashboard never
+copies GitHub or Vercel credentials into its output. It deliberately keeps
+repository views, clone operations, CI checkouts, release-asset requests,
+website visitors, and verified installs separate: none is a proxy for another.
+
+The GitHub traffic window is short, so rebuild or archive the private snapshot
+regularly if trend history matters. Website data comes from Vercel's documented
+Web Analytics REST API. Add `--no-vercel` to generate the GitHub-only dashboard.
+
 ## Working on the legacy Python app
 
 Only security-relevant or fallback-critical fixes are accepted; features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,4 @@ ignore = []
 # the output is HTML, where line length means nothing.
 "scripts/docs_content.py" = ["E501"]
 "scripts/build_docs.py" = ["E501"]  # page chrome (nav, analytics tags) verbatim
+"scripts/analytics_dashboard.py" = ["E501"]  # self-contained private dashboard HTML/CSS template

--- a/scripts/analytics_dashboard.py
+++ b/scripts/analytics_dashboard.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+"""Build a private, local OpenVoiceFlow analytics dashboard.
+
+The collector uses the authenticated GitHub CLI and, when available, the local
+Vercel CLI token. Credentials are never copied into the generated snapshot or
+HTML. The native app remains telemetry-free; this dashboard only combines
+repository traffic, release-asset request counters, CI activity, and aggregate
+website analytics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import subprocess
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from zoneinfo import ZoneInfo
+
+REPOSITORY = "shimoverse/openvoiceflow"
+VERCEL_PROJECT = "openvoiceflow"
+TIMEZONE = "America/Los_Angeles"
+SCHEMA_VERSION = 1
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / ".analytics-dashboard" / "index.html"
+DEFAULT_SNAPSHOT = ROOT / ".analytics-dashboard" / "snapshot.json"
+VERCEL_AUTH = Path.home() / "Library/Application Support/com.vercel.cli/auth.json"
+
+
+class AnalyticsError(RuntimeError):
+    """A source could not be collected without exposing credential details."""
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _require_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    return value
+
+
+def _gh_api(path: str, accept: Optional[str] = None) -> Any:
+    command = ["gh", "api", path]
+    if accept:
+        command.extend(["-H", f"Accept: {accept}"])
+    try:
+        result = subprocess.run(command, cwd=ROOT, check=True, capture_output=True, text=True, timeout=60)
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise AnalyticsError("GitHub analytics request failed; confirm `gh auth status` succeeds") from exc
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AnalyticsError("GitHub returned an unreadable analytics response") from exc
+
+
+def _gh_paginate(path: str, accept: Optional[str] = None, per_page: int = 100) -> List[Any]:
+    separator = "&" if "?" in path else "?"
+    items: List[Any] = []
+    for page in range(1, 11):
+        payload = _gh_api(f"{path}{separator}per_page={per_page}&page={page}", accept=accept)
+        if not isinstance(payload, list):
+            raise AnalyticsError("GitHub pagination returned an unexpected response")
+        items.extend(payload)
+        if len(payload) < per_page:
+            break
+    return items
+
+
+def _gh_paginate_key(path: str, key: str, per_page: int = 100) -> List[Dict[str, Any]]:
+    """Collect a GitHub paginated object response without truncating busy windows."""
+    separator = "&" if "?" in path else "?"
+    items: List[Dict[str, Any]] = []
+    for page in range(1, 51):
+        payload = _gh_api(f"{path}{separator}per_page={per_page}&page={page}")
+        page_items = payload.get(key) if isinstance(payload, dict) else None
+        if not isinstance(page_items, list):
+            raise AnalyticsError(f"GitHub pagination returned an unexpected `{key}` response")
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            break
+    return items
+
+
+def _workflow_checkout_count(run_id: int) -> int:
+    jobs = _gh_paginate_key(f"repos/{REPOSITORY}/actions/runs/{run_id}/jobs", "jobs")
+    count = 0
+    for job in jobs:
+        steps = job.get("steps") or []
+        if any("checkout" in str(step.get("name", "")).lower() and step.get("conclusion") != "skipped" for step in steps):
+            count += 1
+    return count
+
+
+def collect_github(now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Collect GitHub's rolling traffic aggregates and corroborating signals."""
+    now = now or datetime.now(timezone.utc)
+    repository = _gh_api(f"repos/{REPOSITORY}")
+    views = _gh_api(f"repos/{REPOSITORY}/traffic/views?per=day")
+    clones = _gh_api(f"repos/{REPOSITORY}/traffic/clones?per=day")
+    referrers = _gh_api(f"repos/{REPOSITORY}/traffic/popular/referrers")
+    paths = _gh_api(f"repos/{REPOSITORY}/traffic/popular/paths")
+    releases = _gh_paginate(f"repos/{REPOSITORY}/releases")
+
+    traffic_days = [item.get("timestamp") for item in clones.get("clones", []) if item.get("timestamp")]
+    oldest = min((_parse_datetime(item) for item in traffic_days), default=now - timedelta(days=13))
+    created_filter = urllib.parse.quote(f">={oldest.date().isoformat()}")
+    runs = _gh_paginate_key(
+        f"repos/{REPOSITORY}/actions/runs?created={created_filter}",
+        "workflow_runs",
+    )
+    workflow_runs: List[Dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {executor.submit(_workflow_checkout_count, int(run["id"])): run for run in runs}
+        for future in as_completed(futures):
+            run = futures[future]
+            checkout_jobs = future.result()
+            workflow_runs.append(
+                {
+                    "id": run["id"],
+                    "created_at": run.get("created_at"),
+                    "name": run.get("name"),
+                    "event": run.get("event"),
+                    "checkout_jobs": checkout_jobs,
+                }
+            )
+
+    stargazers_raw = _gh_paginate(
+        f"repos/{REPOSITORY}/stargazers",
+        accept="application/vnd.github.star+json",
+    )
+    stargazers: List[Dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            executor.submit(_gh_api, f"users/{item['user']['login']}"): item
+            for item in stargazers_raw
+            if item.get("user", {}).get("login")
+        }
+        for future in as_completed(futures):
+            item = futures[future]
+            try:
+                user = future.result()
+            except AnalyticsError:
+                continue
+            stargazers.append(
+                {
+                    "login": user.get("login"),
+                    "starred_at": item.get("starred_at"),
+                    "created_at": user.get("created_at"),
+                    "public_repos": user.get("public_repos", 0),
+                    "followers": user.get("followers", 0),
+                }
+            )
+
+    return {
+        "repository": {
+            "full_name": repository.get("full_name", REPOSITORY),
+            "html_url": repository.get("html_url", f"https://github.com/{REPOSITORY}"),
+            "stargazers_count": repository.get("stargazers_count", 0),
+            "forks_count": repository.get("forks_count", 0),
+            "open_issues_and_pull_requests_count": repository.get("open_issues_count", 0),
+        },
+        "views": views,
+        "clones": clones,
+        "popular_referrers": referrers,
+        "popular_paths": paths,
+        "releases": releases,
+        "workflow_runs": workflow_runs,
+        "stargazers": stargazers,
+    }
+
+
+def _vercel_token() -> str:
+    token = os.environ.get("VERCEL_TOKEN", "").strip()
+    if token:
+        return token
+    try:
+        payload = json.loads(VERCEL_AUTH.read_text(encoding="utf-8"))
+        token = str(payload.get("token", "")).strip()
+    except (OSError, json.JSONDecodeError):
+        token = ""
+    if not token:
+        raise AnalyticsError("Vercel analytics unavailable; run `vercel login` first")
+    return token
+
+
+def _vercel_json(url: str, token: str) -> Dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"Authorization": f"Bearer {token}", "User-Agent": "OpenVoiceFlow-analytics-dashboard/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        status = getattr(exc, "code", "network")
+        raise AnalyticsError(f"Vercel analytics request failed ({status})") from exc
+
+
+def _discover_vercel_project(token: str, project_name: str) -> Tuple[Optional[str], str]:
+    teams_payload = _vercel_json("https://api.vercel.com/v2/teams?limit=100", token)
+    teams = teams_payload.get("teams", [])
+    scopes: List[Optional[str]] = [None]
+    scopes.extend(str(team["id"]) for team in teams if team.get("id"))
+    for team_id in scopes:
+        query = urllib.parse.urlencode({"teamId": team_id}) if team_id else ""
+        try:
+            suffix = f"?{query}" if query else ""
+            project = _vercel_json(f"https://api.vercel.com/v9/projects/{project_name}{suffix}", token)
+        except AnalyticsError:
+            continue
+        project_id = project.get("id")
+        if project_id:
+            return team_id, str(project_id)
+    raise AnalyticsError(f"Vercel project `{project_name}` was not found in the authenticated account or teams")
+
+
+def collect_vercel(
+    now: Optional[datetime] = None,
+    days: int = 30,
+    project_name: str = VERCEL_PROJECT,
+) -> Dict[str, Any]:
+    """Collect aggregate Vercel Web Analytics without persisting its token."""
+    now = now or datetime.now(timezone.utc)
+    token = _vercel_token()
+    team_id, project_id = _discover_vercel_project(token, project_name)
+    local_now = now.astimezone(ZoneInfo(TIMEZONE))
+    local_start = (local_now - timedelta(days=days - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    start = _utc_iso(local_start)
+    end = _utc_iso(local_now)
+    common = {
+        "projectId": project_id,
+        "since": start,
+        "until": end,
+    }
+    if team_id:
+        common["teamId"] = team_id
+    base = "https://api.vercel.com/v1/query/web-analytics/"
+
+    def request(endpoint: str, extra: Optional[Dict[str, str]] = None) -> Any:
+        query = dict(common)
+        query.update(extra or {})
+        payload = _vercel_json(base + endpoint + "?" + urllib.parse.urlencode(query), token)
+        if payload.get("version") != 1 or "data" not in payload:
+            raise AnalyticsError("Vercel Web Analytics returned an unexpected response schema")
+        return payload["data"]
+
+    overview = request("visits/count")
+    if not isinstance(overview, dict):
+        raise AnalyticsError("Vercel Web Analytics count response was not an object")
+    pageviews = _require_int(overview.get("pageviews"), "vercel pageviews")
+    visitors = _require_int(overview.get("visitors"), "vercel visitors")
+
+    dimensions = {
+        "path": ("visits/aggregate", "requestPath"),
+        "referrer": ("visits/aggregate", "referrerHostname"),
+        "country": ("visits/aggregate", "country"),
+        "device_type": ("visits/aggregate", "deviceType"),
+        "os_name": ("visits/aggregate", "osName"),
+        "client_name": ("visits/aggregate", "browserName"),
+        "event_name": ("events/aggregate", "eventName"),
+    }
+
+    def normalize(rows: Any, dimension: str, event: bool = False) -> List[Dict[str, Any]]:
+        if not isinstance(rows, list):
+            raise AnalyticsError(f"Vercel `{dimension}` aggregate response was not a list")
+        normalized = []
+        for row in rows:
+            if not isinstance(row, dict) or dimension not in row:
+                raise AnalyticsError(f"Vercel `{dimension}` aggregate row had an unexpected shape")
+            total_key = "count" if event else "pageviews"
+            normalized.append(
+                {
+                    "key": str(row[dimension]),
+                    "total": _require_int(row.get(total_key), f"vercel {dimension}.{total_key}"),
+                    "visitors": _require_int(row.get("visitors"), f"vercel {dimension}.visitors"),
+                }
+            )
+        return normalized
+
+    stats: Dict[str, List[Dict[str, Any]]] = {}
+    with ThreadPoolExecutor(max_workers=7) as executor:
+        futures = {
+            executor.submit(request, endpoint, {"by": dimension, "limit": "25"}): (stat_type, dimension, endpoint)
+            for stat_type, (endpoint, dimension) in dimensions.items()
+        }
+        for future in as_completed(futures):
+            stat_type, dimension, endpoint = futures[future]
+            stats[stat_type] = normalize(future.result(), dimension, event=endpoint.startswith("events/"))
+
+    return {
+        "available": True,
+        "window": {"from": start, "to": end, "days": days, "timezone": TIMEZONE},
+        "overview": {"pageviews": pageviews, "visitors": visitors},
+        "stats": stats,
+    }
+
+
+def estimate_external_interest(
+    github: Dict[str, Any],
+    owner_logins: Set[str],
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Return only defensible lower-bound interest signals, never a user claim."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=30)
+    owners = {value.lower() for value in owner_logins}
+    high_confidence = 0
+    low_signal = 0
+    considered = 0
+    for star in github.get("stargazers", []):
+        login = str(star.get("login", "")).lower()
+        if not login or login in owners or not star.get("starred_at") or not star.get("created_at"):
+            continue
+        starred_at = _parse_datetime(star["starred_at"])
+        if starred_at < cutoff:
+            continue
+        considered += 1
+        account_age = starred_at - _parse_datetime(star["created_at"])
+        public_repos = int(star.get("public_repos", 0) or 0)
+        followers = int(star.get("followers", 0) or 0)
+        established = account_age >= timedelta(days=180) and (public_repos >= 2 or followers >= 1)
+        if established:
+            high_confidence += 1
+        else:
+            low_signal += 1
+
+    return {
+        "verified_installs": None,
+        "active_users": None,
+        "exact_real_users": None,
+        "possible_external_cloners": None,
+        "high_confidence_external_interest": high_confidence,
+        "low_signal_recent_stars": low_signal,
+        "recent_external_stars_considered": considered,
+        "label": "High-confidence external interest — not installs or active users",
+        "method": (
+            "Recent non-owner stargazers whose accounts were at least 180 days old and had "
+            "at least two public repositories or one follower. This is a conservative engagement "
+            "signal, not proof that they downloaded or used the app."
+        ),
+    }
+
+
+def _release_assets(releases: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    assets: List[Dict[str, Any]] = []
+    for release in releases:
+        for asset in release.get("assets", []):
+            name = str(asset.get("name", ""))
+            if not name.lower().endswith((".dmg", ".zip", ".pkg")):
+                continue
+            assets.append(
+                {
+                    "tag": release.get("tag_name"),
+                    "name": name,
+                    "requests": _require_int(asset.get("download_count", 0), "release asset download_count"),
+                    "published_at": release.get("published_at"),
+                    "scope": "cumulative",
+                }
+            )
+    return sorted(assets, key=lambda item: str(item.get("published_at") or ""), reverse=True)
+
+
+def build_snapshot(
+    github: Dict[str, Any],
+    vercel: Dict[str, Any],
+    now: Optional[datetime] = None,
+    owner_logins: Optional[Set[str]] = None,
+) -> Dict[str, Any]:
+    """Normalize provider responses into the dashboard's stable data contract."""
+    now = now or datetime.now(timezone.utc)
+    owner_logins = owner_logins or {REPOSITORY.split("/", 1)[0]}
+    clone_count = _require_int(github.get("clones", {}).get("count"), "clones.count")
+    clone_uniques = _require_int(github.get("clones", {}).get("uniques"), "clones.uniques")
+    view_count = _require_int(github.get("views", {}).get("count"), "views.count")
+    view_uniques = _require_int(github.get("views", {}).get("uniques"), "views.uniques")
+    checkout_jobs = sum(_require_int(run.get("checkout_jobs", 0), "workflow checkout_jobs") for run in github.get("workflow_runs", []))
+    estimate = estimate_external_interest(github, owner_logins=owner_logins, now=now)
+
+    website: Dict[str, Any]
+    if vercel.get("available"):
+        overview = vercel.get("overview", {})
+        website = {
+            "available": True,
+            "window": vercel.get("window", {}),
+            "pageviews": _require_int(overview.get("pageviews"), "vercel overview.pageviews"),
+            "visitors": _require_int(overview.get("visitors"), "vercel overview.visitors"),
+            "stats": vercel.get("stats", {}),
+            "note": "Anonymous aggregate visitors are not identifiable people, accounts, downloads, or installs.",
+        }
+    else:
+        website = {"available": False, "error": "Website analytics unavailable", "pageviews": None, "visitors": None, "stats": {}}
+
+    clone_days = github.get("clones", {}).get("clones", [])
+    view_days = github.get("views", {}).get("views", [])
+    traffic_dates = [item.get("timestamp") for item in clone_days + view_days if item.get("timestamp")]
+    github_window = {
+        "from": min(traffic_dates) if traffic_dates else None,
+        "to": max(traffic_dates) if traffic_dates else None,
+        "note": "GitHub repository traffic is a short rolling window and should be snapshotted regularly.",
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _utc_iso(now),
+        "repository": github.get("repository", {}),
+        "adoption": estimate,
+        "github": {
+            "window": github_window,
+            "views": {"operations": view_count, "unique_visitors": view_uniques, "daily": view_days},
+            "clones": {"operations": clone_count, "unique_cloners": clone_uniques, "daily": clone_days},
+            "automation": {
+                "checkout_jobs": checkout_jobs,
+                "owner_external_split": None,
+                "note": (
+                    "Checkout jobs are correlated automation, not one-to-one GitHub clone attribution. "
+                    "GitHub cannot subtract maintainer work or identify the remaining operations as external users."
+                ),
+            },
+            "stars": {
+                "total": github.get("repository", {}).get("stargazers_count", 0),
+                "high_confidence_recent_external": estimate["high_confidence_external_interest"],
+                "low_signal_recent": estimate["low_signal_recent_stars"],
+            },
+            "forks": github.get("repository", {}).get("forks_count", 0),
+            "open_issues_and_pull_requests": github.get("repository", {}).get(
+                "open_issues_and_pull_requests_count", 0
+            ),
+            "popular_referrers": github.get("popular_referrers", []),
+            "popular_paths": github.get("popular_paths", []),
+            "release_assets": _release_assets(github.get("releases", [])),
+        },
+        "website": website,
+        "limitations": [
+            "GitHub does not expose clone identities, IP addresses, user agents, or geography.",
+            "GitHub clone operations and release-asset requests are not people, installations, or successful product use.",
+            "Vercel's anonymous visitor metric cannot retroactively separate owner testing from external visits.",
+            "Website download-click events measure clicks, not completed transfers or installations.",
+            "The native OpenVoiceFlow app is telemetry-free, so verified installs, active users, and retention are unknown.",
+        ],
+    }
+
+
+def _esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _metric(value: Any) -> str:
+    if value is None:
+        return "Unknown"
+    if isinstance(value, int):
+        return f"{value:,}"
+    return _esc(value)
+
+
+def _sparkline(daily: List[Dict[str, Any]], key: str = "count", width: int = 420, height: int = 92) -> str:
+    values = [int(item.get(key, 0) or 0) for item in daily]
+    if not values:
+        return '<div class="chart-empty">No daily data in this window</div>'
+    maximum = max(max(values), 1)
+    gap = 5
+    bar_width = max(3, (width - gap * (len(values) - 1)) / len(values))
+    bars = []
+    for index, value in enumerate(values):
+        bar_height = max(2, (value / maximum) * (height - 18))
+        x = index * (bar_width + gap)
+        y = height - bar_height
+        bars.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_width:.1f}" height="{bar_height:.1f}" rx="3">'
+            f'<title>{_esc(value)}</title></rect>'
+        )
+    return f'<svg class="spark" viewBox="0 0 {width} {height}" role="img" aria-label="Daily trend">{"".join(bars)}</svg>'
+
+
+def _ranked_rows(items: List[Dict[str, Any]], empty: str = "No data") -> str:
+    if not items:
+        return f'<p class="empty">{_esc(empty)}</p>'
+    maximum = max((int(item.get("total", item.get("count", 0)) or 0) for item in items), default=1)
+    rows = []
+    for item in items[:8]:
+        label = item.get("key") or item.get("referrer") or item.get("path") or "Direct / unknown"
+        total = int(item.get("total", item.get("count", 0)) or 0)
+        unique = item.get("visitors", item.get("uniques"))
+        width = max(3, round(total / max(maximum, 1) * 100))
+        detail = f"{total:,}"
+        if isinstance(unique, int):
+            detail += f" · {unique:,} unique"
+        rows.append(
+            '<div class="rank-row">'
+            f'<div class="rank-copy"><span title="{_esc(label)}">{_esc(label)}</span><strong>{_esc(detail)}</strong></div>'
+            f'<div class="rank-track"><span style="width:{width}%"></span></div>'
+            "</div>"
+        )
+    return "".join(rows)
+
+
+def render_dashboard(snapshot: Dict[str, Any]) -> str:
+    """Render a self-contained dashboard with no external scripts or telemetry."""
+    adoption = snapshot["adoption"]
+    gh = snapshot["github"]
+    website = snapshot["website"]
+    updated = _parse_datetime(snapshot["generated_at"]).astimezone(ZoneInfo(TIMEZONE))
+    updated_date = updated.strftime("%b %d, %Y").replace(" 0", " ")
+    updated_time = updated.strftime("%I:%M %p PT").lstrip("0")
+    latest_asset = gh["release_assets"][0] if gh["release_assets"] else None
+    asset_value = latest_asset["requests"] if latest_asset else None
+    asset_label = latest_asset["name"] if latest_asset else "No release asset"
+    if website.get("available"):
+        website_summary = f"""
+          <div class="metric"><span>Website visitors</span><strong>{_metric(website['visitors'])}</strong><small>Anonymous estimate · {website.get('window', {}).get('days', 30)} days</small></div>
+          <div class="metric"><span>Website pageviews</span><strong>{_metric(website['pageviews'])}</strong><small>Production web only</small></div>
+        """
+        website_panels = f"""
+          <section class="section" id="website">
+            <div class="section-head"><div><span class="eyebrow">Website</span><h2>Where discovery is happening</h2></div><span class="badge good">Vercel available</span></div>
+            <div class="grid three">
+              <article class="panel"><h3>Top pages</h3>{_ranked_rows(website['stats'].get('path', []))}</article>
+              <article class="panel"><h3>Referrers</h3>{_ranked_rows(website['stats'].get('referrer', []), 'No attributed referrers')}</article>
+              <article class="panel"><h3>Operating systems</h3>{_ranked_rows(website['stats'].get('os_name', []))}</article>
+            </div>
+            <div class="grid two compact-top">
+              <article class="panel"><h3>Countries</h3>{_ranked_rows(website['stats'].get('country', []))}</article>
+              <article class="panel"><h3>Tracked events</h3>{_ranked_rows(website['stats'].get('event_name', []), 'No custom events in this window')}</article>
+            </div>
+            <p class="footnote">{_esc(website['note'])}</p>
+          </section>
+        """
+    else:
+        website_summary = """
+          <div class="metric muted"><span>Website visitors</span><strong>—</strong><small>Source unavailable</small></div>
+          <div class="metric muted"><span>Website pageviews</span><strong>—</strong><small>Source unavailable</small></div>
+        """
+        website_panels = """
+          <section class="section" id="website"><div class="section-head"><div><span class="eyebrow">Website</span><h2>Website analytics unavailable</h2></div><span class="badge warn">Needs Vercel login</span></div><article class="panel"><p>Run <code>vercel login</code>, then rebuild the dashboard. GitHub analytics remains available.</p></article></section>
+        """
+
+    limitations = "".join(f"<li>{_esc(item)}</li>" for item in snapshot["limitations"])
+    referrer_rows = _ranked_rows(gh["popular_referrers"], "No GitHub referrers reported")
+    release_rows = "".join(
+        f'<div class="release-row"><div><strong>{_esc(item["name"])}</strong><span>{_esc(item["tag"])}</span></div><div><strong>{_metric(item["requests"])}</strong><span>cumulative requests</span></div></div>'
+        for item in gh["release_assets"][:6]
+    ) or '<p class="empty">No downloadable release assets</p>'
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>OpenVoiceFlow Analytics</title>
+<style>
+:root{{--bg:#f7f5f0;--card:#fff;--ink:#26221b;--muted:#746c5f;--hair:rgba(38,34,27,.12);--fill:rgba(38,34,27,.045);--accent:#b4661f;--accent-soft:#f5e7d8;--green:#4e7a58;--green-soft:#e5eee7;--warn:#9b5b21;--warn-soft:#fbf3e7;--shadow:0 18px 50px rgba(38,34,27,.08);--sans:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",sans-serif;--mono:ui-monospace,"SF Mono",Menlo,monospace;color-scheme:light}}
+@media(prefers-color-scheme:dark){{:root{{--bg:#131210;--card:#1d1b18;--ink:#ede9e0;--muted:#a69e8f;--hair:rgba(255,255,255,.11);--fill:rgba(255,255,255,.05);--accent:#e8974e;--accent-soft:#33261b;--green:#88b492;--green-soft:#1c2b21;--warn:#e3a263;--warn-soft:#2a2318;--shadow:0 18px 50px rgba(0,0,0,.22);color-scheme:dark}}}}
+*{{box-sizing:border-box}}html{{scroll-behavior:smooth}}body{{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}}body:before{{content:"";position:fixed;inset:0;pointer-events:none;background:radial-gradient(circle at 88% 2%,rgba(180,102,31,.09),transparent 28%),radial-gradient(circle at 8% 42%,rgba(78,122,88,.06),transparent 22%)}}.shell{{position:relative;max-width:1180px;margin:auto;padding:28px 28px 72px}}header{{display:flex;justify-content:space-between;align-items:center;padding:4px 0 38px;border-bottom:1px solid var(--hair)}}.brand{{display:flex;align-items:center;gap:12px}}.glyph{{width:38px;height:38px;display:grid;place-items:center;border-radius:12px;background:var(--ink);color:var(--bg);font-family:var(--mono);font-weight:800;letter-spacing:-2px}}.brand strong{{display:block;font-size:15px}}.brand span,.stamp{{color:var(--muted);font-size:12px}}.stamp{{text-align:right;font-family:var(--mono)}}.hero{{padding:56px 0 34px;display:grid;grid-template-columns:1.3fr .7fr;gap:42px;align-items:end}}.eyebrow{{display:block;color:var(--accent);font:700 11px var(--mono);letter-spacing:.1em;text-transform:uppercase;margin-bottom:10px}}h1{{font-size:clamp(36px,6vw,70px);line-height:.98;letter-spacing:-.055em;margin:0;max-width:820px}}.hero p{{font-size:18px;color:var(--muted);max-width:700px;margin:22px 0 0}}.answer{{border-left:3px solid var(--green);padding:4px 0 4px 20px}}.answer strong{{display:block;font-size:42px;line-height:1;letter-spacing:-.04em}}.answer span{{font-size:13px;color:var(--muted)}}.answer small{{display:block;margin-top:12px;color:var(--green);font-weight:650}}.metrics{{display:grid;grid-template-columns:repeat(6,1fr);border:1px solid var(--hair);border-radius:18px;overflow:hidden;background:var(--card);box-shadow:var(--shadow)}}.metric{{padding:20px;min-height:132px;border-right:1px solid var(--hair);display:flex;flex-direction:column}}.metric:last-child{{border:0}}.metric span{{font-size:12px;color:var(--muted)}}.metric strong{{font-size:30px;letter-spacing:-.04em;margin-top:auto}}.metric small{{font-size:11px;color:var(--muted);margin-top:4px}}.metric.muted strong{{color:var(--muted)}}.section{{padding:54px 0 0}}.section-head{{display:flex;justify-content:space-between;gap:20px;align-items:end;margin-bottom:18px}}h2{{font-size:28px;line-height:1.1;letter-spacing:-.035em;margin:0}}h3{{font-size:14px;margin:0 0 20px}}.badge{{font:650 11px var(--mono);padding:7px 10px;border-radius:999px;white-space:nowrap}}.badge.good{{color:var(--green);background:var(--green-soft)}}.badge.warn{{color:var(--warn);background:var(--warn-soft)}}.grid{{display:grid;gap:16px}}.grid.two{{grid-template-columns:repeat(2,1fr)}}.grid.three{{grid-template-columns:repeat(3,1fr)}}.compact-top{{margin-top:16px}}.panel{{background:var(--card);border:1px solid var(--hair);border-radius:16px;padding:22px;min-width:0}}.panel p{{color:var(--muted);margin:0}}.panel code{{font-family:var(--mono);color:var(--ink);background:var(--fill);padding:2px 5px;border-radius:5px}}.chart-panel{{padding-bottom:10px}}.chart-head{{display:flex;justify-content:space-between;gap:20px;margin-bottom:20px}}.chart-head div:last-child{{text-align:right}}.chart-head strong{{font-size:24px;display:block}}.chart-head span{{font-size:12px;color:var(--muted)}}.spark{{display:block;width:100%;height:auto;overflow:visible}}.spark rect{{fill:var(--accent);opacity:.78}}.spark rect:hover{{opacity:1}}.chart-empty,.empty{{color:var(--muted);font-size:13px;padding:18px 0}}.signal-list{{list-style:none;margin:0;padding:0}}.signal-list li{{padding:16px 0;border-top:1px solid var(--hair);display:flex;justify-content:space-between;gap:16px}}.signal-list li:first-child{{border-top:0;padding-top:0}}.signal-list strong{{font-size:20px}}.signal-list span{{font-size:12px;color:var(--muted);max-width:70%}}.rank-row{{margin-top:15px}}.rank-row:first-of-type{{margin-top:0}}.rank-copy{{display:flex;justify-content:space-between;gap:12px;font-size:12px}}.rank-copy span{{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--muted)}}.rank-copy strong{{font-size:11px;white-space:nowrap}}.rank-track{{height:5px;background:var(--fill);border-radius:99px;overflow:hidden;margin-top:7px}}.rank-track span{{display:block;height:100%;background:var(--accent);border-radius:99px}}.release-row{{display:flex;justify-content:space-between;gap:16px;padding:15px 0;border-top:1px solid var(--hair)}}.release-row:first-child{{padding-top:0;border:0}}.release-row>div:last-child{{text-align:right}}.release-row strong,.release-row span{{display:block}}.release-row strong{{font-size:13px}}.release-row span{{font-size:11px;color:var(--muted)}}.callout{{background:var(--warn-soft);border-color:rgba(180,102,31,.25)}}.callout h3{{font-size:20px}}.callout p{{font-size:14px}}.limits{{margin:0;padding-left:20px;color:var(--muted)}}.limits li{{padding:7px 0}}.footnote{{font-size:12px;color:var(--muted);margin:12px 2px 0}}footer{{margin-top:56px;padding-top:24px;border-top:1px solid var(--hair);font:12px var(--mono);color:var(--muted);display:flex;justify-content:space-between;gap:20px}}@media(max-width:900px){{.hero{{grid-template-columns:1fr}}.metrics{{grid-template-columns:repeat(3,1fr)}}.metric:nth-child(3){{border-right:0}}.metric:nth-child(-n+3){{border-bottom:1px solid var(--hair)}}.grid.three{{grid-template-columns:1fr}}}}@media(max-width:640px){{.shell{{padding:20px 16px 48px}}header{{align-items:flex-start}}.stamp{{max-width:150px}}.stamp-time{{display:none}}.hero{{padding-top:38px;gap:28px}}.hero p{{font-size:16px}}.metrics{{grid-template-columns:repeat(2,1fr)}}.metric{{border-bottom:1px solid var(--hair)}}.metric:nth-child(2n){{border-right:0}}.metric:nth-last-child(-n+2){{border-bottom:0}}.grid.two{{grid-template-columns:1fr}}.section-head{{align-items:flex-start;flex-direction:column}}footer{{flex-direction:column}}}}
+</style>
+</head>
+<body><main class="shell">
+<header><div class="brand"><div class="glyph">|||</div><div><strong>OpenVoiceFlow Analytics</strong><span>Private maintainer view</span></div></div><div class="stamp">Updated<br>{_esc(updated_date)}<span class="stamp-time"> · {_esc(updated_time)}</span></div></header>
+<section class="hero"><div><span class="eyebrow">Adoption, without false precision</span><h1>Interest is visible.<br>Actual users are not.</h1><p>Repository and website signals in one place, with CI noise and low-signal activity kept separate from genuine adoption.</p></div><div class="answer"><strong>{_metric(adoption['high_confidence_external_interest'])}</strong><span>High-confidence external interest</span><small>No verified install data · exact real-user count unknown</small></div></section>
+<section class="metrics" aria-label="Key metrics">
+<div class="metric"><span>Verified installs</span><strong>{_metric(adoption['verified_installs'])}</strong><small>Native app has no telemetry</small></div>
+<div class="metric"><span>Release requests</span><strong>{_metric(asset_value)}</strong><small title="{_esc(asset_label)}">Latest DMG · cumulative</small></div>
+{website_summary}
+<div class="metric"><span>Repository views</span><strong>{_metric(gh['views']['operations'])}</strong><small>{_metric(gh['views']['unique_visitors'])} GitHub uniques</small></div>
+<div class="metric"><span>Clone operations</span><strong>{_metric(gh['clones']['operations'])}</strong><small>{_metric(gh['clones']['unique_cloners'])} GitHub uniques</small></div>
+</section>
+<section class="section" id="github"><div class="section-head"><div><span class="eyebrow">GitHub</span><h2>Traffic and automation</h2></div><span class="badge warn">Rolling window</span></div>
+<div class="grid two"><article class="panel chart-panel"><div class="chart-head"><div><h3>Clone operations</h3><span>Daily GitHub totals</span></div><div><strong>{_metric(gh['clones']['operations'])}</strong><span>operations</span></div></div>{_sparkline(gh['clones']['daily'])}</article>
+<article class="panel chart-panel"><div class="chart-head"><div><h3>Repository views</h3><span>Daily GitHub totals</span></div><div><strong>{_metric(gh['views']['operations'])}</strong><span>views</span></div></div>{_sparkline(gh['views']['daily'])}</article></div>
+<div class="grid three compact-top"><article class="panel"><h3>Noise accounting</h3><ul class="signal-list"><li><span>CI jobs that executed checkout</span><strong>{_metric(gh['automation']['checkout_jobs'])}</strong></li><li><span>Owner / external clone split</span><strong>{_metric(gh['automation']['owner_external_split'])}</strong></li><li><span>Low-signal recent stars</span><strong>{_metric(gh['stars']['low_signal_recent'])}</strong></li><li><span>High-confidence recent external stars</span><strong>{_metric(gh['stars']['high_confidence_recent_external'])}</strong></li></ul></article><article class="panel"><h3>GitHub referrers</h3>{referrer_rows}</article><article class="panel"><h3>Release assets</h3>{release_rows}</article></div>
+<p class="footnote">{_esc(gh['automation']['note'])}</p></section>
+{website_panels}
+<section class="section"><div class="section-head"><div><span class="eyebrow">Interpretation</span><h2>What “real users” means here</h2></div></div><div class="grid two"><article class="panel callout"><h3>The defensible answer</h3><p>There are <strong>{_metric(adoption['high_confidence_external_interest'])} high-confidence external GitHub accounts</strong> showing recent interest. That is a lower-bound engagement signal, not a count of app users. There are <strong>no verified install or active-user counts</strong> because the app intentionally sends no telemetry.</p></article><article class="panel"><h3>Measurement limits</h3><ul class="limits">{limitations}</ul></article></div></section>
+<footer><span>Generated locally · no analytics scripts · no credentials embedded</span><span>Schema v{_esc(snapshot['schema_version'])}</span></footer>
+</main></body></html>"""
+
+
+def write_private(path: Path, content: str) -> None:
+    """Atomically write owner-readable output, including on replacement."""
+    probe = path.parent
+    while True:
+        if probe.is_symlink():
+            raise AnalyticsError("Refusing to write analytics output through a symlinked directory")
+        if probe == probe.parent:
+            break
+        probe = probe.parent
+    parent_existed = path.parent.exists()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if not parent_existed or path.parent == DEFAULT_OUTPUT.parent:
+        os.chmod(path.parent, 0o700)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Private dashboard HTML path")
+    parser.add_argument("--snapshot-output", type=Path, default=DEFAULT_SNAPSHOT, help="Private normalized JSON path")
+    parser.add_argument("--days", type=int, default=30, help="Website analytics window (default: 30)")
+    parser.add_argument("--no-vercel", action="store_true", help="Build with GitHub analytics only")
+    parser.add_argument("--open", action="store_true", dest="open_dashboard", help="Open the local dashboard after building")
+    args = parser.parse_args(argv)
+    if args.days < 1 or args.days > 90:
+        parser.error("--days must be between 1 and 90")
+
+    now = datetime.now(timezone.utc)
+    github = collect_github(now=now)
+    if args.no_vercel:
+        vercel = {"available": False, "error": "Website analytics unavailable"}
+    else:
+        try:
+            vercel = collect_vercel(now=now, days=args.days)
+        except AnalyticsError as exc:
+            print(f"Warning: {exc}")
+            vercel = {"available": False, "error": "Website analytics unavailable"}
+
+    configured = os.environ.get("OVF_ANALYTICS_OWNER_LOGINS", "shimoverse")
+    owner_logins = {item.strip().lower() for item in configured.split(",") if item.strip()}
+    snapshot = build_snapshot(github, vercel, now=now, owner_logins=owner_logins)
+    write_private(args.snapshot_output, json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+    write_private(args.output, render_dashboard(snapshot))
+    print(f"Dashboard: {args.output}")
+    print(f"Snapshot:  {args.snapshot_output}")
+    print(
+        "Answer: "
+        f"{snapshot['adoption']['high_confidence_external_interest']} high-confidence external interest accounts; "
+        "verified installs and exact real users remain unknown."
+    )
+    if args.open_dashboard:
+        webbrowser.open(args.output.resolve().as_uri())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -1,0 +1,245 @@
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+import scripts.analytics_dashboard as dashboard
+from scripts.analytics_dashboard import (
+    build_snapshot,
+    estimate_external_interest,
+    render_dashboard,
+    write_private,
+)
+
+NOW = datetime(2026, 8, 27, 22, 0, tzinfo=timezone.utc)
+
+
+def github_fixture():
+    return {
+        "repository": {
+            "full_name": "shimoverse/openvoiceflow",
+            "html_url": "https://github.com/shimoverse/openvoiceflow",
+            "stargazers_count": 16,
+            "forks_count": 2,
+            "open_issues_and_pull_requests_count": 1,
+        },
+        "views": {
+            "count": 35,
+            "uniques": 24,
+            "views": [{"timestamp": "2026-08-26T00:00:00Z", "count": 1, "uniques": 1}],
+        },
+        "clones": {
+            "count": 274,
+            "uniques": 141,
+            "clones": [{"timestamp": "2026-08-26T00:00:00Z", "count": 103, "uniques": 41}],
+        },
+        "popular_referrers": [
+            {"referrer": "panel.socialplug.io", "count": 14, "uniques": 12},
+            {"referrer": "github.com", "count": 4, "uniques": 3},
+        ],
+        "popular_paths": [{"path": "/shimoverse/openvoiceflow", "title": "OpenVoiceFlow", "count": 31, "uniques": 22}],
+        "releases": [
+            {
+                "tag_name": "native-v0.5.6",
+                "published_at": "2026-08-26T06:51:52Z",
+                "assets": [
+                    {"name": "OpenVoiceFlow-0.5.6.dmg", "download_count": 25},
+                    {"name": "appcast.xml", "download_count": 1},
+                ],
+            }
+        ],
+        "workflow_runs": [
+            {"id": 1, "created_at": "2026-08-24T01:00:00Z", "checkout_jobs": 90},
+            {"id": 2, "created_at": "2026-08-26T01:00:00Z", "checkout_jobs": 49},
+        ],
+        "stargazers": [
+            {
+                "login": "old-contributor",
+                "starred_at": "2026-08-27T01:00:00Z",
+                "created_at": "2018-01-01T00:00:00Z",
+                "public_repos": 12,
+                "followers": 3,
+            },
+            {
+                "login": "new-empty",
+                "starred_at": "2026-08-26T01:00:00Z",
+                "created_at": "2026-08-26T00:00:00Z",
+                "public_repos": 0,
+                "followers": 0,
+            },
+            {
+                "login": "shimoverse",
+                "starred_at": "2026-08-26T01:00:00Z",
+                "created_at": "2015-01-01T00:00:00Z",
+                "public_repos": 50,
+                "followers": 20,
+            },
+        ],
+    }
+
+
+def vercel_fixture():
+    return {
+        "available": True,
+        "window": {"from": "2026-07-29T07:00:00Z", "to": "2026-08-28T07:00:00Z", "days": 30},
+        "overview": {"pageviews": 16, "visitors": 15},
+        "stats": {
+            "path": [{"key": "/", "total": 15, "visitors": 14}],
+            "referrer": [{"key": "bing.com", "total": 6, "visitors": 5}],
+            "event_name": [],
+            "country": [{"key": "US", "total": 14, "visitors": 13}],
+            "device_type": [{"key": "desktop", "total": 14, "visitors": 13}],
+            "os_name": [{"key": "Mac", "total": 1, "visitors": 1}],
+        },
+    }
+
+
+def test_external_interest_is_a_lower_bound_not_an_install_claim():
+    estimate = estimate_external_interest(github_fixture(), owner_logins={"shimoverse"}, now=NOW)
+
+    assert estimate["high_confidence_external_interest"] == 1
+    assert estimate["verified_installs"] is None
+    assert estimate["possible_external_cloners"] is None
+    assert "not install" in estimate["label"].lower()
+    assert estimate["low_signal_recent_stars"] == 1
+
+
+def test_snapshot_keeps_metrics_separate_and_labels_automation():
+    snapshot = build_snapshot(github_fixture(), vercel_fixture(), now=NOW, owner_logins={"shimoverse"})
+
+    assert snapshot["schema_version"] == 1
+    assert snapshot["github"]["clones"]["operations"] == 274
+    assert snapshot["github"]["clones"]["unique_cloners"] == 141
+    assert snapshot["github"]["automation"]["checkout_jobs"] == 139
+    assert snapshot["github"]["automation"]["owner_external_split"] is None
+    assert snapshot["github"]["release_assets"][0]["requests"] == 25
+    assert snapshot["website"]["pageviews"] == 16
+    assert snapshot["website"]["visitors"] == 15
+    assert snapshot["adoption"]["verified_installs"] is None
+    assert snapshot["adoption"]["active_users"] is None
+    assert snapshot["adoption"]["exact_real_users"] is None
+
+
+def test_snapshot_does_not_embed_credentials_or_local_auth_paths():
+    snapshot = build_snapshot(github_fixture(), vercel_fixture(), now=NOW, owner_logins={"shimoverse"})
+    serialized = json.dumps(snapshot).lower()
+
+    for forbidden in ("authorization", "bearer ", "auth.json", "vercel_token", "github_token"):
+        assert forbidden not in serialized
+
+
+def test_dashboard_is_self_contained_private_and_explains_limitations():
+    snapshot = build_snapshot(github_fixture(), vercel_fixture(), now=NOW, owner_logins={"shimoverse"})
+    html = render_dashboard(snapshot)
+
+    assert "OpenVoiceFlow Analytics" in html
+    assert "High-confidence external interest" in html
+    assert "Verified installs" in html
+    assert "Unknown" in html
+    assert "274" in html
+    assert "139" in html
+    assert "GitHub does not expose clone identities, IP addresses, user agents, or geography" in html
+    assert "<script src=" not in html
+    assert "https://va.vercel-scripts.com" not in html
+
+
+def test_private_writer_uses_owner_only_permissions(tmp_path):
+    output = tmp_path / "nested" / "dashboard.html"
+    write_private(output, "secret-ish aggregate analytics")
+
+    assert output.read_text() == "secret-ish aggregate analytics"
+    assert os.stat(output).st_mode & 0o777 == 0o600
+
+
+def test_private_writer_does_not_chmod_existing_custom_parent(tmp_path):
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o755)
+    os.chmod(shared, 0o755)
+
+    write_private(shared / "dashboard.html", "aggregate analytics")
+
+    assert os.stat(shared).st_mode & 0o777 == 0o755
+    assert os.stat(shared / "dashboard.html").st_mode & 0o777 == 0o600
+
+
+def test_vercel_project_discovery_supports_personal_scope(monkeypatch):
+    calls = []
+
+    def fake_json(url, token):
+        calls.append(url)
+        if "/v2/teams" in url:
+            return {"teams": [{"id": "team_1"}]}
+        if url.endswith("/v9/projects/openvoiceflow"):
+            return {"id": "prj_personal"}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(dashboard, "_vercel_json", fake_json)
+
+    assert dashboard._discover_vercel_project("unused", "openvoiceflow") == (None, "prj_personal")
+    assert not any("teamId=" in url for url in calls)
+
+
+def test_vercel_collector_uses_documented_api_and_normalizes_metrics(monkeypatch):
+    calls = []
+
+    def fake_json(url, token):
+        calls.append(url)
+        if "/visits/count?" in url:
+            return {"version": 1, "data": {"pageviews": 16, "visitors": 15}}
+        if "/events/aggregate?" in url:
+            return {"version": 1, "data": [{"eventName": "download_click", "count": 2, "visitors": 1}]}
+        if "/visits/aggregate?" in url:
+            from urllib.parse import parse_qs, urlparse
+
+            dimension = parse_qs(urlparse(url).query)["by"][0]
+            return {"version": 1, "data": [{dimension: "sample", "pageviews": 3, "visitors": 2}]}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(dashboard, "_vercel_token", lambda: "unused")
+    monkeypatch.setattr(dashboard, "_discover_vercel_project", lambda token, name: ("team_1", "prj_1"))
+    monkeypatch.setattr(dashboard, "_vercel_json", fake_json)
+
+    result = dashboard.collect_vercel(now=NOW, days=30)
+
+    assert result["overview"] == {"pageviews": 16, "visitors": 15}
+    assert result["stats"]["path"] == [{"key": "sample", "total": 3, "visitors": 2}]
+    assert result["stats"]["event_name"] == [{"key": "download_click", "total": 2, "visitors": 1}]
+    assert calls and all(url.startswith("https://api.vercel.com/v1/query/web-analytics/") for url in calls)
+    assert all("vercel.com/api/web-analytics/v2" not in url for url in calls)
+
+
+def test_github_object_pagination_collects_every_page(monkeypatch):
+    def fake_api(path, accept=None):
+        from urllib.parse import parse_qs, urlparse
+
+        page = parse_qs(urlparse(path).query)["page"][0]
+        if page == "1":
+            return {"workflow_runs": [{"id": value} for value in range(100)]}
+        if page == "2":
+            return {"workflow_runs": [{"id": 100}]}
+        raise AssertionError(path)
+
+    monkeypatch.setattr(dashboard, "_gh_api", fake_api)
+
+    runs = dashboard._gh_paginate_key("repos/example/actions/runs", "workflow_runs")
+
+    assert len(runs) == 101
+    assert runs[-1]["id"] == 100
+
+
+def test_dashboard_survives_missing_vercel_data():
+    unavailable = {"available": False, "error": "Vercel analytics unavailable"}
+    snapshot = build_snapshot(github_fixture(), unavailable, now=NOW, owner_logins={"shimoverse"})
+    html = render_dashboard(snapshot)
+
+    assert snapshot["website"]["available"] is False
+    assert "Website analytics unavailable" in html
+
+
+def test_invalid_provider_shapes_fail_closed():
+    bad = github_fixture()
+    bad["clones"] = {"count": "274", "uniques": 10, "clones": []}
+
+    with pytest.raises(ValueError, match="clones.count"):
+        build_snapshot(bad, vercel_fixture(), now=NOW, owner_logins={"shimoverse"})


### PR DESCRIPTION
## Summary

- add a private local dashboard that combines GitHub repository traffic, release-asset requests, paginated CI checkout activity, and aggregate Vercel Web Analytics
- keep clone operations, GitHub uniques, website visitors, release requests, installs, and active users explicitly separate
- add conservative external-interest classification while preserving the truthful answer that verified installs and exact real users are unknown
- write generated HTML/JSON with owner-only file permissions and keep all generated analytics out of Git
- use Vercel's documented Web Analytics REST API, with personal-account and team-project discovery
- document the maintainer workflow and the GitHub-only fallback

## Privacy and claim boundary

- no native app telemetry was added
- no credentials, GitHub/Vercel identities, or raw stargazer profiles are written to the dashboard snapshot
- GitHub does not expose clone IPs, geography, or owner/external attribution
- Vercel anonymous visitors are not presented as people, downloads, installs, or active users

## Verification

- `uvx ruff check scripts/analytics_dashboard.py tests/test_analytics_dashboard.py`
- `env -u OPENROUTER_API_KEY python3 -m pytest -q` — 273 passed, 1 optional dependency skip
- `npm run vercel-build`
- live authenticated collection from GitHub and Vercel's documented REST API
- GitHub-only custom-output fallback, generated-output credential scan, and `0600` file-permission check
- desktop and emulated 390px mobile visual QA; no horizontal overflow

## Live interpretation at verification time

The dashboard found 3 high-confidence external-interest accounts and 12 low-signal recent stars. These are engagement signals only. Verified installs, active users, and the owner/external clone split remain unknown.
