### PR TITLE
chore: bump native app to 0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10] — 2026-08-29
+
 ### Changed
 - Dictionary, Snippets, and Styles are now one **Personalize** pane in the
   dashboard sidebar, switched with tabs instead of three separate rows.

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.9</string>
-    <key>CFBundleVersion</key><string>14</string>
+    <key>CFBundleShortVersionString</key><string>0.5.10</string>
+    <key>CFBundleVersion</key><string>15</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.9
-        CURRENT_PROJECT_VERSION: 14
+        MARKETING_VERSION: 0.5.10
+        CURRENT_PROJECT_VERSION: 15
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

Prepares the release that includes the Personalize pane merge (#98): Dictionary, Snippets, and Styles combined into one tabbed pane in the dashboard.

Bumps all four version fields together, per `RELEASE.md`:
- `native/project.yml`: `MARKETING_VERSION` 0.5.9 → 0.5.10, `CURRENT_PROJECT_VERSION` 14 → 15
- `native/Info.plist`: `CFBundleShortVersionString` 0.5.9 → 0.5.10, `CFBundleVersion` 14 → 15

`CHANGELOG.md`'s `[Unreleased]` section (the #98 entry) becomes `## [0.5.10] — 2026-08-29`, matching the exact pattern of prior bump commits (e.g. #94, #97).

This PR only does step 1 of `RELEASE.md`'s release process ("Bump all four fields on a branch; PR; merge on green CI"). Tagging, building, signing, notarizing, and publishing (steps 2–5) need the Apple signing secrets and `SPARKLE_ED_PRIVATE_KEY`, which aren't available in this session — those steps need a maintainer to dispatch the **Create release tag** and **Release (native app)** workflows.

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes
- [x] No new dependencies

No UI change here, so no screenshot applies. Verified locally:

```
python3 -m pytest -q
# 262 passed, 1 skipped in 0.98s
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAbxndU1PjzyyDPBeeMKLS)_