### PR TITLE
Refine feedback and personalization UX

### DIFF
--- a/native/Sources/OpenVoiceFlow/AnalyticsStore.swift
+++ b/native/Sources/OpenVoiceFlow/AnalyticsStore.swift
@@ -23,25 +23,24 @@ final class AnalyticsIdentityStore: ObservableObject {
     @Published var identity: AnalyticsIdentity { didSet { AppSupport.save(identity, to: "analytics_identity.json") } }
 
     init() {
-        identity = AppSupport.load(AnalyticsIdentity.self, from: "analytics_identity.json")
-            ?? AnalyticsIdentityStore.makeIdentity()
+        if var saved = AppSupport.load(AnalyticsIdentity.self, from: "analytics_identity.json") {
+            let compactName = LeaderboardAlias.compactLegacyDefault(saved.displayName)
+            if compactName != saved.displayName {
+                saved.displayName = compactName
+                AppSupport.save(saved, to: "analytics_identity.json")
+            }
+            identity = saved
+        } else {
+            identity = AnalyticsIdentityStore.makeIdentity()
+        }
     }
 
     private static func makeIdentity() -> AnalyticsIdentity {
-        AnalyticsIdentity(deviceId: UUID().uuidString, displayName: randomDisplayName())
+        AnalyticsIdentity(deviceId: UUID().uuidString, displayName: LeaderboardAlias.random())
     }
 
-    private static let adjectives = [
-        "Quiet", "Swift", "Calm", "Bright", "Steady", "Clever", "Brisk", "Gentle",
-        "Sunny", "Nimble", "Bold", "Sharp", "Warm", "Cool", "Vivid", "Keen",
-    ]
-    private static let nouns = [
-        "Falcon", "Otter", "Maple", "Comet", "Harbor", "Ember", "Willow", "Lynx",
-        "Meadow", "Aspen", "Heron", "Cedar", "Ridge", "Sparrow", "Tundra", "Coral",
-    ]
-
     static func randomDisplayName() -> String {
-        "\(adjectives.randomElement()!) \(nouns.randomElement()!) \(Int.random(in: 10...99))"
+        LeaderboardAlias.random()
     }
 }
 

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -53,18 +53,18 @@ struct DashboardView: View {
         /// one job — teach the app something once. Now they're tabs inside
         /// this single pane.
         case personalize = "Personalize"
-        case knowMe = "Know-Me"
         case settings = "Settings"
         /// Not in the main sidebar loop — it gets its own row below Feedback,
         /// same treatment as the Feedback button itself.
         case leaderboard = "Leaderboard"
     }
 
-    /// The three destinations merged into the Personalize pane.
+    /// The destinations merged into the Personalize pane.
     enum PersonalizeTab: String, CaseIterable, Identifiable, Hashable {
         case dictionary = "Dictionary"
         case snippets = "Snippets"
         case styles = "Styles"
+        case knowMe = "Know Me"
 
         var id: String { rawValue }
 
@@ -73,6 +73,7 @@ struct DashboardView: View {
             case .dictionary: return "Words I keep getting wrong. Fix them once."
             case .snippets: return "Say the short thing, get the long thing."
             case .styles: return "How you sound, per app."
+            case .knowMe: return "Teach cleanup your names, jargon, and voice."
             }
         }
     }
@@ -144,6 +145,9 @@ struct DashboardView: View {
                 .padding(.horizontal, 10)
             }
             .buttonStyle(.plain)
