### PR TITLE
Add a privacy subtitle to the History pane

### DIFF
--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -559,7 +559,7 @@ struct DashboardView: View {
 
     @ViewBuilder private var historyPane: some View {
         VStack(alignment: .leading, spacing: 14) {
-            paneTitle("History", "Stored here, and only here — never synced, never seen by anyone else.")
+            paneTitle("History", "Stored only on this Mac — never synced to a server.")
             if history.entries.isEmpty {
                 emptyPanel(
                     title: "Nothing yet.",

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -559,7 +559,7 @@ struct DashboardView: View {
 
     @ViewBuilder private var historyPane: some View {
         VStack(alignment: .leading, spacing: 14) {
-            paneTitle("History")
+            paneTitle("History", "Stored here, and only here — never synced, never seen by anyone else.")
             if history.entries.isEmpty {
                 emptyPanel(
                     title: "Nothing yet.",


### PR DESCRIPTION
## What this changes (for the user)

Adds a subtitle under "History" (same pattern every other pane uses, e.g. Dictionary's "Words I keep getting wrong. Fix them once."): **"Stored here, and only here — never synced, never seen by anyone else."**

Worded deliberately around what's true unconditionally, not "nothing leaves this machine" — with cloud AI cleanup on (opt-in, off by default), the dictated text does go to whichever provider is selected before landing here, and that's already covered by the existing footer line ("Raw audio is discarded after transcription...") and the privacy docs. This subtitle is about what this specific list does: it's local storage, never synced or uploaded as a dataset, regardless of cleanup settings.

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python) — pending; no Swift/AppKit toolchain in this session to compile locally.
- [ ] Screenshot or recording — not available, no macOS environment in this session.
- [x] No version bumps or new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_011HCGgvR3e4YGBr4Kt5nN3N)_