### PR TITLE
fix(native): restore centered Feedback modal in 0.5.15

### DIFF
--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.14</string>
-    <key>CFBundleVersion</key><string>19</string>
+    <key>CFBundleShortVersionString</key><string>0.5.15</string>
+    <key>CFBundleVersion</key><string>20</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -145,7 +145,7 @@ struct DashboardView: View {
                 .padding(.horizontal, 10)
             }
             .buttonStyle(.plain)
-            .popover(isPresented: $showFeedback) {
+            .sheet(isPresented: $showFeedback) {
                 FeedbackView(controller: controller, onDismiss: { showFeedback = false })
             }
 

--- a/native/project.yml
+++ b/native/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.14
-        CURRENT_PROJECT_VERSION: 19
+        MARKETING_VERSION: 0.5.15
+        CURRENT_PROJECT_VERSION: 20
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:

--- a/tests/test_native_feedback_personalize_ux.py
+++ b/tests/test_native_feedback_personalize_ux.py
@@ -22,12 +22,12 @@ def test_feedback_uses_an_always_visible_optional_email_field() -> None:
     assert "contact: contact.trimmingCharacters(in: .whitespacesAndNewlines)" in feedback
 
 
-def test_feedback_uses_a_native_click_outside_dismissible_popover() -> None:
+def test_feedback_uses_a_centered_native_modal() -> None:
     dashboard = source("DashboardView.swift")
     feedback = source("FeedbackView.swift")
 
-    assert ".sheet(isPresented: $showFeedback)" not in dashboard
-    assert ".popover(isPresented: $showFeedback)" in dashboard
+    assert ".sheet(isPresented: $showFeedback)" in dashboard
+    assert ".popover(isPresented: $showFeedback)" not in dashboard
     assert "private var feedbackOverlay" not in dashboard
     assert "FeedbackView(controller: controller, onDismiss:" in dashboard
     assert "let onDismiss: () -> Void" in feedback


### PR DESCRIPTION
## What this changes (for the user)

- Restores Feedback as a centered native modal instead of a left-anchored popover.
- Keeps the simplified always-visible `Email (optional)` field and existing Cancel, Send, and Escape dismissal.
- Bumps the requested native patch release to 0.5.15 (build 20).

## How it was verified

- [x] Full pytest: 277 passed, 1 optional-dependency skip
- [x] Ruff clean
- [x] SwiftPM build passed
- [x] Unsigned generic macOS Xcode build passed
- [x] Manual debug-app QA: native AXSheet centered within 1 px; Escape dismissed it
- [x] Independent exact-diff UX/security/release review: no blockers
- [x] Version consistency: project.yml and Info.plist both 0.5.15/20; appcast predecessor is build 19

The version bump is explicitly requested as part of this patch release; no dependencies are changed.