+            .popover(isPresented: $showFeedback) {
+                FeedbackView(controller: controller, onDismiss: { showFeedback = false })
+            }
 
             Button { pane = .leaderboard } label: {
                 HStack(spacing: 8) {
@@ -191,7 +195,6 @@ struct DashboardView: View {
                 case .home: home
                 case .history: historyPane
                 case .personalize: personalizePane
-                case .knowMe: knowMe
                 case .settings: settingsPane
                 case .leaderboard: leaderboardPane
                 }
@@ -200,9 +203,6 @@ struct DashboardView: View {
         }
         .sheet(isPresented: $showInterview) {
             KnowMeInterview(controller: controller)
-        }
-        .sheet(isPresented: $showFeedback) {
-            FeedbackView(controller: controller)
         }
         // The first-words card is the one thing a user is likely to miss, so it
         // is a separate, explicit choice rather than collateral damage.
@@ -702,12 +702,10 @@ struct DashboardView: View {
         }
     }
 
-    // MARK: Personalize (Dictionary + Snippets + Styles)
+    // MARK: Personalize (Dictionary + Snippets + Styles + Know Me)
     //
-    // Three sidebar rows for one job — teach the app something once so it
-    // stops needing to be told again — read as three unrelated destinations.
-    // One pane, one set of tabs: switching between words, shortcuts, and
-    // tone now feels like turning a page, not leaving the topic.
+    // Dictionary, snippets, styles, and Know Me all teach the app something
+    // once. One pane keeps them together as facets of the same job.
 
     @ViewBuilder private var personalizePane: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -752,6 +750,7 @@ struct DashboardView: View {
         case .dictionary: return dictionary.entries.count
         case .snippets: return snippets.snippets.count
         case .styles: return styleStore.map.count
+        case .knowMe: return profileStore.hasProfile ? 1 : 0
         }
     }
 
@@ -761,6 +760,7 @@ struct DashboardView: View {
             case .dictionary: dictionarySection
             case .snippets: snippetsSection
             case .styles: stylesSection
+            case .knowMe: knowMe
             }
         }
         .padding(18)
