### PR TITLE
Stop the copy-feedback contract racing the scheduler

### DIFF
--- a/tests/test_native_history_app_identity.py
+++ b/tests/test_native_history_app_identity.py
@@ -31,7 +31,14 @@ def compile_and_run_swift(tmp_path: Path, sources: list[Path], harness_source: s
 
 
 def test_copy_feedback_moves_between_rows_and_self_dismisses(tmp_path: Path) -> None:
-    """A stale timer must not clear a newer row's acknowledgement."""
+    """A stale timer must not clear a newer row's acknowledgement.
+
+    The three delays only have to keep one ordering — the second row's own timer
+    fires inside the wait, the first row's cannot — so they are sized for the
+    slowest runner rather than the fastest. An earlier version proved the same
+    thing with 10 ms / 30 ms / 80 ms and failed in CI when the scheduler took
+    longer than 20 ms to run a due task. Widen these before tightening them.
+    """
     compile_and_run_swift(
         tmp_path,
         [NATIVE_SOURCES / "HistoryCopyFeedback.swift"],
@@ -46,17 +53,17 @@ struct Runner {
         let second = UUID()
         let feedback = HistoryCopyFeedback()
 
-        feedback.markCopied(first, dismissAfterNanoseconds: 80_000_000)
+        feedback.markCopied(first, dismissAfterNanoseconds: 800_000_000)
         let firstIsCopied = feedback.isCopied(first)
         precondition(firstIsCopied)
 
-        feedback.markCopied(second, dismissAfterNanoseconds: 10_000_000)
+        feedback.markCopied(second, dismissAfterNanoseconds: 100_000_000)
         let firstWasCleared = !feedback.isCopied(first)
         let secondIsCopied = feedback.isCopied(second)
         precondition(firstWasCleared)
         precondition(secondIsCopied)
 
-        try? await Task.sleep(nanoseconds: 30_000_000)
+        try? await Task.sleep(nanoseconds: 400_000_000)
         let secondWasDismissed = !feedback.isCopied(second)
         precondition(secondWasDismissed)
     }


### PR DESCRIPTION
## What this changes (for the user)

Nothing users see. `test_copy_feedback_moves_between_rows_and_self_dismisses` gave a 10 ms auto-dismiss timer 30 ms to fire — a 20 ms margin for the Swift concurrency scheduler to run a due task on a macOS runner that is simultaneously compiling the app and running the rest of the suite.

It failed on [#125](https://github.com/shimoverse/openvoiceflow/pull/125) and passed on re-run against the same commit, with `HistoryCopyFeedback.swift` byte-identical to the `main` where it had just passed twice. That is the signature of the margin, not of the code under test.

All three delays scale by 10:

| | before | after |
| :--- | ---: | ---: |
| first row's timer (must *not* fire) | 80 ms | 800 ms |
| second row's timer (must fire) | 10 ms | 100 ms |
| wait before asserting | 30 ms | 400 ms |

The ordering the test proves is unchanged — the second row's own timer fires inside the wait, the first row's cannot — but with 300 ms of slack instead of 20 ms. Costs about 370 ms of suite time.

**The production default in `HistoryCopyFeedback.swift` stays 1.5 s.** The fragility was the test's margin, not the shipping behaviour, so nothing users see moves. The docstring now records the failure so the next reader widens these rather than tightening them back.

## How it was verified

- [x] CI green — pending on this PR; this is the check that was flaking, so a green `test (3.9/3.10/3.11)` here is the evidence. Locally `pytest tests/test_native_history_app_identity.py` passes with the two Swift contracts skipped (no Xcode toolchain in a Linux container), and `ruff check tests/` is clean. The Swift harness itself is unchanged apart from three literals.
- [ ] Screenshot or recording attached for UI changes — no UI change.
- [x] No version bumps or new dependencies.

Follow-up to the 0.5.19 release. The one item still genuinely outstanding is device verification of the 0.5.19 leaderboard pane, which needs a Mac and cannot be done from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe)_