### PR TITLE
Release native app 0.5.13

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.12</string>
-    <key>CFBundleVersion</key><string>17</string>
+    <key>CFBundleShortVersionString</key><string>0.5.13</string>
+    <key>CFBundleVersion</key><string>18</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.12
-        CURRENT_PROJECT_VERSION: 17
+        MARKETING_VERSION: 0.5.13
+        CURRENT_PROJECT_VERSION: 18
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## Summary

- bump native marketing version from 0.5.12 to 0.5.13
- increment Sparkle build number from 17 to 18
- keep all four release version fields aligned

## Verification

- `python3 -m pytest -q` — 273 passed, 1 optional dependency skip
- `npm run vercel-build`
- unsigned local Release build succeeded after `xcodegen generate`
- built app reports version 0.5.13, build 18
- built binary is universal: x86_64 + arm64
- `git diff --check`