### PR TITLE
Merge Dictionary, Snippets, and Styles into one Personalize pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Dictionary, Snippets, and Styles are now one **Personalize** pane in the
+  dashboard sidebar, switched with tabs instead of three separate rows.
+  Each tab keeps its item count, the content area now sits in a single card,
+  and switching tabs animates instead of jumping. No data or behavior
+  changes — same stores, same add/remove actions, same empty states. Docs
+  updated to describe the new location (`Dashboard ▸ Personalize`).
+
 ## [0.5.8] — 2026-08-28
 
 ### Added

--- a/docs/blog/personal-dictionary-dictation.html
+++ b/docs/blog/personal-dictionary-dictation.html
@@ -106,7 +106,7 @@
         <div class="article-body">
           <div class="article-answer">
             <span class="mono-kicker">The short answer</span>
-            Open <strong>Dashboard ▸ Dictionary</strong>, add the names and jargon you say most, and turn <strong>AI cleanup</strong> on — the dictionary only applies during cleanup, so with it set to <em>None</em> your entries do nothing. Ten minutes now saves months of retyping the same three names.
+            Open <strong>Dashboard ▸ Personalize</strong>, add the names and jargon you say most, and turn <strong>AI cleanup</strong> on — the dictionary only applies during cleanup, so with it set to <em>None</em> your entries do nothing. Ten minutes now saves months of retyping the same three names.
           </div>
 
           <p>Every dictation tool eventually hits the same wall: it's fluent on ordinary prose and unreliable on the words that make your work yours — your name, your coworker's name, your product, the command you type fifty times a day. That's not a bug to route around with a bigger model. It's a gap only you can fill, and it takes about as long as reading this article.</p>
@@ -123,7 +123,7 @@
           <h2>Ten minutes, done properly</h2>
           <ol>
             <li><strong>List your top offenders.</strong> Don't try to be exhaustive on day one. Write down the five to ten words you've hand-corrected more than twice: your name if it's uncommon, your manager's, your product, your company, your most-used CLI tool.</li>
-            <li><strong>Add them under Dashboard ▸ Dictionary.</strong> Type each word the way it should be spelled and add it. There's no meaningful cap, but resist the urge to dump in a whole glossary — every entry is context the cleanup model has to weigh on every request, so a focused list actually performs better than a sprawling one.</li>
+            <li><strong>Add them under Dashboard ▸ Personalize.</strong> Type each word the way it should be spelled and add it. There's no meaningful cap, but resist the urge to dump in a whole glossary — every entry is context the cleanup model has to weigh on every request, so a focused list actually performs better than a sprawling one.</li>
             <li><strong>Add aliases for the specific, repeatable misses.</strong> If "kubectl" reliably comes back as "cube cuddle," attach that as an alias rather than hoping the base entry alone catches it.</li>
             <li><strong>Run the Know-Me interview if you haven't.</strong> It seeds names and technical terms you mention into the dictionary automatically, without overwriting anything you've added by hand — the fastest way to get a useful starting set beyond your manual list.</li>
             <li><strong>Dictate a real paragraph and check it.</strong> Not a test sentence — an actual message you'd send. Add whatever still trips it, and stop when nothing does.</li>

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -162,12 +162,18 @@
         <p>To clear it: <strong>Settings ▸ Privacy ▸ Delete history…</strong>, which offers <strong>Delete, keep my first words</strong> or <strong>Delete everything</strong>. The first option exists because people tend to want the memento even when clearing the log.</p>
 
         <h2 id="panes">The other panes</h2>
+        <p><strong>Personalize</strong> is one pane with three tabs — everything that teaches the app something once so it stops needing to be told again:</p>
         <table>
-          <thead><tr><th scope="col">Pane</th><th scope="col">What it is for</th></tr></thead>
+          <thead><tr><th scope="col">Tab</th><th scope="col">What it is for</th></tr></thead>
           <tbody>
             <tr><td><a href="dictionary.html">Dictionary</a></td><td>Words it keeps getting wrong. Fix them once.</td></tr>
             <tr><td><a href="snippets.html">Snippets</a></td><td>Say the short thing, get the long thing.</td></tr>
             <tr><td><a href="styles.html">Styles</a></td><td>How you sound, per app.</td></tr>
