### PR TITLE
release: bump native app to 0.5.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.19] — 2026-09-02
+
 ### Changed
 - The leaderboard now draws a fixed seven rows whatever the standings return, so the height of the card no longer reveals how many people use OpenVoiceFlow. Rows the service doesn't name are masked — a shimmering placeholder with no rank, name, or total — and the tail fades out rather than ending on a countable last row. The card states no rule and shows no threshold: naming the bar would let anyone counting the visible names work out what population they were counting.
 

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.18</string>
-    <key>CFBundleVersion</key><string>23</string>
+    <key>CFBundleShortVersionString</key><string>0.5.19</string>
+    <key>CFBundleVersion</key><string>24</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -479,14 +479,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.18;
+				MARKETING_VERSION = 0.5.19;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;
@@ -499,14 +499,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.18;
+				MARKETING_VERSION = 0.5.19;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.18
-        CURRENT_PROJECT_VERSION: 23
+        MARKETING_VERSION: 0.5.19
+        CURRENT_PROJECT_VERSION: 24
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

Nothing on its own — this is RELEASE.md step 1, the version bump that lets `native-v0.5.19` be tagged and built.

All four version fields move together, plus the committed generated `project.pbxproj`:

| Field | 0.5.18 | 0.5.19 |
| :--- | :--- | :--- |
| `native/project.yml` → `MARKETING_VERSION` | 0.5.18 | 0.5.19 |
| `native/project.yml` → `CURRENT_PROJECT_VERSION` | 23 | 24 |
| `native/Info.plist` → `CFBundleShortVersionString` | 0.5.18 | 0.5.19 |
| `native/Info.plist` → `CFBundleVersion` | 23 | 24 |
| `project.pbxproj` (Debug + Release) | 23 / 0.5.18 | 24 / 0.5.19 |

Build 24 strictly increases past 23, which is what the published appcast currently offers — Sparkle orders updates by build number and silently offers nothing if it stalls.

The CHANGELOG's `Unreleased` entry moves under `[0.5.19] — 2026-09-02`. What ships in it: the leaderboard card no longer publishes the user count through its height ([#123](https://github.com/shimoverse/openvoiceflow/pull/123)).

## How it was verified

- [x] CI green — pending on this PR; the bump touches no code paths, and the same four-field shape matches the 0.5.18 bump in `d8b2d8a`. Locally `pytest tests/` shows the same 256 passed / 14 failed / 17 errors as `main` before this commit — those failures are the legacy Python app's macOS-only imports (`sounddevice`, `rumps`, `pynput`) missing in a Linux container, not a regression.
- [ ] Screenshot or recording attached for UI changes — no UI change in this PR.
- [x] No new dependencies. Version bumps are the point of this one.

Next steps once merged, per RELEASE.md: dispatch **Create release tag** with `native-v0.5.19` and this merge SHA, then **Release (native app)** to build, sign, notarize and attach the DMG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe)_