### PR TITLE
Call the leaderboard figure time back, not time saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The leaderboard now labels its figure "time back" instead of "time saved", matching Home, onboarding, and the manual. The number is how long the same words would have taken to type at 40 wpm; nothing subtracts the time dictating them actually took, so calling it a saving overstated it. The number itself is unchanged, as are the `minutesSaved` field and `minutes_saved` column that already-shipped clients depend on.
+
 ## [0.5.19] — 2026-09-02
 
 ### Changed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,7 +34,7 @@ Everything OpenVoiceFlow knows about you lives in one of the rows below.
 | **Snippets** | App Application Support folder | Voice triggers and their expansions. May contain signature blocks. | Empty until you add snippets | **No** — but expansions become part of dictated text and follow whatever path you've set for that text. |
 | **History / stats** | App Application Support folder | Recent dictations and aggregate counters | Local | **No.** Never sent anywhere. |
 | **Sparkle update check** | In transit to the appcast host | A request for the update feed to see if a newer signed build exists | On by default | **Yes** — an anonymous request for the update manifest. No PII, no key, no user ID. |
-| **Anonymous usage summary** | App Application Support folder (device ID + display name), synced to our leaderboard API | Total words, total time saved, streak, feature-usage counts, a random device ID, a display name you choose | **On by default** since v0.5.7 — toggle in Settings ▸ Privacy | **Yes, if the toggle is on.** Never dictated text, snippets, dictionary, or profile content. Country is derived server-side from the request; no IP address is stored. |
+| **Anonymous usage summary** | App Application Support folder (device ID + display name), synced to our leaderboard API | Total words, total time back, streak, feature-usage counts, a random device ID, a display name you choose | **On by default** since v0.5.7 — toggle in Settings ▸ Privacy | **Yes, if the toggle is on.** Never dictated text, snippets, dictionary, or profile content. Country is derived server-side from the request; no IP address is stored. |
 
 ### Data flow for a single dictation
 
@@ -121,7 +121,7 @@ Anything you've already sent to OpenRouter lives by that provider's retention po
 **In-app usage summary & leaderboard (since v0.5.7).** With "Share anonymous usage & leaderboard rank" on in Settings ▸ Privacy — **on by default** — the app periodically sends:
 
 - A random device ID generated for this installation, and a display name you choose (shown to other users on the leaderboard). There is no account: installations remain separate even when they use the same nickname, so three computers produce three independent leaderboard rows.