+          </tbody>
+        </table>
+        <table>
+          <thead><tr><th scope="col">Pane</th><th scope="col">What it is for</th></tr></thead>
+          <tbody>
             <tr><td><a href="profile.html">Know-Me</a></td><td>A short profile that helps cleanup spell your world correctly.</td></tr>
             <tr><td><a href="settings.html">Settings</a></td><td>Permissions, dictation, transcription, cleanup, privacy, and updates.</td></tr>
           </tbody>

--- a/docs/docs/dictionary.html
+++ b/docs/docs/dictionary.html
@@ -154,7 +154,7 @@
         </div>
 
         <h2 id="adding">Adding words</h2>
-        <p>Open <strong>Dashboard ▸ Dictionary</strong> and type the word as it should be spelled, then press add. Entries are stored immediately.</p>
+        <p>Open <strong>Dashboard ▸ Personalize</strong> and type the word as it should be spelled, then press add. Entries are stored immediately.</p>
         <p>Good candidates:</p>
         <ul>
           <li>Colleagues' and clients' names, especially non-English spellings.</li>

--- a/docs/docs/snippets.html
+++ b/docs/docs/snippets.html
@@ -153,7 +153,7 @@
         <p>Common uses: your email signature, your address, a standup preamble, a bug-report template, a legal disclaimer, a support reply you send daily.</p>
 
         <h2 id="creating">Creating one</h2>
-        <p><strong>Dashboard ▸ Snippets</strong> has two fields — trigger and expansion. Keep triggers short and distinctive: <code>my address</code>, <code>signature</code>, <code>standup intro</code>. Triggers are stored lowercase and matched case-insensitively, so you do not need to worry about how you capitalize them.</p>
+        <p>The Snippets tab in <strong>Dashboard ▸ Personalize</strong> has two fields — trigger and expansion. Keep triggers short and distinctive: <code>my address</code>, <code>signature</code>, <code>standup intro</code>. Triggers are stored lowercase and matched case-insensitively, so you do not need to worry about how you capitalize them.</p>
         <p>Adding a trigger that already exists replaces its expansion, which makes editing a snippet as simple as re-adding it.</p>
 
         <h2 id="matching">How matching works</h2>

--- a/docs/docs/styles.html
+++ b/docs/docs/styles.html
@@ -176,11 +176,11 @@
             <tr><td>Neutral</td><td>Microsoft Word, Pages, Notion, Safari, Google Chrome</td></tr>
           </tbody>
         </table>
-        <p>Dictate into an app that is not on this list and the fallback style applies. You can change the style assigned to any app already in the list from <strong>Dashboard ▸ Styles</strong>.</p>
+        <p>Dictate into an app that is not on this list and the fallback style applies. You can change the style assigned to any app already in the list from the Styles tab in <strong>Dashboard ▸ Personalize</strong>.</p>
 
         <div class="callout">
           <span class="callout-label">In this version</span>
-          <p>The Styles pane edits the mapping for apps already listed; there is no control for adding an app that is not on the list, so unlisted apps use the fallback. If per-app tone in a specific app matters to you, tell us at <a href="mailto:shimoverse@gmail.com">shimoverse@gmail.com</a> — that feedback is how the list grows.</p>
+          <p>The Styles tab edits the mapping for apps already listed; there is no control for adding an app that is not on the list, so unlisted apps use the fallback. If per-app tone in a specific app matters to you, tell us at <a href="mailto:shimoverse@gmail.com">shimoverse@gmail.com</a> — that feedback is how the list grows.</p>
         </div>
 
         <h2 id="storage">Where it is stored</h2>

--- a/docs/docs/uninstall.html
+++ b/docs/docs/uninstall.html
@@ -165,7 +165,7 @@
         </div>
 
         <h2 id="keep">Clearing your data but keeping the app</h2>
