### PR TITLE
Release native app 0.5.14

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.13</string>
-    <key>CFBundleVersion</key><string>18</string>
+    <key>CFBundleShortVersionString</key><string>0.5.14</string>
+    <key>CFBundleVersion</key><string>19</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.13
-        CURRENT_PROJECT_VERSION: 18
+        MARKETING_VERSION: 0.5.14
+        CURRENT_PROJECT_VERSION: 19
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## Summary
- bump native marketing version to 0.5.14
- increment Sparkle build number to 19

## Verification
- 277 tests passed, 1 optional dependency skip
- Ruff clean
- unsigned generic macOS Debug build succeeded
- all four version fields agree and build 19 exceeds published build 18