### PR TITLE
chore: bump native app to 0.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12] — 2026-08-29
+
+### Changed
+- “Where you dictate” now shows each app’s real icon with a time-share ring,
+  making the per-app breakdown easier to scan while preserving the existing
+  local-only usage data and accessibility labels.
+
 ## [0.5.11] — 2026-08-29
 
 ### Changed

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.11</string>
-    <key>CFBundleVersion</key><string>16</string>
+    <key>CFBundleShortVersionString</key><string>0.5.12</string>
+    <key>CFBundleVersion</key><string>17</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.11
-        CURRENT_PROJECT_VERSION: 16
+        MARKETING_VERSION: 0.5.12
+        CURRENT_PROJECT_VERSION: 17
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## Summary
- bump the native marketing version to 0.5.12
- increment the Sparkle build from 16 to 17
- document the app-icon time-share-ring change

## Test plan
- [x] `ruff check .`
- [x] `pytest -q` (263 passed)
- [x] `xcodegen generate` + unsigned universal `xcodebuild` (Debug)
- [x] four-field version consistency and build > live appcast build 13