### PR TITLE
release: bump native app to 0.5.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.20] — 2026-09-02
+
 ### Changed
 - The leaderboard now labels its figure "time back" instead of "time saved", matching Home, onboarding, and the manual. The number is how long the same words would have taken to type at 40 wpm; nothing subtracts the time dictating them actually took, so calling it a saving overstated it. The number itself is unchanged, as are the `minutesSaved` field and `minutes_saved` column that already-shipped clients depend on.
 

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.19</string>
-    <key>CFBundleVersion</key><string>24</string>
+    <key>CFBundleShortVersionString</key><string>0.5.20</string>
+    <key>CFBundleVersion</key><string>25</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -479,14 +479,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.19;
+				MARKETING_VERSION = 0.5.20;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;
@@ -499,14 +499,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.19;
+				MARKETING_VERSION = 0.5.20;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.19
-        CURRENT_PROJECT_VERSION: 24
+        MARKETING_VERSION: 0.5.20
+        CURRENT_PROJECT_VERSION: 25
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## What this changes (for the user)

Nothing on its own — RELEASE.md step 1, the bump that lets `native-v0.5.20` be tagged and built.

| Field | 0.5.19 | 0.5.20 |
| :--- | :--- | :--- |
| `native/project.yml` → `MARKETING_VERSION` | 0.5.19 | 0.5.20 |
| `native/project.yml` → `CURRENT_PROJECT_VERSION` | 24 | 25 |
| `native/Info.plist` → `CFBundleShortVersionString` | 0.5.19 | 0.5.20 |
| `native/Info.plist` → `CFBundleVersion` | 24 | 25 |
| `project.pbxproj` (Debug + Release) | 24 / 0.5.19 | 25 / 0.5.20 |

Build 25 clears the appcast's current 24, which is what Sparkle orders updates by.

**What ships in it:** the leaderboard figure is labelled "time back" rather than "time saved" ([#127](https://github.com/shimoverse/openvoiceflow/pull/127)), matching Home, onboarding and the manual. The number is unchanged — it was always minutes, computed correctly; the word "saved" was the part that overstated it.

## How it was verified

- [x] CI green — pending here. The bump touches no code paths and matches the shape of the 0.5.19 bump in `abeb3cf`; I checked it against `release-native.yml`'s classify step, which asserts tag base == `MARKETING_VERSION`, plist short version == tag base, plist build == `CURRENT_PROJECT_VERSION`, and build > the appcast's last published build.
- [ ] Screenshot or recording attached for UI changes — none in this PR.
- [x] No new dependencies. Version bumps are the point of this one.

Next, per RELEASE.md: dispatch **Create release tag** with `native-v0.5.20` and this merge SHA, then **Release (native app)**, then the publish PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMZHJkXeG1SnKj3eTSd9oe)_