-- Aggregate counters: total words dictated, total time saved, streak, and which features are on (cleanup enabled, snippet/dictionary counts, whether you've completed Know Me) — counts only, never content.
+- Aggregate counters: total words dictated, total time back, streak, and which features are on (cleanup enabled, snippet/dictionary counts, whether you've completed Know Me) — counts only, never content.
 - Your country, derived server-side from the request at the moment it arrives. We do not log or store your IP address.
 
 This never includes dictated text, snippets, dictionary entries, Know-Me profile content, or anything from the cleanup path. Aggregate totals sync periodically during active dictation. Opening Leaderboard sends the same aggregate snapshot before fetching standings, so saved local totals can restore that installation's row. Changing a nickname also sends the snapshot once when you press Return or leave the field; individual keystrokes are not uploaded. Turn the toggle off and every one of these requests stops immediately — nothing queues up to send later. The leaderboard itself does not disclose how many people use OpenVoiceFlow in total.

--- a/docs/docs/privacy-architecture.html
+++ b/docs/docs/privacy-architecture.html
@@ -185,12 +185,12 @@
         <p>Set cleanup to <strong>None</strong> (the default) or <strong>Ollama</strong>, and the cleanup row never happens. Turn off automatic updates and the update-check row stops too. Turn off usage sharing and the fourth row stops immediately — nothing queues up and sends later.</p>
 
         <h2 id="analytics">Analytics &amp; leaderboard</h2>
-        <p>Since <strong>0.5.7</strong>, the app can share an anonymous usage summary to power an in-app leaderboard ranked by time saved. This is a real change from earlier versions, which sent nothing — it's on by default, and this section says exactly what that means.</p>
+        <p>Since <strong>0.5.7</strong>, the app can share an anonymous usage summary to power an in-app leaderboard ranked by time back (typing time avoided, not a net saving — see the dashboard manual). This is a real change from earlier versions, which sent nothing — it's on by default, and this section says exactly what that means.</p>
         <p><strong>Turning it off:</strong> Settings ▸ Privacy ▸ <em>&ldquo;Share anonymous usage &amp; leaderboard rank&rdquo;</em>. Off stops every request in the row above; nothing is cached to send later.</p>
         <p><strong>What's sent, when it's on:</strong></p>
         <ul>
           <li>A random device ID generated for this installation (not tied to your Apple ID, email, or any account — there is no account) and a display name you can change, shown to other users on the leaderboard. Installations remain separate even when they use the same nickname, so three computers produce three independent rows.</li>
-          <li>Aggregate counters already shown on your Home pane: total words dictated, total time saved, your streak, and which features are on (cleanup enabled, snippet/dictionary counts, whether you've run Know-Me) — counts only, never contents.</li>
+          <li>Aggregate counters already shown on your Home pane: total words dictated, total time back, your streak, and which features are on (cleanup enabled, snippet/dictionary counts, whether you've run Know-Me) — counts only, never contents.</li>
           <li>Your country, derived server-side from the request at the moment it arrives. Your IP address itself is never logged or stored.</li>
         </ul>
         <p>Aggregate totals sync periodically during active dictation. Opening Leaderboard sends the same aggregate snapshot before fetching standings, so saved local totals can restore that installation's row. Changing a nickname also sends the snapshot once when you press Return or leave the field; individual keystrokes are not uploaded.</p>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -77,7 +77,7 @@
         <p>Settings ▸ Privacy ▸ <em>&ldquo;Share anonymous usage &amp; leaderboard rank&rdquo;</em> — <strong>on by default</strong>. While it's on, the app periodically sends:</p>
         <ul class="check-list">
           <li>A random device ID generated on your Mac, and a display name you choose — shown to other users on the leaderboard, tied to no account or email.</li>
-          <li>Aggregate counters already shown on your Home pane: total words, total time saved, streak, and which features are on. Counts only, never content.</li>
+          <li>Aggregate counters already shown on your Home pane: total words, total time back, streak, and which features are on. Counts only, never content.</li>
           <li>Your country, derived from the request when it arrives. Your IP address is never stored.</li>
         </ul>
         <p>Never sent, sharing on or off: dictated text, snippets, dictionary entries, or your Know-Me profile. Turn the toggle off and every request stops immediately. A &ldquo;Delete my leaderboard data&rdquo; button in the same Settings row removes a past submission outright. The leaderboard never discloses how many people use OpenVoiceFlow in total.</p>

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -649,7 +649,7 @@ struct DashboardView: View {
 
     @ViewBuilder private var leaderboardPane: some View {
         VStack(alignment: .leading, spacing: 14) {
-            paneTitle("Leaderboard", "Ranked by time saved. Your name is the one you set in Settings.")
+            paneTitle("Leaderboard", "Ranked by time back. Your name is the one you set in Settings.")
             if !controller.settings.shareAnalytics {
                 emptyPanel(
                     title: "Sharing is off",
@@ -739,7 +739,7 @@ struct DashboardView: View {
                     .background(RoundedRectangle(cornerRadius: 5).fill(DT.emberWave.opacity(0.12)))
             }
             Spacer()
-            Text(Self.hoursMinutes(minutes) + " saved")
+            Text(Self.hoursMinutes(minutes) + " back")
                 .font(.system(size: 12.5, weight: .medium)).foregroundStyle(ink2)
         }
         .padding(.vertical, 11)

--- a/native/Sources/OpenVoiceFlow/FeatureStores.swift
+++ b/native/Sources/OpenVoiceFlow/FeatureStores.swift
@@ -306,8 +306,15 @@ final class HistoryStore: ObservableObject {
     // MARK: minutes
     //
     // Words are the app's unit; nobody wants more words. Minutes returned is
-    // the thing worth counting, at the same 40 wpm divisor "time saved" uses so
+    // the thing worth counting, at the same 40 wpm divisor "time back" uses so
     // the two figures can never disagree.
+    //
+    // This is typing time avoided — how long the same words would have taken to
+    // type — not a net saving. Dictating them took real time too, and nothing
+    // here subtracts it. Every surface therefore says "time back", never
+    // "saved"; onboarding shows both numbers side by side rather than the
+    // difference. The wire field and column stay `minutesSaved`/`minutes_saved`
+    // for compatibility with already-shipped clients.
     static let wordsPerMinute = 40.0
 
     static func minutes(fromWords words: Int) -> Int {

--- a/native/Sources/OpenVoiceFlow/FeedbackView.swift
+++ b/native/Sources/OpenVoiceFlow/FeedbackView.swift
@@ -126,7 +126,7 @@ struct FeedbackView: View {
             "  App version: \(snapshot.appVersion)",
             "  Using since: \(snapshot.usingSince)",
             "  Total words dictated: \(snapshot.totalWords)",
-            "  Total time saved: \(snapshot.timeSaved)",
+            "  Total time back: \(snapshot.timeBack)",
             "  Current streak: \(snapshot.streakDays) day(s)",
             "  Last 7 days (minutes returned): \(snapshot.lastWeekMinutes.map(String.init).joined(separator: ", "))",
             "  Total takes recorded: \(snapshot.totalTakes)",
@@ -142,7 +142,7 @@ struct UsageSnapshot {
     let appVersion: String
     let usingSince: String
     let totalWords: Int
-    let timeSaved: String
+    let timeBack: String
     let streakDays: Int
     let lastWeekMinutes: [Int]
     let totalTakes: Int
@@ -160,7 +160,7 @@ struct UsageSnapshot {
         }
         totalWords = history.totalWords
         let minutes = history.totalMinutes
-        timeSaved = minutes >= 60 ? "\(minutes / 60)h \(minutes % 60)m" : "\(minutes)m"
+        timeBack = minutes >= 60 ? "\(minutes / 60)h \(minutes % 60)m" : "\(minutes)m"
         streakDays = history.streak
         lastWeekMinutes = history.minutesLastWeek
         totalTakes = history.entries.count

--- a/scripts/docs_content.py
+++ b/scripts/docs_content.py
@@ -1057,12 +1057,12 @@ PAGES["privacy-architecture"] = {
         <p>Set cleanup to <strong>None</strong> (the default) or <strong>Ollama</strong>, and the cleanup row never happens. Turn off automatic updates and the update-check row stops too. Turn off usage sharing and the fourth row stops immediately — nothing queues up and sends later.</p>
 
         <h2 id="analytics">Analytics &amp; leaderboard</h2>
-        <p>Since <strong>0.5.7</strong>, the app can share an anonymous usage summary to power an in-app leaderboard ranked by time saved. This is a real change from earlier versions, which sent nothing — it's on by default, and this section says exactly what that means.</p>
+        <p>Since <strong>0.5.7</strong>, the app can share an anonymous usage summary to power an in-app leaderboard ranked by time back (typing time avoided, not a net saving — see the dashboard manual). This is a real change from earlier versions, which sent nothing — it's on by default, and this section says exactly what that means.</p>
         <p><strong>Turning it off:</strong> Settings ▸ Privacy ▸ <em>&ldquo;Share anonymous usage &amp; leaderboard rank&rdquo;</em>. Off stops every request in the row above; nothing is cached to send later.</p>
         <p><strong>What's sent, when it's on:</strong></p>
         <ul>
           <li>A random device ID generated for this installation (not tied to your Apple ID, email, or any account — there is no account) and a display name you can change, shown to other users on the leaderboard. Installations remain separate even when they use the same nickname, so three computers produce three independent rows.</li>
-          <li>Aggregate counters already shown on your Home pane: total words dictated, total time saved, your streak, and which features are on (cleanup enabled, snippet/dictionary counts, whether you've run Know-Me) — counts only, never contents.</li>
+          <li>Aggregate counters already shown on your Home pane: total words dictated, total time back, your streak, and which features are on (cleanup enabled, snippet/dictionary counts, whether you've run Know-Me) — counts only, never contents.</li>
           <li>Your country, derived server-side from the request at the moment it arrives. Your IP address itself is never logged or stored.</li>
         </ul>
         <p>Aggregate totals sync periodically during active dictation. Opening Leaderboard sends the same aggregate snapshot before fetching standings, so saved local totals can restore that installation's row. Changing a nickname also sends the snapshot once when you press Return or leave the field; individual keystrokes are not uploaded.</p>

--- a/tests/test_native_leaderboard_reliability.py
+++ b/tests/test_native_leaderboard_reliability.py
@@ -164,3 +164,38 @@ def test_card_does_not_publish_the_reveal_threshold() -> None:
     for shown in strings:
         assert "hour" not in shown.lower(), f"card copy states the reveal bar: {shown!r}"
         assert "60" not in shown, f"card copy states the reveal bar: {shown!r}"
+
+
+def test_time_back_is_never_called_time_saved() -> None:
+    """The figure is typing time avoided, not a net saving.
+
+    minutes(fromWords:) divides the word count by 40 wpm — how long the same
+    words would have taken to type. Nothing subtracts the time dictating them
+    actually took, so the difference is not a saving and the UI must not call it
+    one. Home ("TIME BACK", "you didn't spend typing"), onboarding ("You spoke
+    for 4 seconds. Typing that would have taken 18.") and the dashboard manual
+    all say this carefully; the leaderboard used to say "saved" and overstated
+    the same number.
+
+    The wire field and column stay minutesSaved/minutes_saved — renaming those
+    would break already-shipped clients — so this pins the copy, not the schema.
+    """
+    sources = {
+        name: (NATIVE_SOURCES / name).read_text(encoding="utf-8")
+        for name in ("DashboardView.swift", "FeedbackView.swift", "OnboardingView.swift")
+    }
+
+    for name, text in sources.items():
+        shown = re.findall(r'Text\("((?:[^"\\]|\\.)*)"', text)
+        shown += re.findall(r'paneTitle\("[^"]*",\s*"((?:[^"\\]|\\.)*)"', text)
+        for line in shown:
+            assert "time saved" not in line.lower(), f"{name} calls time back a saving: {line!r}"
+
+    dashboard = sources["DashboardView.swift"]
+    assert 'paneTitle("Leaderboard", "Ranked by time back.' in dashboard
+    assert 'Text(Self.hoursMinutes(minutes) + " back")' in dashboard
+
+    # The divisor still has to be the single source both figures share.
+    stores = (NATIVE_SOURCES / "FeatureStores.swift").read_text(encoding="utf-8")
+    assert "static let wordsPerMinute = 40.0" in stores
+    assert "Int((Double(words) / wordsPerMinute).rounded())" in stores


### PR DESCRIPTION
## What this changes (for the user)

An audit of the time figure, prompted by a doubt about its units.

**The units are correct — no bug there.** `minutes(fromWords:)` returns `round(words / 40.0)` *minutes*; ingest stores it in `minutes_saved INTEGER` with no conversion; `readLeaderboard` returns it unchanged; `hoursMinutes` renders 1253 as `20 h 53 m`. Words are counted once per take into `dailyWords`, which loads from `stats.json` and is never re-seeded from history, so nothing double-counts either.

**The defect is what the number is called.** `words / 40` is how long the same text would have taken to *type*. Dictating it took real time too, and nothing subtracts that — so the figure is typing time avoided, not a net saving. The legacy app states the assumption outright: `# Estimate time saved: ~40 WPM typing vs instant dictation`.

Three surfaces already got this right:

| Surface | Says |
| :--- | :--- |
| Home | `TIME BACK` — "two working days you didn't spend typing" |
| Onboarding | "You spoke for 4 seconds. Typing that would have taken 18." — both numbers, not the difference |
| Manual | "time back — an estimate of how long the same text would have taken to type … an order of magnitude, not a stopwatch" |

The leaderboard was the outlier: *"Ranked by time saved"* and *"20 h 53 m saved"*, claiming a net benefit for the same arithmetic. The feedback email and the privacy pages repeated it. AGENTS.md is explicit that claims must be true of the shipped app and to understate when in doubt.

This moves every user-visible surface to "time back". **The number itself is unchanged**, and so are the `minutesSaved` wire field and `minutes_saved` column — renaming those would break clients already in the field.

Not touched: the legacy Python app (`voiceflow/`), which is EOL and takes fallback-critical fixes only, and the `stats.json` rows in `THREAT_MODEL.md` / `DPA-template.md`, which accurately describe that legacy file.

## How it was verified

- [x] CI green — pending on this PR. Locally `pytest tests/` shows 257 passed against `main`'s 256 (the one new test) with the identical 14 failed / 17 errors, all the legacy app's macOS-only imports on Linux. `ruff` clean; `build_docs.py` regenerates only the intended paragraphs.
- [x] New contract test — no `Text`/`paneTitle` string in the dashboard, feedback or onboarding may contain "time saved"; the leaderboard copy is asserted directly; and the 40 wpm divisor stays the single source both figures share. I confirmed it fails on a canary that puts `" time saved"` back, then restored.
- [ ] Screenshot or recording attached — the visible change is two strings ("Ranked by time back", "20 h 53 m back"). Compile-verified by CI only; no Mac here.
- [x] No version bumps or new dependencies.

The rename in `FeedbackView` (`timeSaved` → `timeBack`) moves declaration, assignment and use together; `grep timeSaved native/` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe)_