### PR TITLE
chore: bump native app to 0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8] — 2026-08-28
+
 ### Added
 - Anonymous usage sharing and an in-app Leaderboard, ranked by time saved.
   **On by default** — a real, disclosed change from every prior release,

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.7</string>
-    <key>CFBundleVersion</key><string>12</string>
+    <key>CFBundleShortVersionString</key><string>0.5.8</string>
+    <key>CFBundleVersion</key><string>13</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.7
-        CURRENT_PROJECT_VERSION: 12
+        MARKETING_VERSION: 0.5.8
+        CURRENT_PROJECT_VERSION: 13
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## Summary
- bump native app version from 0.5.7 to 0.5.8
- increment Sparkle build number from 12 to 13
- cut the merged analytics/leaderboard changes into the 0.5.8 changelog section

## Verification
- `plutil -lint native/Info.plist`
- version contract: all four fields agree on 0.5.8 (13), and 13 > 12
- `python3 -m pytest -q` — 262 passed, 1 skipped
- `git diff --check`