### PR TITLE
Fix Feedback sheet category picker overflowing its width

### DIFF
--- a/native/Sources/OpenVoiceFlow/FeedbackView.swift
+++ b/native/Sources/OpenVoiceFlow/FeedbackView.swift
@@ -24,6 +24,18 @@ struct FeedbackView: View {
         case praise = "Just saying thanks"
         case other = "Something else"
         var id: String { rawValue }
+
+        /// Short enough that all four segments fit a 480pt-wide sheet without
+        /// truncating — the full rawValue is still what goes in the email
+        /// subject/body, this is only what the segmented control displays.
+        var shortLabel: String {
+            switch self {
+            case .bug: return "Bug"
+            case .idea: return "Idea"
+            case .praise: return "Thanks"
+            case .other: return "Other"
+            }
+        }
     }
 
     @State private var category: Category = .idea
@@ -47,7 +59,7 @@ struct FeedbackView: View {
             }
 
             Picker("", selection: $category) {
-                ForEach(Category.allCases) { Text($0.rawValue).tag($0) }
+                ForEach(Category.allCases) { Text($0.shortLabel).tag($0) }
             }
             .labelsHidden().pickerStyle(.segmented)
 
@@ -91,7 +103,7 @@ struct FeedbackView: View {
             }
         }
         .padding(24)
-        .frame(width: 440, height: 420)
+        .frame(width: 480, height: 420)
     }
 
     private func send() {


### PR DESCRIPTION
## What this changes (for the user)

A screenshot of the Feedback sheet showed its content clipped. The one concrete, in-code defect I could confirm and fix: the segmented category picker's four labels ("Something's broken", "Feature idea", "Just saying thanks", "Something else") are too long to fit a 440pt-wide sheet, so the leading and trailing segments were truncating/overflowing.

- Segmented control now shows short labels: **Bug / Idea / Thanks / Other**.
- The full original wording is still what goes into the email subject and body (`Category.rawValue` is unchanged) — only the on-screen segment label changed.
- Sheet widened 440 → 480pt for margin.

(Note: some of what was clipped in the screenshot — e.g. the sheet's own title and background dashboard text behind it, both cut at the same left edge — looks more consistent with a partial/cropped screenshot than a SwiftUI layout bug, since that's not something app code controls. This PR fixes the one layout defect I could actually verify and reproduce in the code: the picker overflow.)

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python) — pending; no Swift/AppKit toolchain in this session to compile locally.
- [ ] Screenshot or recording attached for UI changes — not available, no macOS environment in this session.
- [x] No version bumps or new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_011HCGgvR3e4YGBr4Kt5nN3N)_