### PR TITLE
Show real app icons with a time-share ring in "Where you dictate"

### DIFF
--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1CFD6F2CDE3892A1A5D8036F /* HotkeyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52E97784B7D61DB0DA2B3E /* HotkeyEngine.swift */; };
+		E2D8D98E3249EC25B29F5A86 /* AppIconProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BE137CDD498B29369B9D4E /* AppIconProvider.swift */; };
 		21718FD49AAD5FFDCB42DF41 /* KnowMeInterview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE7EF596B3AEE5F057EACCD /* KnowMeInterview.swift */; };
 		2976A8647F7E72B7567DFD8F /* AudioCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1DCFDCDBB87F1BAA548B04 /* AudioCapture.swift */; };
 		2BECEA0193E7CFDB54AFEC47 /* FeatureStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C990C954D554F3DB4F1C0F /* FeatureStores.swift */; };
@@ -31,6 +32,7 @@
 
 /* Begin PBXFileReference section */
 		1AEE4987BADD8952A8D2BD91 /* AppController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppController.swift; sourceTree = "<group>"; };
+		61BE137CDD498B29369B9D4E /* AppIconProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconProvider.swift; sourceTree = "<group>"; };
 		2B693C11C689950AA094C951 /* HUDController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDController.swift; sourceTree = "<group>"; };
 		2BF148CC7407807156F032DE /* Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Permissions.swift; sourceTree = "<group>"; };
 		34D72CC634525CAF888070FE /* Paster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paster.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				1AEE4987BADD8952A8D2BD91 /* AppController.swift */,
+				61BE137CDD498B29369B9D4E /* AppIconProvider.swift */,
 				3F1DCFDCDBB87F1BAA548B04 /* AudioCapture.swift */,
 				DC8FA7D7EC4D4436012C04C2 /* CleanupProvider.swift */,
 				9BCE6187B5EB8E49A290CC73 /* DashboardView.swift */,
@@ -196,6 +199,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFC25E3AEBF348F41F0EEC56 /* AppController.swift in Sources */,
+				E2D8D98E3249EC25B29F5A86 /* AppIconProvider.swift in Sources */,
 				2976A8647F7E72B7567DFD8F /* AudioCapture.swift in Sources */,
 				E7D6DB42A76697F5E75E3FD9 /* CleanupProvider.swift in Sources */,
 				8D95E21B1C470A7D28C9D177 /* DashboardView.swift in Sources */,

--- a/native/Sources/OpenVoiceFlow/AppIconProvider.swift
+++ b/native/Sources/OpenVoiceFlow/AppIconProvider.swift
@@ -1,0 +1,51 @@
+import AppKit
+
+/// Resolves the real macOS icon for an app the user has dictated into, keyed
+/// by display name — the only identifier `HistoryStore` tracks (see
+/// `HistoryEntry.app`, captured from `NSWorkspace.frontmostApplication`).
+///
+/// Deliberately does *not* ship any bundled logo assets: a fixed icon set
+/// would only cover a handful of apps, needs upkeep as logos change, and
+/// means redistributing third-party trademarks. Asking macOS for the icon
+/// it already has on disk covers every app a user could possibly dictate
+/// into, with zero maintenance.
+@MainActor
+enum AppIconProvider {
+    private static var cache: [String: NSImage?] = [:]
+
+    /// The running-or-installed app's own icon, or nil if nothing on this
+    /// Mac matches `name` (uninstalled since, or the name isn't really an
+    /// app — e.g. a browser tab title). Callers fall back to a monogram,
+    /// same as the Styles pane already does for apps with no icon.
+    static func icon(for name: String) -> NSImage? {
+        if let cached = cache[name] { return cached }
+        let resolved = runningAppIcon(named: name) ?? installedAppIcon(named: name)
+        cache[name] = resolved
+        return resolved
+    }
+
+    /// Cheapest path: the app is (or recently was) running, so AppKit
+    /// already has its icon loaded — no disk lookup at all.
+    private static func runningAppIcon(named name: String) -> NSImage? {
+        NSWorkspace.shared.runningApplications
+            .first { $0.localizedName == name }?
+            .icon
+    }
+
+    /// Fallback for an app that appears in history but isn't running right
+    /// now. `fullPath(forApplication:)` is deprecated in favor of bundle-ID
+    /// lookups, but we only ever have a display name to go on, and it's
+    /// still the one Launch Services API that resolves one — so it stays,
+    /// synchronous and cached, rather than reaching for an async Spotlight
+    /// query for a nice-to-have icon.
+    private static func installedAppIcon(named name: String) -> NSImage? {
+        guard let path = NSWorkspace.shared.fullPath(forApplication: name) else { return nil }
+        return NSWorkspace.shared.icon(forFile: path)
+    }
+
+    /// Shared with the Styles pane's per-app row, which shows the same
+    /// letter fallback when there's no icon to draw.
+    static func monogram(_ name: String) -> String {
+        String(name.split(separator: " ").prefix(2).compactMap { $0.first }).uppercased()
+    }
+}

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -409,16 +409,21 @@ struct DashboardView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 5))
                 .padding(.top, 14)
 