@@ -863,7 +863,6 @@ struct DashboardView: View {
 
     private var knowMe: some View {
         VStack(alignment: .leading, spacing: 18) {
-            paneTitle("Know-Me", "Two minutes, and your name comes out right every time.")
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 280), spacing: 14)], spacing: 14) {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Profile").font(.system(size: 13, weight: .bold)).foregroundStyle(ink)

--- a/native/Sources/OpenVoiceFlow/FeedbackView.swift
+++ b/native/Sources/OpenVoiceFlow/FeedbackView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// Know-Me profile — only counters already shown on the dashboard.
 struct FeedbackView: View {
     @ObservedObject var controller: AppController
-    @Environment(\.dismiss) private var dismiss
+    let onDismiss: () -> Void
     @Environment(\.colorScheme) private var scheme
 
     enum Category: String, CaseIterable, Identifiable {
@@ -40,7 +40,6 @@ struct FeedbackView: View {
 
     @State private var category: Category = .idea
     @State private var message = ""
-    @State private var includeContact = false
     @State private var contact = ""
 
     private var dark: Bool { scheme == .dark }
@@ -55,7 +54,7 @@ struct FeedbackView: View {
             HStack {
                 Text("Send feedback").font(.system(size: 20, weight: .bold)).foregroundStyle(ink)
                 Spacer()
-                Button("Cancel") { dismiss() }.buttonStyle(.plain).foregroundStyle(ink2)
+                Button("Cancel") { onDismiss() }.buttonStyle(.plain).foregroundStyle(ink2)
             }
 
             Picker("", selection: $category) {
@@ -78,14 +77,9 @@ struct FeedbackView: View {
                     }
                 }
 
-            Toggle("Include my email so you can follow up", isOn: $includeContact)
-                .toggleStyle(.switch).tint(DT.moss)
-                .font(.system(size: 12.5)).foregroundStyle(ink)
-            if includeContact {
-                TextField("you@example.com", text: $contact)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(size: 13))
-            }
+            TextField("Email (optional)", text: $contact)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 13))
 
             Spacer(minLength: 0)
 
@@ -97,14 +91,14 @@ struct FeedbackView: View {
             }
         }
         .padding(24)
-        .frame(width: 480, height: 420)
+        .frame(width: 480, height: 380)
     }
 
     private func send() {
         let body = Self.emailBody(
             category: category.rawValue,
             message: message.trimmingCharacters(in: .whitespacesAndNewlines),
-            contact: includeContact ? contact.trimmingCharacters(in: .whitespaces) : nil,
+            contact: contact.trimmingCharacters(in: .whitespacesAndNewlines),
             snapshot: UsageSnapshot(controller: controller)
         )
         var components = URLComponents()
@@ -117,7 +111,7 @@ struct FeedbackView: View {
         if let url = components.url {
             NSWorkspace.shared.open(url)
         }
-        dismiss()
+        onDismiss()
     }
 
     static func emailBody(category: String, message: String, contact: String?, snapshot: UsageSnapshot) -> String {

--- a/native/Sources/OpenVoiceFlow/LeaderboardAlias.swift
+++ b/native/Sources/OpenVoiceFlow/LeaderboardAlias.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A readable, anonymous leaderboard alias. Generated aliases are one token
+/// so they scan like handles rather than accidental first-and-last names.
+enum LeaderboardAlias {
+    private static let adjectives = [
+        "Quiet", "Swift", "Calm", "Bright", "Steady", "Clever", "Brisk", "Gentle",
+        "Sunny", "Nimble", "Bold", "Sharp", "Warm", "Cool", "Vivid", "Keen",
+    ]
+    private static let nouns = [
+        "Falcon", "Otter", "Maple", "Comet", "Harbor", "Ember", "Willow", "Lynx",
+        "Meadow", "Aspen", "Heron", "Cedar", "Ridge", "Sparrow", "Tundra", "Coral",
+    ]
+
+    static func make(adjective: String, noun: String, number: Int) -> String {
+        "\(adjective)\(noun)\(number)"
+    }
+
+    static func random() -> String {
+        make(
+            adjective: adjectives.randomElement()!,
+            noun: nouns.randomElement()!,
+            number: Int.random(in: 1000...9999)
+        )
+    }
+
+    /// Compact only names that exactly match the app's old generated format.
+    /// User-chosen display names keep their original spacing.
+    static func compactLegacyDefault(_ name: String) -> String {
+        let parts = name.components(separatedBy: " ")
+        guard parts.count == 3,
+              adjectives.contains(parts[0]),
+              nouns.contains(parts[1]),
+              let number = Int(parts[2]),
+              (10...99).contains(number),
+              String(number) == parts[2]
+        else { return name }
+
+        return make(adjective: parts[0], noun: parts[1], number: number)
+    }
+}

--- a/tests/test_native_feedback_personalize_ux.py
+++ b/tests/test_native_feedback_personalize_ux.py
@@ -1,0 +1,81 @@
+"""Regression contracts for the native feedback and Personalize UX."""
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+NATIVE_SOURCES = ROOT / "native" / "Sources" / "OpenVoiceFlow"
+
+
+def source(name: str) -> str:
+    return (NATIVE_SOURCES / name).read_text(encoding="utf-8")
+
+
+def test_feedback_uses_an_always_visible_optional_email_field() -> None:
+    feedback = source("FeedbackView.swift")
+
+    assert 'TextField("Email (optional)", text: $contact)' in feedback
+    assert "includeContact" not in feedback
+    assert "contact: contact.trimmingCharacters(in: .whitespacesAndNewlines)" in feedback
+
+
+def test_feedback_uses_a_native_click_outside_dismissible_popover() -> None:
+    dashboard = source("DashboardView.swift")
+    feedback = source("FeedbackView.swift")
+
+    assert ".sheet(isPresented: $showFeedback)" not in dashboard
+    assert ".popover(isPresented: $showFeedback)" in dashboard
+    assert "private var feedbackOverlay" not in dashboard
+    assert "FeedbackView(controller: controller, onDismiss:" in dashboard
+    assert "let onDismiss: () -> Void" in feedback
+
+
+def test_know_me_is_a_personalize_tab_not_a_sidebar_pane() -> None:
+    dashboard = source("DashboardView.swift")
+
+    pane_block = dashboard.split("enum Pane:", 1)[1].split("enum PersonalizeTab:", 1)[0]
+    tab_block = dashboard.split("enum PersonalizeTab:", 1)[1].split("private var dark:", 1)[0]
+
+    assert "case knowMe" not in pane_block
+    assert 'case knowMe = "Know Me"' in tab_block
+    assert "case .knowMe: knowMe" in dashboard
+
+
+def test_leaderboard_alias_is_one_token_and_migrates_only_legacy_defaults(tmp_path: Path) -> None:
+    alias_source = NATIVE_SOURCES / "LeaderboardAlias.swift"
+    harness = tmp_path / "main.swift"
+    harness.write_text(
+        """
+import Foundation
+
+precondition(LeaderboardAlias.make(adjective: "Keen", noun: "Coral", number: 13) == "KeenCoral13")
+precondition(LeaderboardAlias.compactLegacyDefault("Keen Coral 13") == "KeenCoral13")
+precondition(LeaderboardAlias.compactLegacyDefault("Mohit Jain") == "Mohit Jain")
+precondition(LeaderboardAlias.compactLegacyDefault("keen coral 13") == "keen coral 13")
+precondition(LeaderboardAlias.compactLegacyDefault("Keen Coral 13 ") == "Keen Coral 13 ")
+precondition(LeaderboardAlias.compactLegacyDefault("Keen\\tCoral\\t13") == "Keen\\tCoral\\t13")
+precondition(LeaderboardAlias.compactLegacyDefault("Keen  Coral 13") == "Keen  Coral 13")
+for _ in 0..<100 {
+    precondition(!LeaderboardAlias.random().contains(where: { $0.isWhitespace }))
+}
+print("ok")
+""",
+        encoding="utf-8",
+    )
+    binary = tmp_path / "alias-contract"
+
+    compile_result = subprocess.run(
+        ["xcrun", "swiftc", str(alias_source), str(harness), "-o", str(binary)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    run_result = subprocess.run([str(binary)], text=True, capture_output=True, check=False)
+    assert run_result.returncode == 0, run_result.stderr
+    assert run_result.stdout.strip() == "ok"
+
+    analytics = source("AnalyticsStore.swift")
+    assert "LeaderboardAlias.compactLegacyDefault" in analytics
+    assert "LeaderboardAlias.random()" in analytics

--- a/tests/test_native_feedback_personalize_ux.py
+++ b/tests/test_native_feedback_personalize_ux.py
@@ -1,7 +1,10 @@
 """Regression contracts for the native feedback and Personalize UX."""
 
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 NATIVE_SOURCES = ROOT / "native" / "Sources" / "OpenVoiceFlow"
@@ -42,6 +45,9 @@ def test_know_me_is_a_personalize_tab_not_a_sidebar_pane() -> None:
 
 
 def test_leaderboard_alias_is_one_token_and_migrates_only_legacy_defaults(tmp_path: Path) -> None:
+    if shutil.which("xcrun") is None:
+        pytest.skip("Swift contract requires the macOS Xcode toolchain")
+
     alias_source = NATIVE_SOURCES / "LeaderboardAlias.swift"
     harness = tmp_path / "main.swift"
     harness.write_text(


### PR DESCRIPTION
## Summary
- simplify feedback contact capture to one optional email field
- use a native macOS popover for click-outside and Escape dismissal
- move Know Me under Personalize
- generate one-token leaderboard aliases and safely migrate only exact legacy defaults

## Verification
- `python3 -m pytest -q` — 277 passed, 1 optional dependency skipped
- `uvx ruff check .` — passed
- `swift build` — passed
- XcodeGen unsigned macOS Debug build — passed
- independent staged-diff review — passed after migration/accessibility fixes

## QA scope
Compile-verified on macOS. The feedback modal was not conclusively exercised through a live accessibility-driven UI session.