-        <p>You do not have to uninstall to reset. <strong>Dashboard ▸ Settings ▸ Delete history…</strong> clears your transcripts, with an option to keep your first-ever dictation. <strong>Know-Me ▸ Clear</strong> empties your profile. Dictionary and snippet entries can be deleted individually from their panes.</p>
+        <p>You do not have to uninstall to reset. <strong>Dashboard ▸ Settings ▸ Delete history…</strong> clears your transcripts, with an option to keep your first-ever dictation. <strong>Know-Me ▸ Clear</strong> empties your profile. Dictionary and snippet entries can be deleted individually from the Personalize pane.</p>
 
         <h2 id="reinstall">Reinstalling later</h2>
         <p>If you leave the Application Support folder in place, reinstalling picks up exactly where you left off — same settings, same history, same dictionary. Remove that folder first if you want a genuinely clean start.</p>

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -21,6 +21,7 @@ struct DashboardView: View {
     // background check finishes.
     @ObservedObject private var updater = UpdaterController.shared
     @State private var pane: Pane = .home
+    @State private var personalizeTab: PersonalizeTab = .dictionary
     @State private var showInterview = false
     @State private var showFeedback = false
     @State private var apiKeyDraft = ""       // mirrors the Keychain key for the selected backend
@@ -48,14 +49,32 @@ struct DashboardView: View {
     enum Pane: String, CaseIterable {
         case home = "Home"
         case history = "History"
-        case dictionary = "Dictionary"
-        case snippets = "Snippets"
-        case styles = "Styles"
+        /// Dictionary, Snippets, and Styles used to be three sidebar rows for
+        /// one job — teach the app something once. Now they're tabs inside
+        /// this single pane.
+        case personalize = "Personalize"
         case knowMe = "Know-Me"
         case settings = "Settings"
         /// Not in the main sidebar loop — it gets its own row below Feedback,
         /// same treatment as the Feedback button itself.
         case leaderboard = "Leaderboard"
+    }
+
+    /// The three destinations merged into the Personalize pane.
+    enum PersonalizeTab: String, CaseIterable, Identifiable, Hashable {
+        case dictionary = "Dictionary"
+        case snippets = "Snippets"
+        case styles = "Styles"
+
+        var id: String { rawValue }
+
+        var caption: String {
+            switch self {
+            case .dictionary: return "Words I keep getting wrong. Fix them once."
+            case .snippets: return "Say the short thing, get the long thing."
+            case .styles: return "How you sound, per app."
+            }
+        }
     }
 
     private var dark: Bool { scheme == .dark }
@@ -171,9 +190,7 @@ struct DashboardView: View {
                 switch pane {
                 case .home: home
                 case .history: historyPane
-                case .dictionary: dictionaryPane
-                case .snippets: snippetsPane
-                case .styles: styles
+                case .personalize: personalizePane
                 case .knowMe: knowMe
                 case .settings: settingsPane
                 case .leaderboard: leaderboardPane
@@ -680,104 +697,156 @@ struct DashboardView: View {
         }
     }
 
-    // MARK: Dictionary
+    // MARK: Personalize (Dictionary + Snippets + Styles)
+    //
+    // Three sidebar rows for one job — teach the app something once so it
+    // stops needing to be told again — read as three unrelated destinations.
+    // One pane, one set of tabs: switching between words, shortcuts, and
+    // tone now feels like turning a page, not leaving the topic.
 
-    @ViewBuilder private var dictionaryPane: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            paneTitle("Dictionary", "Words I keep getting wrong. Fix them once.")
-            addRow(placeholder: "Add a word (e.g. WhisperKit)") { dictionary.add(word: $0) }
-            if dictionary.entries.isEmpty {
-                emptyPanel(title: "No corrections yet",
-                           body: "Add a word above, or run the Know-Me interview to seed names and jargon automatically.",
-                           button: nil)
-            } else {
-                ForEach(dictionary.entries) { entry in
-                    HStack {
-                        Text(entry.word).font(.system(size: 13, weight: .semibold)).foregroundStyle(ink)
-                        if !entry.aliases.isEmpty {
-                            Text("↤ \(entry.aliases.joined(separator: ", "))")
-                                .font(.system(size: 11)).foregroundStyle(ink2)
-                        }
-                        Spacer()
-                        Button { dictionary.remove(entry) } label: {
-                            Image(systemName: "xmark.circle.fill").foregroundStyle(ink2)
-                        }.buttonStyle(.plain)
+    @ViewBuilder private var personalizePane: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            paneTitle("Personalize", personalizeTab.caption)
+            personalizeTabBar
+            personalizeCard
+        }
+    }
+
+    private var personalizeTabBar: some View {
+        HStack(spacing: 4) {
+            ForEach(PersonalizeTab.allCases) { tab in
+                Button {
+                    withAnimation(DT.snap) { personalizeTab = tab }
+                } label: {
+                    HStack(spacing: 6) {
+                        Text(tab.rawValue)
+                            .font(.system(size: 12.5, weight: personalizeTab == tab ? .semibold : .regular))
+                            .foregroundStyle(personalizeTab == tab ? ink : ink2)
+                        Text("\(personalizeCount(tab))")
+                            .font(.system(size: 10.5, weight: .bold))
+                            .foregroundStyle(personalizeTab == tab ? .white : ink2)
+                            .padding(.horizontal, 5.5).padding(.vertical, 1.5)
+                            .background(Capsule().fill(personalizeTab == tab ? DT.emberWave : fill))
                     }
-                    .padding(.vertical, 9)
-                    .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
+                    .padding(.vertical, 7).padding(.horizontal, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(personalizeTab == tab ? card : .clear)
+                    )
                 }
+                .buttonStyle(.plain)
+            }
+            Spacer()
+        }
+        .padding(4)
+        .background(RoundedRectangle(cornerRadius: 10).fill(fill))
+    }
+
+    private func personalizeCount(_ tab: PersonalizeTab) -> Int {
+        switch tab {
+        case .dictionary: return dictionary.entries.count
+        case .snippets: return snippets.snippets.count
+        case .styles: return styleStore.map.count
+        }
+    }
+
+    @ViewBuilder private var personalizeCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            switch personalizeTab {
+            case .dictionary: dictionarySection
+            case .snippets: snippetsSection
+            case .styles: stylesSection
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+        .id(personalizeTab)
+        .transition(.opacity)
+    }
+
+    @ViewBuilder private var dictionarySection: some View {
+        addRow(placeholder: "Add a word (e.g. WhisperKit)") { dictionary.add(word: $0) }
+        if dictionary.entries.isEmpty {
+            emptyPanel(title: "No corrections yet",
+                       body: "Add a word above, or run the Know-Me interview to seed names and jargon automatically.",
+                       button: nil)
+        } else {
+            ForEach(dictionary.entries) { entry in
+                HStack {
+                    Text(entry.word).font(.system(size: 13, weight: .semibold)).foregroundStyle(ink)
+                    if !entry.aliases.isEmpty {
+                        Text("↤ \(entry.aliases.joined(separator: ", "))")
+                            .font(.system(size: 11)).foregroundStyle(ink2)
+                    }
+                    Spacer()
+                    Button { dictionary.remove(entry) } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(ink2)
+                    }.buttonStyle(.plain)
+                }
+                .padding(.vertical, 9)
+                .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
             }
         }
     }
 
-    // MARK: Snippets
-
-    @ViewBuilder private var snippetsPane: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            paneTitle("Snippets", "Say the short thing, get the long thing.")
-            SnippetAddRow(fill: fill, ink: ink, ink2: ink2, accent: DT.emberLight) { trigger, expansion in
-                snippets.add(trigger: trigger, expansion: expansion)
-            }
-            if snippets.snippets.isEmpty {
-                emptyPanel(title: "No snippets yet",
-                           body: "Try \"my address\". Then just say it.",
-                           button: nil)
-            } else {
-                ForEach(snippets.snippets) { snip in
-                    HStack(alignment: .top, spacing: 12) {
-                        Text(snip.trigger).font(.system(size: 11, weight: .bold)).foregroundStyle(DT.emberLight)
-                            .padding(.horizontal, 6).padding(.vertical, 2)
-                            .background(RoundedRectangle(cornerRadius: 6).fill(fill))
-                        Text(snip.expansion).font(.system(size: 12.5)).foregroundStyle(ink)
-                        Spacer()
-                        Button { snippets.remove(snip) } label: {
-                            Image(systemName: "xmark.circle.fill").foregroundStyle(ink2)
-                        }.buttonStyle(.plain)
-                    }
-                    .padding(.vertical, 10)
-                    .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
+    @ViewBuilder private var snippetsSection: some View {
+        SnippetAddRow(fill: fill, ink: ink, ink2: ink2, accent: DT.emberLight) { trigger, expansion in
+            snippets.add(trigger: trigger, expansion: expansion)
+        }
+        if snippets.snippets.isEmpty {
+            emptyPanel(title: "No snippets yet",
+                       body: "Try \"my address\". Then just say it.",
+                       button: nil)
+        } else {
+            ForEach(snippets.snippets) { snip in
+                HStack(alignment: .top, spacing: 12) {
+                    Text(snip.trigger).font(.system(size: 11, weight: .bold)).foregroundStyle(DT.emberLight)
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(RoundedRectangle(cornerRadius: 6).fill(fill))
+                    Text(snip.expansion).font(.system(size: 12.5)).foregroundStyle(ink)
+                    Spacer()
+                    Button { snippets.remove(snip) } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(ink2)
+                    }.buttonStyle(.plain)
                 }
+                .padding(.vertical, 10)
+                .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
             }
         }
     }
 
-    /// A one-field add row used by the Dictionary pane.
+    /// A one-field add row used by the Dictionary tab.
     private func addRow(placeholder: String, onAdd: @escaping (String) -> Void) -> some View {
         InlineAddField(placeholder: placeholder, fill: fill, ink: ink, accent: DT.emberLight, onAdd: onAdd)
     }
 
-    // MARK: Styles
-
-    private var styles: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            paneTitle("Styles", "How you sound, per app.")
-                .padding(.bottom, 12)
-            ForEach(styleStore.map.sorted(by: { $0.key < $1.key }), id: \.key) { app, styleID in
-                HStack(spacing: 12) {
-                    Text(monogram(app))
-                        .font(.system(size: 11, weight: .bold)).foregroundStyle(ink2)
-                        .frame(width: 30, height: 30)
-                        .background(RoundedRectangle(cornerRadius: 7).fill(fill))
-                    Text(app).font(.system(size: 13, weight: .semibold)).foregroundStyle(ink)
-                        .frame(width: 150, alignment: .leading)
-                    Picker("", selection: styleBinding(for: app)) {
-                        Text("Casual").tag("casual")
-                        Text("Neutral").tag("default")
-                        Text("Formal").tag("formal")
-                        Text("Code").tag("code")
-                        Text("Email").tag("email")
-                    }
-                    .labelsHidden()
-                    .frame(width: 130)
-                    Spacer()
+    @ViewBuilder private var stylesSection: some View {
+        ForEach(styleStore.map.sorted(by: { $0.key < $1.key }), id: \.key) { app, styleID in
+            HStack(spacing: 12) {
+                Text(monogram(app))
+                    .font(.system(size: 11, weight: .bold)).foregroundStyle(ink2)
+                    .frame(width: 30, height: 30)
+                    .background(RoundedRectangle(cornerRadius: 7).fill(fill))
+                Text(app).font(.system(size: 13, weight: .semibold)).foregroundStyle(ink)
+                    .frame(width: 150, alignment: .leading)
+                Picker("", selection: styleBinding(for: app)) {
+                    Text("Casual").tag("casual")
+                    Text("Neutral").tag("default")
+                    Text("Formal").tag("formal")
+                    Text("Code").tag("code")
+                    Text("Email").tag("email")
                 }
-                .padding(.vertical, 11)
-                .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
+                .labelsHidden()
+                .frame(width: 130)
+                Spacer()
             }
-            Text("Cleanup uses the frontmost app's style automatically; the menu-bar Style is the fallback.")
-                .font(.system(size: 11)).foregroundStyle(ink2)
-                .padding(.top, 12)
+            .padding(.vertical, 11)
+            .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
         }
+        Text("Cleanup uses the frontmost app's style automatically; the menu-bar Style is the fallback.")
+            .font(.system(size: 11)).foregroundStyle(ink2)
+            .padding(.top, 12)
     }
 
     private func styleBinding(for app: String) -> Binding<String> {

--- a/scripts/docs_content.py
+++ b/scripts/docs_content.py
@@ -388,12 +388,18 @@ PAGES["dashboard"] = {
         <p>To clear it: <strong>Settings ▸ Privacy ▸ Delete history…</strong>, which offers <strong>Delete, keep my first words</strong> or <strong>Delete everything</strong>. The first option exists because people tend to want the memento even when clearing the log.</p>
 
         <h2 id="panes">The other panes</h2>
+        <p><strong>Personalize</strong> is one pane with three tabs — everything that teaches the app something once so it stops needing to be told again:</p>
         <table>
-          <thead><tr><th scope="col">Pane</th><th scope="col">What it is for</th></tr></thead>
+          <thead><tr><th scope="col">Tab</th><th scope="col">What it is for</th></tr></thead>
           <tbody>
             <tr><td><a href="dictionary.html">Dictionary</a></td><td>Words it keeps getting wrong. Fix them once.</td></tr>
             <tr><td><a href="snippets.html">Snippets</a></td><td>Say the short thing, get the long thing.</td></tr>
             <tr><td><a href="styles.html">Styles</a></td><td>How you sound, per app.</td></tr>
+          </tbody>
+        </table>
+        <table>
+          <thead><tr><th scope="col">Pane</th><th scope="col">What it is for</th></tr></thead>
+          <tbody>
             <tr><td><a href="profile.html">Know-Me</a></td><td>A short profile that helps cleanup spell your world correctly.</td></tr>
             <tr><td><a href="settings.html">Settings</a></td><td>Permissions, dictation, transcription, cleanup, privacy, and updates.</td></tr>
           </tbody>
@@ -660,7 +666,7 @@ PAGES["dictionary"] = {
         </div>
 
         <h2 id="adding">Adding words</h2>
-        <p>Open <strong>Dashboard ▸ Dictionary</strong> and type the word as it should be spelled, then press add. Entries are stored immediately.</p>
+        <p>Open <strong>Dashboard ▸ Personalize</strong> and type the word as it should be spelled, then press add. Entries are stored immediately.</p>
         <p>Good candidates:</p>
         <ul>
           <li>Colleagues' and clients' names, especially non-English spellings.</li>
@@ -696,7 +702,7 @@ PAGES["snippets"] = {
         <p>Common uses: your email signature, your address, a standup preamble, a bug-report template, a legal disclaimer, a support reply you send daily.</p>
 
         <h2 id="creating">Creating one</h2>
-        <p><strong>Dashboard ▸ Snippets</strong> has two fields — trigger and expansion. Keep triggers short and distinctive: <code>my address</code>, <code>signature</code>, <code>standup intro</code>. Triggers are stored lowercase and matched case-insensitively, so you do not need to worry about how you capitalize them.</p>
+        <p>The Snippets tab in <strong>Dashboard ▸ Personalize</strong> has two fields — trigger and expansion. Keep triggers short and distinctive: <code>my address</code>, <code>signature</code>, <code>standup intro</code>. Triggers are stored lowercase and matched case-insensitively, so you do not need to worry about how you capitalize them.</p>
         <p>Adding a trigger that already exists replaces its expansion, which makes editing a snippet as simple as re-adding it.</p>
 
         <h2 id="matching">How matching works</h2>
@@ -760,11 +766,11 @@ PAGES["styles"] = {
             <tr><td>Neutral</td><td>Microsoft Word, Pages, Notion, Safari, Google Chrome</td></tr>
           </tbody>
         </table>
-        <p>Dictate into an app that is not on this list and the fallback style applies. You can change the style assigned to any app already in the list from <strong>Dashboard ▸ Styles</strong>.</p>
+        <p>Dictate into an app that is not on this list and the fallback style applies. You can change the style assigned to any app already in the list from the Styles tab in <strong>Dashboard ▸ Personalize</strong>.</p>
 
         <div class="callout">
           <span class="callout-label">In this version</span>
-          <p>The Styles pane edits the mapping for apps already listed; there is no control for adding an app that is not on the list, so unlisted apps use the fallback. If per-app tone in a specific app matters to you, tell us at <a href="mailto:shimoverse@gmail.com">shimoverse@gmail.com</a> — that feedback is how the list grows.</p>
+          <p>The Styles tab edits the mapping for apps already listed; there is no control for adding an app that is not on the list, so unlisted apps use the fallback. If per-app tone in a specific app matters to you, tell us at <a href="mailto:shimoverse@gmail.com">shimoverse@gmail.com</a> — that feedback is how the list grows.</p>
         </div>
 
         <h2 id="storage">Where it is stored</h2>
@@ -1143,7 +1149,7 @@ PAGES["uninstall"] = {
         </div>
 
         <h2 id="keep">Clearing your data but keeping the app</h2>
-        <p>You do not have to uninstall to reset. <strong>Dashboard ▸ Settings ▸ Delete history…</strong> clears your transcripts, with an option to keep your first-ever dictation. <strong>Know-Me ▸ Clear</strong> empties your profile. Dictionary and snippet entries can be deleted individually from their panes.</p>
+        <p>You do not have to uninstall to reset. <strong>Dashboard ▸ Settings ▸ Delete history…</strong> clears your transcripts, with an option to keep your first-ever dictation. <strong>Know-Me ▸ Clear</strong> empties your profile. Dictionary and snippet entries can be deleted individually from the Personalize pane.</p>
 
         <h2 id="reinstall">Reinstalling later</h2>
         <p>If you leave the Application Support folder in place, reinstalling picks up exactly where you left off — same settings, same history, same dictionary. Remove that folder first if you want a genuinely clean start.</p>


### PR DESCRIPTION
## What this changes (for the user)

Dictionary, Snippets, and Styles were three separate sidebar rows that all did the same underlying job — teach the app something once so it stops needing to be told again. They're now **one "Personalize" pane** with a segmented tab bar (`Dictionary` · `Snippets` · `Styles`), each tab showing a live item count.

- Sidebar shrinks from 7 rows to 5 — `Home`, `History`, `Personalize`, `Know-Me`, `Settings` (+ `Leaderboard` below Feedback, unchanged).
- The pane title's subtitle now changes with the active tab (e.g. "Words I keep getting wrong. Fix them once." for Dictionary), so it still reads as a purposeful destination, not a generic wrapper.
- Content now sits inside one shared card surface (matching the visual weight of the Home/Know-Me cards) instead of floating directly on the window background, and switching tabs animates instead of jumping.
- Every existing behavior is untouched: same `DictionaryStore` / `SnippetStore` / `StyleStore`, same add/remove actions, same empty states, same styling per row. This is purely a navigation/layout merge — no data model or persistence changes.

Docs updated to match: `Dashboard ▸ Dictionary` / `▸ Snippets` / `▸ Styles` become `Dashboard ▸ Personalize` (with the specific tab named where it matters), across `docs_content.py` (regenerated into `docs/docs/*.html`) and the one static blog post that referenced the old path. `CHANGELOG.md` gets an `[Unreleased] ▸ Changed` entry; no version bump, per `AGENTS.md`.

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes
- [x] No version bumps or new dependencies

This session runs on Linux with no Xcode/macOS, so the Swift change is **compile-verified by inspection only** here — I reused the file's existing SwiftUI patterns (design tokens, card chrome, pill/badge styling) verbatim rather than inventing new ones, and traced every `Pane` reference across `native/` to confirm nothing else pointed at the removed `.dictionary` / `.snippets` / `.styles` cases. CI's `native-build` job (`macos-15`) will give the real compile signal, and a screenshot isn't something I can produce without a Mac — flagging that per `AGENTS.md`'s "say plainly what was compile-verified vs. device-verified."

For the website side, `python3 scripts/build_docs.py` was run to regenerate `docs/docs/*.html` from the updated `docs_content.py`, and the full suite passes locally:

```
python3 -m pytest -q
# 262 passed, 1 skipped in 1.18s
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01RAbxndU1PjzyyDPBeeMKLS)_