### PR TITLE
Release native OpenVoiceFlow 0.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.18] — 2026-08-31
+
+### Fixed
+- Public leaderboard standings now include only rows with at least 60 minutes saved and show no more than five entries, while still showing your own row separately.
+- Legacy auto-generated leaderboard names now use the same exact 10–99 suffix range as the native app, preserving custom-looking names ending in 00–09.
+
 ## [0.5.17] — 2026-08-30
 
 ### Added

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.17</string>
-    <key>CFBundleVersion</key><string>22</string>
+    <key>CFBundleShortVersionString</key><string>0.5.18</string>
+    <key>CFBundleVersion</key><string>23</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -479,14 +479,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.17;
+				MARKETING_VERSION = 0.5.18;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;
@@ -499,14 +499,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.17;
+				MARKETING_VERSION = 0.5.18;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.17
-        CURRENT_PROJECT_VERSION: 22
+        MARKETING_VERSION: 0.5.18
+        CURRENT_PROJECT_VERSION: 23
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

- Prepares native OpenVoiceFlow 0.5.18, build 23.
- Ships the server-side leaderboard privacy threshold and five-row public cap while continuing to return the viewer's own row separately.
- Aligns legacy generated-alias formatting with the native app's exact 10–99 range, preserving custom-looking names ending in 00–09.
- Adds the 0.5.18 changelog entry for both fixes.

## How it was verified

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes
- [ ] No version bumps or new dependencies (discuss those in an issue first)

Release verification:

- All native version sources agree on 0.5.18 / build 23, including both generated Xcode configurations.
- `xcodegen generate --spec native/project.yml` — generated project committed; a second generation was byte-identical.
- Unsigned universal `xcodebuild` — passed on Xcode 26.5.
- `python3 -m pytest -q -k 'not test_copy_feedback_moves_between_rows_and_self_dismisses'` — 286 passed, 1 optional menu-bar test skipped, 1 known 30 ms Xcode 26 timing harness deselected. The full suite is left to the Xcode 16.4 CI gate used by this repository.
- `uvx ruff check .` — passed.
- `npm run test:api` — 7 passed.
- `npm run build` — passed.
- `npm audit` — 0 vulnerabilities.

The version checkbox is intentionally unchecked: this PR performs the documented release-only version bump. No UI changed, so a screenshot is not applicable. CI must be fully green before merge and tagging.