### PR TITLE
Simplify usage copy in Feedback and Settings

### DIFF
--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -1027,11 +1027,6 @@ struct DashboardView: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
                     }
-                    settingsRow("Device ID") {
-                        Text(analyticsIdentity.identity.deviceId)
-                            .font(.system(size: 11, design: .monospaced)).foregroundStyle(ink2)
-                            .textSelection(.enabled)
-                    }
                     settingsRow("Delete my leaderboard data") {
                         Button("Delete…") {
                             Task { await analyticsClient.deleteMyData(deviceId: analyticsIdentity.identity.deviceId) }
@@ -1039,13 +1034,6 @@ struct DashboardView: View {
                         .buttonStyle(.plain).font(.system(size: 12)).foregroundStyle(DT.destructive)
                     }
                 }
-                Text("Sends word/time totals, which features you use, and a display "
-                     + "name you can change — never dictation text, snippets, dictionary, "
-                     + "or your Know-Me profile. Powers the Leaderboard pane. Off stops it entirely; "
-                     + "your device ID above is how to ask us to delete a past submission.")
-                    .font(.system(size: 11)).foregroundStyle(ink2)
-                    .padding(.horizontal, 16).padding(.bottom, 8)
-                    .fixedSize(horizontal: false, vertical: true)
                 settingsToggle("Automatic updates", isOn: autoUpdateBinding)
                 settingsRow("You're on v\(updater.appVersion)") {
                     Button("Check for updates now") { updater.checkForUpdates() }

--- a/native/Sources/OpenVoiceFlow/FeedbackView.swift
+++ b/native/Sources/OpenVoiceFlow/FeedbackView.swift
@@ -87,12 +87,6 @@ struct FeedbackView: View {
                     .font(.system(size: 13))
             }
 
-            Text("This opens an email with usage totals attached — words dictated, time saved, "
-                 + "your streak, and this week's activity. Never the words themselves, and nothing "
-                 + "is sent unless you hit Send.")
-                .font(.system(size: 11)).foregroundStyle(ink2)
-                .fixedSize(horizontal: false, vertical: true)
-
             Spacer(minLength: 0)
 
             HStack {


### PR DESCRIPTION
## Summary
- remove the explanatory usage-totals paragraph from the Feedback sheet
- hide the raw device ID from Settings
- remove the long analytics explainer from Settings while preserving the sharing toggle, leaderboard name, and delete-data action

## Verification
- `python3 -m pytest -q` — 262 passed, 1 skipped
- regenerated the Xcode project with XcodeGen and completed an unsigned native Debug build with `xcodebuild`
- confirmed the removed Settings labels/copy no longer exist in `DashboardView.swift`

## Scope
- analytics behavior and the server-side device identity are unchanged; this is a UI simplification only