### PR TITLE
chore: bump native app to 0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.11] — 2026-08-29
+
+### Changed
+- The History pane now carries a subtitle: "Stored only on this Mac —
+  never synced to a server." Scoped deliberately to what's true
+  unconditionally (this list is local storage, full stop) rather than a
+  blanket "nothing leaves this machine" claim, since cloud AI cleanup
+  (opt-in, off by default) does send dictated text to the selected
+  provider before it lands here — that's covered separately by the
+  existing footer line and the privacy docs.
+
 ## [0.5.10] — 2026-08-29
 
 ### Changed

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.10</string>
-    <key>CFBundleVersion</key><string>15</string>
+    <key>CFBundleShortVersionString</key><string>0.5.11</string>
+    <key>CFBundleVersion</key><string>16</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.10
-        CURRENT_PROJECT_VERSION: 15
+        MARKETING_VERSION: 0.5.11
+        CURRENT_PROJECT_VERSION: 16
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

Version bump only: `MARKETING_VERSION`/`CFBundleShortVersionString` 0.5.10 → 0.5.11, build 15 → 16, and a CHANGELOG entry for what's shipping — the History pane privacy subtitle in #99.

- `native/Info.plist`
- `native/project.yml`
- `CHANGELOG.md`

## How it was verified

- [x] No version bumps or new dependencies — N/A, this PR *is* the version bump.
- [ ] CI green — pending, no source code touched here.
- [ ] Screenshot — N/A, no UI change.

This does not create the release tag or trigger the signed/notarized build.


---
_Generated by [Claude Code](https://claude.ai/code/session_011HCGgvR3e4YGBr4Kt5nN3N)_