### PR TITLE
Release native OpenVoiceFlow 0.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.17] — 2026-08-30
+
 ### Added
 - App names across Home, History, and Personalize now use recognizable app or company logos, including Claude, Discord, Notion, and Outlook. Installed macOS app icons remain the first choice, with bundled brand marks as reliable fallbacks.
 

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.16</string>
-    <key>CFBundleVersion</key><string>21</string>
+    <key>CFBundleShortVersionString</key><string>0.5.17</string>
+    <key>CFBundleVersion</key><string>22</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -479,14 +479,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.16;
+				MARKETING_VERSION = 0.5.17;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;
@@ -499,14 +499,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.16;
+				MARKETING_VERSION = 0.5.17;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.16
-        CURRENT_PROJECT_VERSION: 21
+        MARKETING_VERSION: 0.5.17
+        CURRENT_PROJECT_VERSION: 22
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

- Prepares native OpenVoiceFlow 0.5.17, build 22.
- Ships History Copy confirmation, complete app/company logo coverage, immediate nickname updates, honest retry states, and per-install leaderboard recovery.
- Moves the completed Unreleased changelog into the 0.5.17 section.

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes
- [ ] No version bumps or new dependencies (discuss those in an issue first)

Release verification:

- All four native version fields agree on 0.5.17 / build 22.
- `python3 -m pytest -q` — 287 passed, 1 optional menu-bar test skipped
- `python3 -m ruff check voiceflow/` — passed
- `npm run test:api` — 4 passed
- `npm run build` — passed
- `npm audit` — 0 vulnerabilities
- `xcodegen generate --spec native/project.yml` — generated project committed

The version checkbox is intentionally unchecked: this PR performs the documented release-only version bump. The native UI was compiled in prior CI, and this PR will repeat the full native Xcode gate before tagging.