### PR TITLE
chore: bump native app to 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9] — 2026-08-29
+
+### Fixed
+- The Feedback sheet's category picker ("Something's broken" / "Feature
+  idea" / "Just saying thanks" / "Something else") overflowed a 440pt-wide
+  sheet, truncating the leading and trailing segments. Segmented control now
+  shows short labels (Bug/Idea/Thanks/Other); the full wording still goes
+  into the email subject and body. Sheet widened to 480pt for margin.
+
 ## [0.5.8] — 2026-08-28
 
 ### Added

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.8</string>
-    <key>CFBundleVersion</key><string>13</string>
+    <key>CFBundleShortVersionString</key><string>0.5.9</string>
+    <key>CFBundleVersion</key><string>14</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.8
-        CURRENT_PROJECT_VERSION: 13
+        MARKETING_VERSION: 0.5.9
+        CURRENT_PROJECT_VERSION: 14
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

Version bump only, same pattern as prior bumps (#87, #91): `MARKETING_VERSION`/`CFBundleShortVersionString` 0.5.8 → 0.5.9, build 13 → 14, and a CHANGELOG entry for what's shipping — the Feedback sheet width fix in #96.

- `native/Info.plist`
- `native/project.yml`
- `CHANGELOG.md`

**Merge order matters:** this should land after #96 (the actual fix) merges, so 0.5.9 includes it rather than shipping an unbumped 0.5.8-equivalent.

## How it was verified

- [x] No version bumps or new dependencies — N/A, this PR *is* the version bump.
- [ ] CI green — pending, no source code touched here.
- [ ] Screenshot — N/A, no UI change.

This does not create the release tag or trigger the signed/notarized build.


---
_Generated by [Claude Code](https://claude.ai/code/session_011HCGgvR3e4YGBr4Kt5nN3N)_