-                VStack(spacing: 9) {
+                VStack(spacing: 12) {
                     ForEach(Array(top.enumerated()), id: \.offset) { i, row in
-                        HStack(spacing: 8) {
-                            Circle().fill(DT.emberWave.opacity(1 - Double(i) * 0.13))
-                                .frame(width: 7, height: 7)
+                        HStack(spacing: 10) {
+                            AppTimeIcon(
+                                name: row.app, fraction: row.fraction,
+                                ringColor: DT.emberWave.opacity(1 - Double(i) * 0.13),
+                                trackColor: hair, ink2: ink2
+                            )
                             Text(row.app).font(.system(size: 12.5)).foregroundStyle(ink).lineLimit(1)
                             Spacer()
                             Text("\(Int((row.fraction * 100).rounded()))%")
                                 .font(.system(size: 12.5, weight: .semibold)).foregroundStyle(ink)
                         }
+                        .help("\(row.app) — \(Int((row.fraction * 100).rounded()))% of your dictation, "
+                              + "≈\(HistoryStore.minutes(fromWords: row.words))m of typing given back")
                     }
                 }
                 .padding(.top, 14)
@@ -754,7 +759,7 @@ struct DashboardView: View {
                 .padding(.bottom, 12)
             ForEach(styleStore.map.sorted(by: { $0.key < $1.key }), id: \.key) { app, styleID in
                 HStack(spacing: 12) {
-                    Text(monogram(app))
+                    Text(AppIconProvider.monogram(app))
                         .font(.system(size: 11, weight: .bold)).foregroundStyle(ink2)
                         .frame(width: 30, height: 30)
                         .background(RoundedRectangle(cornerRadius: 7).fill(fill))
@@ -783,10 +788,6 @@ struct DashboardView: View {
     private func styleBinding(for app: String) -> Binding<String> {
         Binding(get: { styleStore.map[app] ?? "default" },
                 set: { styleStore.map[app] = $0 })
-    }
-
-    private func monogram(_ app: String) -> String {
-        String(app.split(separator: " ").prefix(2).compactMap { $0.first }).uppercased()
     }
 
     // MARK: Know-Me
@@ -1405,5 +1406,46 @@ private struct SnippetAddRow: View {
         guard !t.isEmpty, !e.isEmpty else { return }
         onAdd(t, e)
         trigger = ""; expansion = ""
+    }
+}
+
+/// One "Where you dictate" row's leading icon: the app's real macOS icon,
+/// ringed like an activity ring whose fill is that app's share of total
+/// dictation time — readable at a glance, no percentage needed to parse it.
+/// Falls back to the same letter monogram the Styles pane uses when macOS
+/// has no icon for the name.
+private struct AppTimeIcon: View {
+    let name: String
+    let fraction: Double
+    let ringColor: Color
+    let trackColor: Color
+    let ink2: Color
+    var diameter: CGFloat = 24
+
+    private var lineWidth: CGFloat { 2 }
+
+    var body: some View {
+        ZStack {
+            Circle().stroke(trackColor, lineWidth: lineWidth)
+            Circle()
+                .trim(from: 0, to: max(fraction, 0.03))
+                .stroke(ringColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            icon
+                .frame(width: diameter - lineWidth * 3, height: diameter - lineWidth * 3)
+                .clipShape(Circle())
+        }
+        .frame(width: diameter, height: diameter)
+    }
+
+    @ViewBuilder private var icon: some View {
+        if let nsImage = AppIconProvider.icon(for: name) {
+            Image(nsImage: nsImage).resizable().scaledToFit()
+        } else {
+            Circle().fill(ink2.opacity(0.12)).overlay(
+                Text(AppIconProvider.monogram(name))
+                    .font(.system(size: 8, weight: .bold)).foregroundStyle(ink2)
+            )
+        }
     }
 }


### PR DESCRIPTION
## What this changes (for the user)

The dashboard's "Where you dictate" card used a flat-opacity colored dot per app instead of anything identifiable. This replaces each dot with:

- **The app's real macOS icon** — resolved dynamically at runtime via `NSWorkspace` from the app's display name (the same name `HistoryStore` already tracks). No logos are bundled: this works for any app the user dictates into (Slack, Notion, WhatsApp, Zoom, …), not just a hardcoded list, and avoids shipping third-party trademarked assets. Falls back to the same letter monogram the Styles pane already uses when macOS has no icon for a name.
- **An activity-ring-style progress ring** around the icon, filled to that app's share of total dictation time — readable at a glance, no percentage text required.
- **A hover tooltip** with the exact share and minutes of typing that app has saved (`HistoryStore.minutes(fromWords:)`, same 40 wpm figure used everywhere else in the app).

New file: `native/Sources/OpenVoiceFlow/AppIconProvider.swift` (icon resolution + caching, plus the shared `monogram` helper the Styles pane now also calls). `DashboardView.swift`'s `whereYouDictateCard` row and a new `AppTimeIcon` view wire it together. `project.pbxproj` updated to include the new file (the SwiftPM `Package.swift` target already auto-discovers it).

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes — **not done**: this session has no macOS/Xcode available to build or run the app, so the change is unverified visually. Please sanity-check the ring/icon rendering in Xcode before merging.
- [x] No version bumps or new dependencies


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5T3Njk11jHoDWmcJwy2ip)_