### PR TITLE
Add GitHub nav link, Releases page, and fill recent-feature doc gaps

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,10 @@ The release workflow's classify step hard-fails on any mismatch.
 5. **Verify live**: the site serves the new appcast build number and the DMG
    sha256 matches the notarized artifact byte-for-byte.
 6. Add a CHANGELOG entry; prune the previous version's DMG from
-   `docs/downloads/` and add its redirect in `vercel.json`.
+   `docs/downloads/` and add its redirect in `vercel.json`. Then regenerate
+   `docs/releases.html` with `python3 scripts/build_releases.py` — it renders
+   straight from CHANGELOG.md, so this is the only way the public Releases
+   page picks up the new entry.
 
 Never regenerate the Sparkle keypair — every shipped app pins the public key,
 and a new pair permanently breaks updates for every existing install.

--- a/docs/blog/best-dictation-software-mac.html
+++ b/docs/blog/best-dictation-software-mac.html
@@ -91,6 +91,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -103,6 +104,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -224,6 +226,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/dictation-for-writers.html
+++ b/docs/blog/dictation-for-writers.html
@@ -78,6 +78,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -90,6 +91,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -175,6 +177,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/how-to-dictate-on-mac.html
+++ b/docs/blog/how-to-dictate-on-mac.html
@@ -93,6 +93,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -105,6 +106,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -227,6 +229,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -59,6 +59,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -159,6 +161,7 @@
         <a href="../install.html">Install</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/is-on-device-dictation-private.html
+++ b/docs/blog/is-on-device-dictation-private.html
@@ -78,6 +78,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -90,6 +91,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -175,6 +177,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/offline-dictation-mac.html
+++ b/docs/blog/offline-dictation-mac.html
@@ -91,6 +91,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -103,6 +104,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -200,6 +202,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/personal-dictionary-dictation.html
+++ b/docs/blog/personal-dictionary-dictation.html
@@ -78,6 +78,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -90,6 +91,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -178,6 +180,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/voice-typing-for-developers.html
+++ b/docs/blog/voice-typing-for-developers.html
@@ -76,6 +76,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -88,6 +89,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -181,6 +183,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/whisper-models-for-dictation.html
+++ b/docs/blog/whisper-models-for-dictation.html
@@ -78,6 +78,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -90,6 +91,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -193,6 +195,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/blog/wispr-flow-alternative.html
+++ b/docs/blog/wispr-flow-alternative.html
@@ -78,6 +78,7 @@
         <li><a href="../install.html">Install</a></li>
         <li><a href="../docs/index.html">Docs</a></li>
         <li><a href="index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -90,6 +91,7 @@
       <a href="../how-it-works.html">How it works</a>
       <a href="../docs/index.html">Docs</a>
       <a href="index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -207,6 +209,7 @@
         <a href="../how-it-works.html">How it works</a>
         <a href="../docs/index.html">Docs</a>
         <a href="index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/accuracy.html
+++ b/docs/docs/accuracy.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -201,6 +203,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/ai-cleanup.html
+++ b/docs/docs/ai-cleanup.html
@@ -74,6 +74,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -85,6 +86,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -227,6 +229,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/api-keys.html
+++ b/docs/docs/api-keys.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -200,6 +202,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/backends.html
+++ b/docs/docs/backends.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -207,6 +209,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -179,6 +181,16 @@
           </tbody>
         </table>
 
+        <h2 id="feedback-leaderboard">Feedback and Leaderboard</h2>
+        <p>Two more rows sit below Settings in the sidebar:</p>
+        <table>
+          <thead><tr><th scope="col">Pane</th><th scope="col">What it is for</th></tr></thead>
+          <tbody>
+            <tr><td>Feedback</td><td>A short form (bug, idea, praise, or other, plus an optional reply email) that opens a <code>mailto:</code> on Send with a small aggregate usage snapshot attached — never dictation text.</td></tr>
+            <tr><td>Leaderboard</td><td>Your rank by <strong>time back</strong> against other installations sharing usage, with a display name you can change. Sharing is on by default since 0.5.7 — see <a href="privacy-architecture.html#analytics">Analytics &amp; leaderboard</a> for exactly what that sends and how to turn it off.</td></tr>
+          </tbody>
+        </table>
+
         <h2 id="menubar">The menu-bar menu</h2>
         <p>The waveform icon at the top right gives you the fast controls without opening the dashboard: pause listening for an hour, change the hotkey, change the cleanup backend, open permission settings, and check for updates.</p>
         <div class="callout tip">
@@ -207,6 +219,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/dictation-basics.html
+++ b/docs/docs/dictation-basics.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -209,6 +211,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/dictionary.html
+++ b/docs/docs/dictionary.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -198,6 +200,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/faq.html
+++ b/docs/docs/faq.html
@@ -96,6 +96,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -107,6 +108,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -236,6 +238,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/hotkeys.html
+++ b/docs/docs/hotkeys.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -202,6 +204,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/how-transcription-works.html
+++ b/docs/docs/how-transcription-works.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -202,6 +204,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -59,6 +59,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -70,6 +71,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -214,6 +216,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -216,6 +218,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/languages.html
+++ b/docs/docs/languages.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -247,6 +249,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/models.html
+++ b/docs/docs/models.html
@@ -74,6 +74,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -85,6 +86,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -244,6 +246,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/permissions.html
+++ b/docs/docs/permissions.html
@@ -74,6 +74,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -85,6 +86,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -228,6 +230,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/privacy-architecture.html
+++ b/docs/docs/privacy-architecture.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -239,6 +241,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/profile.html
+++ b/docs/docs/profile.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -198,6 +200,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/quickstart.html
+++ b/docs/docs/quickstart.html
@@ -76,6 +76,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -87,6 +88,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -230,6 +232,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/settings.html
+++ b/docs/docs/settings.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -188,6 +190,8 @@
             <tr><td>Reveal in Finder</td><td>—</td><td>Opens the folder holding your settings, history, and personalization files.</td></tr>
             <tr><td>Delete history…</td><td>—</td><td>Clears dictation history, with the option to keep your first-ever transcript.</td></tr>
             <tr><td>Show what was typed in the HUD</td><td>On</td><td>Echoes the tail of inserted text. Turn off when dictating sensitive material — the HUD shows a word count instead.</td></tr>
+            <tr><td>Share anonymous usage &amp; leaderboard rank</td><td>On</td><td>Powers the in-app Leaderboard. On by default since 0.5.7 — full detail in <a href="privacy-architecture.html#analytics">Analytics &amp; leaderboard</a>.</td></tr>
+            <tr><td>Delete my leaderboard data</td><td>—</td><td>Removes a past leaderboard submission outright; does not itself turn off future sharing.</td></tr>
             <tr><td>Automatic updates</td><td>On</td><td>Checks for signed updates in the background daily and installs them on next launch — see <a href="updates.html">Updates</a>.</td></tr>
           </tbody>
         </table>
@@ -219,6 +223,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/snippets.html
+++ b/docs/docs/snippets.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -202,6 +204,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/styles.html
+++ b/docs/docs/styles.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -207,6 +209,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/text-insertion.html
+++ b/docs/docs/text-insertion.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -197,6 +199,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -351,6 +353,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/uninstall.html
+++ b/docs/docs/uninstall.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -194,6 +196,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/docs/updates.html
+++ b/docs/docs/updates.html
@@ -60,6 +60,7 @@
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -71,6 +72,7 @@
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -196,6 +198,7 @@
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/docs/download.html
+++ b/docs/download.html
@@ -52,6 +52,7 @@
         <li><a href="install.html">Install</a></li>
         <li><a href="docs/index.html">Docs</a></li>
         <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -64,6 +65,7 @@
       <a href="how-it-works.html">How it works</a>
       <a href="docs/index.html">Docs</a>
       <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -172,6 +174,7 @@
         <a href="privacy.html">Privacy</a>
         <a href="docs/index.html">Docs</a>
         <a href="blog/index.html">Blog</a>
+        <a href="releases.html">Releases</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -41,6 +41,7 @@
         <li><a href="install.html">Install</a></li>
         <li><a href="docs/index.html">Docs</a></li>
         <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -53,6 +54,7 @@
       <a href="how-it-works.html">How it works</a>
       <a href="docs/index.html">Docs</a>
       <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -89,6 +91,7 @@
         <a href="privacy.html">Privacy</a>
         <a href="docs/index.html">Docs</a>
         <a href="blog/index.html">Blog</a>
+        <a href="releases.html">Releases</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,6 +113,7 @@
         <li><a href="install.html">Install</a></li>
         <li><a href="docs/index.html">Docs</a></li>
         <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -125,6 +126,7 @@
       <a href="how-it-works.html">How it works</a>
       <a href="docs/index.html">Docs</a>
       <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -385,6 +387,7 @@
         <a href="privacy.html">Privacy</a>
         <a href="docs/index.html">Docs</a>
         <a href="blog/index.html">Blog</a>
+        <a href="releases.html">Releases</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/install.html
+++ b/docs/install.html
@@ -41,6 +41,7 @@
         <li><a href="install.html">Install</a></li>
         <li><a href="docs/index.html">Docs</a></li>
         <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -53,6 +54,7 @@
       <a href="how-it-works.html">How it works</a>
       <a href="docs/index.html">Docs</a>
       <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -83,6 +85,7 @@
         <a href="privacy.html">Privacy</a>
         <a href="docs/index.html">Docs</a>
         <a href="blog/index.html">Blog</a>
+        <a href="releases.html">Releases</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,8 @@ OpenVoiceFlow is a free push-to-talk voice dictation app for macOS. It transcrib
 - Download page: https://openvoiceflow.com/download.html
 - Install guide: https://openvoiceflow.com/install.html
 - How it works: https://openvoiceflow.com/how-it-works.html
+- Releases (version history and release notes): https://openvoiceflow.com/releases.html
+- Source code (GitHub, MIT-licensed): https://github.com/shimoverse/openvoiceflow
 - Website-hosted universal macOS DMG (v0.5.20): https://openvoiceflow.com/downloads/OpenVoiceFlow-0.5.20.dmg
 - Website-hosted macOS 12–13 fallback (v0.3.6 Apple Silicon): https://openvoiceflow.com/downloads/OpenVoiceFlow-0.3.6-arm64.dmg
 - Product film (52-second MP4, original score, captioned): https://openvoiceflow.com/assets/openvoiceflow-demo.mp4

--- a/docs/mission.html
+++ b/docs/mission.html
@@ -48,6 +48,7 @@
         <li><a href="install.html">Install</a></li>
         <li><a href="docs/index.html">Docs</a></li>
         <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -60,6 +61,7 @@
       <a href="how-it-works.html">How it works</a>
       <a href="docs/index.html">Docs</a>
       <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -111,6 +113,7 @@
         <a href="privacy.html">Privacy</a>
         <a href="docs/index.html">Docs</a>
         <a href="blog/index.html">Blog</a>
+        <a href="releases.html">Releases</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -38,6 +38,7 @@
         <li><a href="install.html">Install</a></li>
         <li><a href="docs/index.html">Docs</a></li>
         <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
         <li><a href="download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -50,6 +51,7 @@
       <a href="how-it-works.html">How it works</a>
       <a href="docs/index.html">Docs</a>
       <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
       <a href="download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>
@@ -138,6 +140,7 @@
         <a href="how-it-works.html">How it works</a>
         <a href="docs/index.html">Docs</a>
         <a href="blog/index.html">Blog</a>
+        <a href="releases.html">Releases</a>
         <a href="llms.txt">llms.txt</a>
       </nav>
     </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -1,0 +1,491 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Releases — OpenVoiceFlow Version History</title>
+  <meta name="description" content="Every OpenVoiceFlow release with its notes, newest first: what shipped, what changed, and what was fixed, straight from the project's changelog." />
+  <meta property="og:title" content="OpenVoiceFlow release history" />
+  <meta property="og:description" content="Every OpenVoiceFlow release with its notes, newest first — see exactly what shipped and when." />
+  <meta property="og:url" content="https://openvoiceflow.com/releases.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html" />
+  <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="favicon-48.png" sizes="48x48" type="image/png" />
+  <link rel="icon" href="favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{display:none}</style>
+  <link rel="stylesheet" href="style.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": "OpenVoiceFlow release history",
+    "url": "https://openvoiceflow.com/releases.html",
+    "description": "Every OpenVoiceFlow release with its notes, newest first: what shipped, what changed, and what was fixed.",
+    "isPartOf": {"@type": "WebSite", "name": "OpenVoiceFlow", "url": "https://openvoiceflow.com/"}
+  }
+  </script>
+  <script>
+    window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+  </script>
+  <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
+</head>
+<body>
+  <nav class="nav" id="nav" aria-label="Main">
+    <div class="nav-inner container">
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
+      <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
+        <li><a href="how-it-works.html">How it works</a></li>
+        <li><a href="install.html">Install</a></li>
+        <li><a href="docs/index.html">Docs</a></li>
+        <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
+      </ul>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
+    </div>
+    <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
+      <a href="download.html">Download</a>
+      <a href="install.html">Install</a>
+      <a href="how-it-works.html">How it works</a>
+      <a href="docs/index.html">Docs</a>
+      <a href="blog/index.html">Blog</a>
+      <a href="https://github.com/shimoverse/openvoiceflow" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
+      <a href="download.html" class="btn btn-primary">Download for Mac</a>
+    </div>
+  </nav>
+
+  <main>
+    <section class="page-hero"><div class="container hero-inner">
+      <h1 class="hero-title">Releases</h1>
+      <p class="hero-sub answer-block">OpenVoiceFlow ships often — every release below is real, shipped, and notarized, newest first. Notes come straight from the project's changelog, so this list is exactly as current as the code. Want the raw commit history or to file an issue? <a href="https://github.com/shimoverse/openvoiceflow/releases">See every release on GitHub</a>.</p>
+
+      <details class="content-card" open><summary><h2>v0.5.20 <span class="release-date">· September 2, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>The leaderboard now labels its figure "time back" instead of "time saved", matching Home, onboarding, and the manual. The number is how long the same words would have taken to type at 40 wpm; nothing subtracts the time dictating them actually took, so calling it a saving overstated it. The number itself is unchanged, as are the <code>minutesSaved</code> field and <code>minutes_saved</code> column that already-shipped clients depend on.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.19 <span class="release-date">· September 2, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>The leaderboard now draws a fixed seven rows whatever the standings return, so the height of the card no longer reveals how many people use OpenVoiceFlow. Rows the service doesn't name are masked — a shimmering placeholder with no rank, name, or total — and the tail fades out rather than ending on a countable last row. The card states no rule and shows no threshold: naming the bar would let anyone counting the visible names work out what population they were counting.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.18 <span class="release-date">· August 31, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Public leaderboard standings now include only rows with at least 60 minutes saved and show no more than five entries, while still showing your own row separately.</li>
+          <li>Legacy auto-generated leaderboard names now use the same exact 10–99 suffix range as the native app, preserving custom-looking names ending in 00–09.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.17 <span class="release-date">· August 30, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>App names across Home, History, and Personalize now use recognizable app or company logos, including Claude, Discord, Notion, and Outlook. Installed macOS app icons remain the first choice, with bundled brand marks as reliable fallbacks.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>Leaderboard nicknames now save when Return is pressed or the field loses focus, immediately publish that installation's aggregate totals, and refresh the standings after a successful update. Each installation keeps its own row even when multiple computers use the same nickname.</li>
+          <li>Opening Leaderboard now republishes that installation's saved aggregate totals before fetching standings, restoring existing local usage without requiring another dictation or nickname change.</li>
+          <li>The leaderboard service now uses Neon's supported serverless database client and accepts both current and legacy Vercel database environment-variable names.</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>History's Copy action now changes to “Copied” with a checkmark after a successful copy and resets automatically after 1.5 seconds.</li>
+          <li>Leaderboard loading and nickname-sync failures now show an honest retry action instead of appearing as empty standings.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.16 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Personalized Styles now shows recognizable Discord and Gmail icons, using installed app icons first and bundled brand marks when those apps are unavailable.</li>
+          <li>Clicking the dashboard outside the centered Feedback sheet now dismisses it, while clicks inside the sheet or in unrelated OpenVoiceFlow windows keep their normal behavior.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.15 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Restored Feedback as a centered native modal instead of a left-anchored popover, while retaining the always-visible optional email field and Cancel, Send, and Escape dismissal.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.14 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>Simplified feedback to one optional email field in a native macOS popover that dismisses with Cancel, Send, Escape, or an outside click.</li>
+          <li>Moved Know Me into Personalize so related controls stay together.</li>
+          <li>Changed generated leaderboard aliases to compact one-token handles while preserving custom names during legacy migration.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.13 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>Settings no longer exposes the anonymous analytics device ID or the long leaderboard-sharing explanation, and the Feedback sheet no longer shows its usage-snapshot explainer. The sharing toggle, leaderboard name, deletion action, and feedback behavior are unchanged.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.12 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>“Where you dictate” now shows each app’s real icon with a time-share ring, making the per-app breakdown easier to scan while preserving the existing local-only usage data and accessibility labels.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.11 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>The History pane now carries a subtitle: "Stored only on this Mac — never synced to a server." Scoped deliberately to what's true unconditionally (this list is local storage, full stop) rather than a blanket "nothing leaves this machine" claim, since cloud AI cleanup (opt-in, off by default) does send dictated text to the selected provider before it lands here — that's covered separately by the existing footer line and the privacy docs.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.10 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>Dictionary, Snippets, and Styles are now one <strong>Personalize</strong> pane in the dashboard sidebar, switched with tabs instead of three separate rows. Each tab keeps its item count, the content area now sits in a single card, and switching tabs animates instead of jumping. No data or behavior changes — same stores, same add/remove actions, same empty states. Docs updated to describe the new location (<code>Dashboard ▸ Personalize</code>).</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.9 <span class="release-date">· August 29, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The Feedback sheet's category picker ("Something's broken" / "Feature idea" / "Just saying thanks" / "Something else") overflowed a 440pt-wide sheet, truncating the leading and trailing segments. Segmented control now shows short labels (Bug/Idea/Thanks/Other); the full wording still goes into the email subject and body. Sheet widened to 480pt for margin.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.8 <span class="release-date">· August 28, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>Anonymous usage sharing and an in-app Leaderboard, ranked by time saved. <strong>On by default</strong> — a real, disclosed change from every prior release, which sent nothing. Settings ▸ Privacy ▸ "Share anonymous usage &amp; leaderboard rank" turns it off, deletes nothing retroactively but stops every future request immediately; a "Delete my leaderboard data" button removes a past submission outright. What's sent: a random per-device ID, a display name you can change, aggregate word/time/streak/feature-usage counters already shown on Home, and a server-derived country (no IP stored). Never dictation text, snippets, dictionary entries, or the Know-Me profile. Full detail in <code>PRIVACY.md</code> §7 and the docs site's Privacy architecture ▸ Analytics &amp; leaderboard section.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>Docs and <code>PRIVACY.md</code> updated to describe the above plainly, replacing the "no telemetry" claims that were accurate through 0.5.7 and are not anymore.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.7 <span class="release-date">· August 28, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>A Feedback item in the sidebar, below Settings. Opens a short form (bug / idea / praise / other, plus an optional reply email) and, only on Send, opens a <code>mailto:</code> with the message and a small aggregate usage snapshot (words dictated, time saved, streak, last 7 days, first-use date) — never dictation text, snippets, dictionary entries, or the Know-Me profile, and nothing is sent until Send is pressed.</li>
+        </ul>
+      </details>
+      <details class="content-card" open><summary><h2>v0.5.6 <span class="release-date">· August 25, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>The language picker now offers all 99 languages in Whisper's multilingual set (previously eleven), including Ukrainian. Tiny, Small, Medium, and Large turbo all share the same tokenizer, so the list applies to every engine offered in Settings.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.5.5 <span class="release-date">· July 27, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The progress bar no longer parks at 100% with no way forward. WhisperKit compiles the model for your chip after the download — minutes on a first large-model run, with no progress signal — so the transfer now owns 0–90% and the compile creeps through the 90s under "Downloaded — now optimizing for your Mac. First run only." 100% arrives only with the Try It button.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>RECOMMENDED now adapts to the Mac: Large turbo on Apple Silicon with disk headroom, Small on Intel or a tight disk. No permissions involved.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.5.4 <span class="release-date">· July 27, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The download meter showed "0 of 0 MB · 0.0 MB/s" over a moving bar: WhisperKit reports abstract progress units for multi-file model downloads, not bytes. The meter now shows percent (and the always-honest ETA) when units can't be bytes, instead of inventing megabytes.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.5.3 <span class="release-date">· July 27, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li><strong>Large turbo could never download.</strong> Its model id didn't exist in the WhisperKit repo; every user who chose it hit "no models found" disguised as a connection error. Correct id shipped, saved settings migrate silently.</li>
+          <li>Browsing the engine chooser no longer starts a download per click: a 1.5 s grace window ("Starting in a moment — switch engines freely") starts the transfer only once the choice rests, and switching cancels the superseded download outright. Model loads are single-flight, so overlapping transfers can no longer corrupt each other's cache.</li>
+          <li>Download failure copy points at Details instead of guessing "check your connection" — the guess was wrong exactly when it mattered.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.5.2 <span class="release-date">· July 26, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>Live transcript in the HUD while the key is held ("Show words as you speak", default on; respects the text-echo privacy setting).</li>
+          <li>Speech-engine choice in onboarding — four models with size and benefit, nothing preselected, nothing downloading until you pick.</li>
+          <li>Launch at login (SMAppService), default on, with a Settings toggle.</li>
+          <li>Onboarding's "I live up there" now anchors a callout to the real menu-bar icon, with a mock menu-bar illustration when the icon is squeezed out.</li>
+          <li>Dashboard banner explaining when macOS hides the menu-bar icon (full bar / notch) and the ⌘-drag fix.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>Onboarding ends in the dashboard instead of an empty desktop; the try-it card acknowledges key-down instantly.</li>
+          <li>The "names I'd get wrong" question moved out of onboarding (Know-Me keeps it).</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.5.1 <span class="release-date">· July 26, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li><strong>The hotkey now works from launch.</strong> Previously nothing started the key listener after first run — every relaunch came up deaf until Start Dictation was clicked in the menu. The Start/Stop menu item is gone (Pause remains); a Turn On Dictation button appears only if a permission was revoked.</li>
+        </ul>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>PERMISSIONS card in dashboard Settings with live status per grant; re-granting revives dictation without a relaunch.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.4.3 <span class="release-date">· July 26, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Dock presence obeys the setting; <code>fn</code> is the default hotkey; onboarding gives real feedback while permissions land.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.4.2 <span class="release-date">· July 25, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>Automatic background updates (Sparkle) with honest in-app update cues.</li>
+          <li>Per-app dictation breakdown ("Where you dictate").</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Failed pastes recover; the transcription model hot-swaps without restart.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.6 <span class="release-date">· July 18, 2026</span></h2></summary>
+        <h3>Fixed — Fn / 🌐 Globe key no longer fails silently</h3>
+        <ul class="check-list">
+          <li><strong>Fn was never a working hotkey.</strong> macOS doesn't deliver the Fn/Globe key to <code>pynput</code>, so selecting it left dictation permanently dead with no feedback. Choosing Fn now surfaces an immediate modal explaining the limitation and pointing at Right Command (the default), the menu-bar picker hides Fn unless it's the current (legacy) selection, and onboarding no longer offers it.</li>
+        </ul>
+        <h3>Fixed — production-hardening pass (end-to-end audit follow-up)</h3>
+        <ul class="check-list">
+          <li><strong>Hotkey can't be wedged by a consent dialog.</strong> The microphone is now armed on the event-tap thread and the ~150 ms of <code>osascript</code> context capture runs on a worker, so a stalled Automation/Accessibility dialog can no longer block (and let macOS disable) the global hotkey.</li>
+          <li><strong>Runaway recordings self-terminate.</strong> A max-duration watchdog force-stops a dictation whose key-release was lost, instead of leaving the mic and <code>whisper-stream</code> running indefinitely.</li>
+          <li><strong>No PortAudio stream leak.</strong> <code>recorder.stop()</code> always releases the audio stream even when the input device is unplugged mid-recording; that failure is now surfaced instead of silently freezing the overlay.</li>
+          <li><strong>Clipboard data-loss fixed.</strong> Selected-text capture no longer overwrites a non-text clipboard (image/file) and never restores empty text over the selection.</li>
+          <li><strong>Security defense-in-depth.</strong> Secrets are written with <code>O_EXCL|O_NOFOLLOW</code> (symlink-swap safe); <code>~/.openvoiceflow/logs/</code> is <code>0700</code>; LLM/Ollama responses are read with a 16 MB cap; <code>ollama_url</code> rejects non-HTTP schemes and warns when it points off-box. Hung <code>pbcopy</code> children are reaped, not orphaned.</li>
+          <li><strong>Upgrades actually reinstall dependencies.</strong> The DMG venv marker is now version-stamped, so a release that adds or bumps a dependency reinstalls for existing upgraders instead of breaking on import.</li>
+          <li><strong>Overlay polish.</strong> HUD timers run in the common run-loop mode (no freeze during menu tracking), fades honor Reduce Motion, and the window is ordered out after fading so it doesn't linger in every Space.</li>
+          <li><strong>Know-Me interview no longer self-destructs</strong> when Escape is pressed while a text field is focused.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.5 <span class="release-date">· July 13, 2026</span></h2></summary>
+        <h3>Fixed — first launch could silently do nothing (no menu bar icon, no wizard)</h3>
+        <ul class="check-list">
+          <li><strong>Stale bootstrap lock.</strong> <code>~/.openvoiceflow/.bootstrap.lock</code> survives reboots, and its stored pid could be reused by an unrelated live process — the alive check then matched, so every launch exited silently forever. The lock now only counts when the pid is alive *and* is really our <code>launcher.sh</code>.</li>
+          <li><strong>Command Line Tools stub.</strong> <code>command -v python3</code> always succeeds on macOS (Apple ships an installer stub), so a Mac without the Command Line Tools got past the check and failed later with no message. First launch now probes <code>xcode-select</code>, triggers the CLT installer, and shows instructions.</li>
+          <li><strong>Broken venv skipped as "installed".</strong> A macOS/CLT update can break the venv's interpreter or native wheels while the <code>.ovf-deps-installed</code> marker stays present, so the bootstrap was skipped and every launch died on import. The launcher now health-checks the venv (imports numpy/sounddevice/pynput/ rumps/objc) and rebuilds it when the check fails.</li>
+          <li><strong>Silent progress + silent fallbacks.</strong> First launch now shows an up-front dialog explaining the ~5-minute setup and where the menu bar icon appears (including the 14"/16" notch tip); the venv/pip steps fail with a visible dialog instead of exiting quietly; a skipped setup wizard and a menu-bar (rumps) failure now say so instead of dropping to an invisible background process.</li>
+          <li><strong>Input Monitoring permission (native launcher).</strong> The native launcher now proactively requests Input Monitoring (<code>IOHIDRequestAccess</code>) at first launch, in addition to Microphone and Accessibility, so the grant is in place before the dead-listener watchdog would ever need to fire.</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Startup now checks the <strong>Input Monitoring</strong> permission — the one the global hotkey listener actually needs. It was never verified (only the doctor knew about it), so a missing grant produced a "Ready" menu with a hotkey that silently never fired. A denied probe warns loudly with a one-click System Settings link but never blocks startup, because Accessibility trust can also grant listen access.</li>
+          <li>A new dead-listener watchdog catches the same failure by measuring reality: if no key events at all arrive within 15 seconds of the listener starting *and* macOS reports Input Monitoring denied, the menu bar shows a front-and-center alert with the fix. An idle user without the permission problem gets a one-time gentle tip instead. (Previously this self-check existed only for the fn/Globe key, never for the default Right Command hotkey.)</li>
+          <li>Setup failures at launch now surface as a <strong>modal alert</strong> with a one-click settings link instead of only a Notification Center banner — notifications require a permission of their own and the status item can hide behind a MacBook notch, so the old failure path could be entirely invisible.</li>
+          <li>A corrupt or wrong-shaped file in <code>~/.openvoiceflow/</code> (snippets, stats, profile, dictionary aliases, transcript logs, seen-tips) can no longer make every dictation fail with a generic error: all user-data loaders now validate shape, drop malformed entries, and degrade to safe defaults. <code>--show-profile</code> prints recovery guidance instead of a literal <code>null</code> when the profile file is corrupt.</li>
+          <li>Every <code>osascript</code>/<code>launchctl</code>/<code>open</code> subprocess call now has a timeout, so a pending macOS consent dialog or a wedged <code>launchd</code> can no longer freeze the hotkey thread permanently. If auto-paste times out, a notification explains that the text is already on the clipboard, ready for ⌘V.</li>
+          <li>Auto-learn no longer records ordinary content edits (e.g. "june" → "july") as permanent corrections: the word-similarity threshold was raised from 0.4 to 0.55, calibrated so genuine mishearings ("mir" → "Meer", "recieve" → "receive") are still learned.</li>
+          <li>Setup wizard: an <code>llm_backend</code> of <code>none</code> no longer breaks the backend screen; switching backends clears the previous backend's prefilled API key instead of finishing without saving a key; a failed final config write now shows an error dialog instead of a Finish button that silently does nothing.</li>
+          <li>Know Me interview: no longer clobbers a configured <code>--style</code> (the style radio preselects from config, and styles the interview can't express, like <code>code</code> or <code>email</code>, are preserved unless actively changed); Enter-key bindings no longer leak between screens; context-menu paste into multi-line fields is no longer dropped; a hand-edited profile can't crash the wizard.</li>
+          <li>Menu bar: notifications fall back to the osascript path when <code>rumps.notification</code> is unavailable (non-framework Python installs), and <strong>Check for Updates…</strong> can no longer get stuck on unexpected network/response errors. The duplicate startup update check in menu-bar mode was removed.</li>
+          <li>Overlay: the compact auto-learn pill no longer permanently shrinks the font of every subsequent HUD message.</li>
+          <li>CLI: value-taking flags now reject empty strings (<code>--search ""</code> used to launch the app; <code>--add-command ""</code> corrupted every dictation); config setters combined with an action flag now print a warning instead of being silently ignored; <code>--auto-learn</code>, <code>--update-check</code>, and <code>--log-transcripts</code> now compose on one command line.</li>
+          <li>Doctor: macOS version detection resolves the "10.16" Big Sur compatibility shim via <code>sysctl kern.osproductversion</code> and reports "unknown" (a WARN) rather than false-failing supported systems; bare-major versions ("12") no longer compare below the (12, 0) minimum.</li>
+        </ul>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>CI now compiles the native launcher (<code>clang -fsyntax-only</code>) and runs a functional test suite (<code>tests/test_launcher_flows.py</code>) that renders the real <code>launcher.sh</code> and exercises the stale-lock, missing-CLT, broken-venv, and first-run-visibility paths with shimmed macOS commands.</li>
+          <li>The menu-bar app now shows a <strong>Dock icon</strong> while running (toggleable via <strong>Advanced → Show in Dock</strong>, default on). A menu-bar-only icon can hide behind a MacBook notch, leaving no visible sign the app is running; clicking the Dock icon opens the native status summary with the active dictation shortcut.</li>
+          <li>17 regression tests pinning the defensive-loader, learner-threshold, updater, and macOS-version behaviors (<code>tests/test_defensive_loaders.py</code>), plus 12 pinning the Input Monitoring gate, dead-listener watchdog, and Dock default (<code>tests/test_visibility_and_watchdog.py</code>).</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>CI lint now covers the entire repository (<code>ruff check .</code>), not just <code>voiceflow/</code>.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.4 <span class="release-date">· July 10, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>A polished native menu-bar experience led by <strong>Open OpenVoiceFlow</strong>, with grouped Dictation Shortcut, AI Cleanup, Writing Style, Personalization, and Advanced menus.</li>
+          <li>A user-triggered <strong>Check for Updates…</strong> action that always reports whether a release is available, the app is current, or the service could not be reached.</li>
+          <li>Direct menu links to macOS Microphone and Accessibility settings.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>The status item now uses dark-mode-safe SF Symbols with accessible labels: a waveform while ready, a pause symbol while paused, and a warning symbol when setup needs attention. A visible <code>OpenVoiceFlow</code> text label remains as the fallback if symbols are unavailable.</li>
+          <li>Menu selections now use native macOS checkmarks, clean human-readable names, every supported dictation shortcut, standard separators, and <strong>⌘Q</strong> for <strong>Quit OpenVoiceFlow</strong> instead of emoji-prefixed labels.</li>
+          <li>The long-lived Python UI process now stays out of the Dock and uses the bundled OpenVoiceFlow icon for native dialogs. The Current App row refreshes as focus changes without mistaking the UI process for the user's app.</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The waveform status item is created before backend validation begins, so a slow local backend no longer makes launch look unresponsive.</li>
+          <li><strong>Edit Profile</strong> now runs its Tk interview in an isolated process instead of risking a native Tk crash in the menu-bar process.</li>
+          <li>The <strong>Download</strong> button in the update alert now recognizes AppKit's native button result and opens the release page correctly.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.3 <span class="release-date">· July 10, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>The menu-bar menu now includes a persistent <strong>How to Use</strong> guide, and the first-run hotkey tip also appears in the floating HUD instead of relying only on a potentially hidden macOS notification.</li>
+          <li><code>voiceflow/platform_support.py</code>: one place for OS, macOS-version, architecture (Apple Silicon / Intel / Rosetta), and permission detection.</li>
+          <li>CLI platform gate: on Linux/Windows, <code>openvoiceflow</code> now prints a clear "macOS-only" explanation with uninstall guidance and exits cleanly instead of crashing with a traceback. <code>--doctor</code> and <code>--show-config</code> keep working so users can inspect state first.</li>
+          <li>New doctor checks: operating system + version, architecture (warns on Rosetta-translated Python and Intel Homebrew on Apple Silicon), and the three macOS permissions dictation depends on (Microphone, Accessibility, Input Monitoring) with click-to-fix System Settings links.</li>
+          <li>A launch below the supported macOS floor (12 Monterey) now prints an upgrade warning.</li>
+          <li>CI: new <code>non-macos-guard</code> job on <code>ubuntu-latest</code> pins the "friendly message, never a traceback" guarantee and runs the full suite on Linux.</li>
+          <li>Website: the download page now detects the visitor's OS. Windows, Linux, ChromeOS, Android, and iPhone/iPad visitors get an inert "Not available for &lt;OS&gt;" notice instead of a live DMG button; Safari-on-Mac visitors get an Apple Silicon / Intel recommendation via a WebGL renderer fallback (Chromium browsers already used architecture hints).</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Short streaming dictations no longer lose the final transcript fragment when <code>whisper-stream</code> exits without a trailing newline.</li>
+          <li>Fresh installs now use the reliable batch recorder by default. Experimental real-time streaming remains available through the menu bar or <code>--streaming on</code>. Existing v0.3.2 installs are reset to batch mode once and can opt back into streaming afterward.</li>
+          <li><code>voiceflow.recorder</code> no longer imports <code>sounddevice</code> at module load — the import crashed the whole app (<code>OSError: PortAudio library not found</code>) on machines without PortAudio before any error handling could run.</li>
+          <li><code>find_whisper_cpp</code> / the doctor's Homebrew check use <code>shutil.which</code> instead of spawning <code>which</code>, which crashed on Windows.</li>
+          <li>The keyboard-listener (pynput) import is now guarded in CLI and menu-bar modes: a missing input backend produces a clear error instead of a crash.</li>
+          <li>Clipboard/keystroke/sound helpers (<code>pbcopy</code>, <code>pbpaste</code>, <code>osascript</code>, <code>afplay</code>) no longer propagate <code>FileNotFoundError</code> when the binaries are missing; failures surface as user-visible notifications.</li>
+          <li><code>--autostart</code> refuses politely off-macOS instead of writing a <code>~/Library/LaunchAgents</code> folder on Linux; on macOS it now prefers the supported <code>launchctl bootstrap</code>/<code>bootout</code> verbs, falling back to the deprecated <code>load</code>/<code>unload</code>.</li>
+          <li><code>validate_setup</code> reports a broken audio backend (<code>OSError</code>) instead of only a missing <code>sounddevice</code> package.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.2 <span class="release-date">· July 9, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The DMG bootstrap now executes the virtual-environment Python interpreter at its original path, preventing a silent dynamic-library crash on launch.</li>
+          <li>Native startup failures now show an alert with a direct link to the launcher log instead of making the app appear to do nothing.</li>
+          <li>First-run Tk onboarding runs in an isolated process, so an incompatible system Tk build falls back to local transcription without killing the app.</li>
+          <li>Menu-bar settings no longer clear uninitialized native submenus during startup.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.1 <span class="release-date">· July 9, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The notarized macOS app now carries the hardened-runtime entitlements for microphone input and Apple Events, allowing recording and auto-paste to pass macOS privacy enforcement.</li>
+          <li>DMGs now use a small native launcher so macOS attributes Microphone and Accessibility consent to OpenVoiceFlow instead of its Python bootstrap.</li>
+          <li>First launch uses the native macOS consent prompts and no longer stacks two conflicting custom permission dialogs.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.3.0 <span class="release-date">· July 8, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>Pytest scaffold under <code>tests/</code> with regression tests for every Wave-1 ship-stopper (<code>test_python39_compat</code>, <code>test_install_sh</code>, <code>test_config_migration</code>, <code>test_onboarding</code>, <code>test_voice_commands_count</code>, <code>test_updater</code>) plus privacy invariants (<code>test_chmod_600</code>, <code>test_privacy_defaults</code>) and package smoke tests. 60 tests total, green on Python 3.9, 3.10, and 3.11.</li>
+          <li><code>[dev]</code> extras in <code>pyproject.toml</code> (pytest, pytest-cov, ruff, build, twine).</li>
+          <li>CI Python matrix: 3.9, 3.10, 3.11 on macos-latest. Lint is now a blocking step. A separate <code>build</code> job exercises <code>python -m build</code> and <code>twine check</code>.</li>
+          <li><code>--update-check on/off</code> CLI flag and matching <code>update_check</code> config key for opting out of the daily GitHub-Releases ping.</li>
+          <li><code>--log-transcripts on/off</code> CLI flag for explicit control of the <code>~/.openvoiceflow/logs/</code> daily files.</li>
+          <li>"Privacy at a glance" panel in the README that maps every on-disk file and every network egress in one table.</li>
+          <li><code>voiceflow/_secure_io.py</code> — <code>secure_write_json()</code> and <code>secure_chmod()</code> helpers that all config / profile / dictionary / snippets / stats / daily-log writes now go through, enforcing mode 600.</li>
+          <li>Community-health docs: SECURITY, PRIVACY, CONTRIBUTING, CODE_OF_CONDUCT, SUPPORT, VERSIONING, AGENTS, plus docs/COMPLIANCE, docs/COMPATIBILITY, docs/THREAT_MODEL, docs/ARCHITECTURE, docs/legal/DPA-template, docs/legal/THIRD_PARTY_NOTICES. ~14 files, ~2,100 lines.</li>
+          <li><code>RELEASE.md</code> — maintainer's three-command playbook plus when-things-go-wrong table.</li>
+          <li><code>.github/workflows/release.yml</code> rebuilt: tag-driven, Trusted Publisher PyPI publish on non-pre-release tags, split arm64/x86_64 DMG attach, <code>verify-version</code> gate that fails the release if tag ↔ pyproject ↔ <code>__version__</code> disagree.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li><strong>Config-key migration:</strong> <code>cleanup_prompt</code> → <code>llm_prompt</code>. Existing <code>~/.openvoiceflow/config.json</code> files are migrated transparently on load; the rename was the v0.2.0 schema change that previously dropped users' custom prompts on upgrade. (Fixes SS5.)</li>
+          <li><strong>Privacy defaults flipped to off for fresh installs.</strong> New users get <code>log_transcripts: False</code> and <code>auto_learn: False</code> until they opt in via the Know Me onboarding interview. <strong>Existing users keep their setting</strong> — the migration logic only applies the new defaults when no config exists.</li>
+          <li><code>install.sh</code> shim now <code>exec</code>s the pip-installed <code>openvoiceflow</code> console script directly instead of <code>python3 -m openvoiceflow</code> (which never existed — the module is <code>voiceflow</code>). (Fixes SS2.)</li>
+          <li><strong>Lint is now blocking in CI.</strong> Previously <code>ruff check</code> was advisory; the 43-finding backlog meant noise floor only ever climbed.</li>
+          <li>README hero rewritten so the privacy framing matches the actual data flow (audio is local; transcripts go to whatever LLM backend you pick; default Gemini is cloud, Ollama is local).</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li><strong>Code-review pass (2026-07)</strong> — full-codebase review; the notable fixes: - Streaming mode + snippet match no longer crashes with a <code>NameError</code> (the dictation was silently lost with only an error sound). - OpenAI, Anthropic, and Groq backends now honor per-app style and app context (previously silently dropped — the per-app style feature only worked on OpenRouter/Ollama). - Empty LLM responses fall back to the raw transcript instead of pasting nothing. - Custom voice commands containing backslashes no longer crash every dictation; command expansions are no longer re-processed by later commands (single-pass replacement). - Snippet triggers only match on word boundaries — a trigger like <code>sig</code> no longer swallows a dictation starting with "significant…". - Menu bar: LLM Backend / Hotkey / Style submenus are now populated at startup (previously empty until first use); Streaming/Auto-Style/ Auto-Learn toggles now apply to the running session; stopping or quitting aborts an in-flight recording instead of orphaning the whisper-stream process (hot mic). - Corrupt <code>config.json</code> no longer bricks every CLI entry point — the bad file is preserved as <code>config.json.corrupt</code> and defaults are restored. - Whisper model downloads use <code>curl --fail</code> with a temp file, so an HTTP error page or interrupted transfer can't be mistaken for a valid model forever after (fixed in <code>transcriber.py</code>, <code>install.sh</code>, and the DMG launcher). - Batch transcription timeout raised 30 s → 300 s so long dictations aren't discarded; Ollama cleanup timeout raised 30 s → 120 s for cold model loads. - Mic failures during recording start are surfaced (notification + error sound) instead of being silently swallowed with stale state. - Overlay no longer sticks on screen after too-short/no-speech/error aborts. - Selected-text capture no longer erases image/file clipboards when nothing was selected; <code>pbpaste</code>/<code>pbcopy</code> calls have timeouts. - <code>--show-config</code> no longer masks <code>hotkey</code> (over-broad secret matching); <code>--streaming-step</code> validates its value and <code>0</code> is no longer ignored; <code>--language</code> no longer crashes on a null <code>whisper_model</code>; env-var-only API-key setups aren't forced through onboarding on every launch. - Onboarding: re-running the wizard and switching backends no longer saves the old backend's key under the new backend's field; the Finish button survives a corrupt config; headless runs fail with instructions instead of a traceback (also fixed for <code>--profile</code>). - Interview: pressing Escape on the final screen no longer mislabels a saved profile as skipped. - <code>--autostart on</code> fails with a clear message when the executable can't be resolved (previously installed a LaunchAgent that silently never launched); the plist is generated with <code>plistlib</code> so paths containing <code>&amp;</code> can't produce invalid XML. - <code>install.sh</code> works under <code>curl | bash</code> (wizard prompts read from <code>/dev/tty</code>), installs from the script's own directory instead of the CWD, creates <code>~/.zshrc</code> when no shell rc exists, and uses <code>set -euo pipefail</code>. - Release workflow: DMG job sequenced after the PyPI job so the two release-upload steps can't race creating the same GitHub Release.</li>
+        </ul>
+        <h3>Changed (code-review pass)</h3>
+        <ul class="check-list">
+          <li>The typed 🎙 recording indicator is now opt-in (<code>"recording_indicator": true</code>): it edits the frontmost document and could delete a user character when focus changed mid-dictation; the overlay HUD remains the default recording feedback.</li>
+          <li><code>paste_text</code> no longer moves the caret to end-of-line before pasting — text is pasted at the cursor, as documented.</li>
+          <li><code>--set-key BACKEND -</code> reads the key from stdin so it stays out of shell history and <code>ps</code> output (used by <code>install.sh</code>, which also hides key input).</li>
+        </ul>
+        <h3>Security (code-review pass)</h3>
+        <ul class="check-list">
+          <li>Config/profile/dictionary writes are atomic and created with mode 600 from the first byte (previously created 644 then chmod'd — a crash mid-write could truncate the file or leave secrets world-readable).</li>
+          <li><code>~/.openvoiceflow/</code> is chmod 700; LaunchAgent stdout/stderr logs are pre-created with mode 600 (they capture dictated text via stdout).</li>
+          <li>Update-notification strings from the GitHub API are escaped before AppleScript interpolation (a crafted release tag/URL could otherwise break out of the string literal).</li>
+          <li>Internal <code>docs/superpowers/</code> documents removed from the repository, and the website build excludes any such directory as defense-in-depth.</li>
+          <li><strong>SS2</strong> — <code>install.sh</code> shim no longer crashes with <code>ModuleNotFoundError: No module named 'openvoiceflow'</code>.</li>
+          <li><strong>SS3</strong> — <code>from __future__ import annotations</code> added to all 30 modules using <code>X | None</code> syntax. <code>pip install .</code> and <code>openvoiceflow --version</code> now work on Python 3.9 (macOS 12 default) in addition to 3.10 / 3.11.</li>
+          <li><strong>SS5</strong> — Silent loss of custom <code>cleanup_prompt</code> on v0.1 → v0.2 upgrade. Migration now preserves the user's prompt under the new key.</li>
+          <li><strong>SS6</strong> — Onboarding "Personalize OpenVoiceFlow" button no longer silently swallows every exception from <code>interview.run_interview()</code>. Errors surface with a logged traceback and an in-app message.</li>
+          <li>The cargo-culted PyObjC import in <code>overlay.py</code> that broke the module for anyone installing without the <code>[overlay]</code> extra.</li>
+          <li>43 lint findings (37 unused imports, 4 placeholder-less f-strings, 1 multiple-statements, 1 unused variable). All resolved; lint now gates CI.</li>
+        </ul>
+        <h3>Security</h3>
+        <ul class="check-list">
+          <li>All <code>~/.openvoiceflow/*.json</code> files (config, profile, dictionary, snippets, stats) and the daily transcript logs are written with mode 600 — owner-only — instead of inheriting umask 022. API keys and personal data are no longer world-readable on default macOS user accounts.</li>
+          <li>Lint gating in CI closes the "style debt grew silently" loop.</li>
+          <li>Twelve community-health files added so a procurement reviewer can find the answers they need without filing an issue: <code>SECURITY.md</code>, <code>PRIVACY.md</code>, <code>THREAT_MODEL.md</code>, <code>COMPLIANCE.md</code>, <code>CODE_OF_CONDUCT.md</code>, <code>CONTRIBUTING.md</code>, <code>SUPPORT.md</code>, <code>CHANGELOG.md</code> (this file), <code>VERSIONING.md</code>, <code>COMPATIBILITY.md</code>, <code>legal/DPA-template.md</code>, <code>legal/THIRD_PARTY_NOTICES.md</code>.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.2.0 <span class="release-date">· March 15, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li><strong>Know Me</strong> — tkinter onboarding interview. Captures name, occupation, industry, frequently-mentioned names/tools, communication style. Output is injected into every LLM cleanup prompt as system context.</li>
+          <li><strong>Auto-learn</strong> — watches the focused text field via the macOS Accessibility API for 30 seconds after every paste and learns word-level substitutions from your edits. Levenshtein-gated, substitutions only (never inserts/deletes), 5-sample minimum.</li>
+          <li><strong>Streaming transcription</strong> via <code>whisper-stream</code> with refinement-replacement and Jaccard-overlap deduplication. Falls back to non-streaming for the canonical text.</li>
+          <li><strong>Per-app context + per-app styles</strong> — frontmost-app detection via Apple events; the cleanup prompt picks up the right style automatically (e.g. terse in Slack, formal in Mail).</li>
+          <li><strong>Voice commands</strong> — say "new line", "period", "delete that", etc. Configurable via <code>--add-command</code> / <code>--remove-command</code> / <code>--list-commands</code> / <code>--voice-commands on/off</code>.</li>
+          <li><strong>Clipboard / selected-text context</strong> — whatever's selected when you start dictating gets handed to the LLM as context.</li>
+          <li><strong>History search</strong> — <code>--search QUERY</code> greps the daily transcript logs.</li>
+          <li><strong>Voice snippets</strong> — trigger-phrase → expansion. <code>--add-snippet</code> / <code>--remove-snippet</code> / <code>--list-snippets</code>.</li>
+          <li><strong>Personal dictionary</strong> — proper-noun and acronym table. <code>--add-word</code> / <code>--remove-word</code> / <code>--list-words</code>.</li>
+          <li><strong>Launch-at-login</strong> — <code>--autostart on/off</code>; writes a LaunchAgent plist.</li>
+          <li><strong>Statistics</strong> — <code>--stats</code> shows dictations, words, time saved.</li>
+          <li><strong>Auto-update notifier</strong> — once-a-day check against the GitHub Releases API; quiet on failure.</li>
+          <li><strong>Floating macOS overlay HUD</strong> — visual feedback during recording, streaming, and auto-learn moments.</li>
+          <li>New CLI flags across the board: <code>--version</code>, <code>--show-config</code>, <code>--set-prompt</code>, <code>--clear-prompt</code>, <code>--set-key</code>, <code>--app-style</code>, <code>--remove-app-style</code>, <code>--list-app-styles</code>, <code>--auto-style on/off</code>, <code>--streaming on/off</code>, <code>--auto-learn on/off</code>.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>DMG installer split into separate <code>arm64</code> and <code>x86_64</code> artifacts — one-click install on any Mac, no Rosetta dance.</li>
+          <li><code>pyproject.toml</code> gained an <code>[overlay]</code> extra for the optional PyObjC dependencies (Cocoa, Quartz). <code>rumps</code> (the menubar lib) transitively installs Cocoa, so menubar users get the HUD by default.</li>
+          <li>Codebase grew from ~13 modules to ~28. Backend <code>cleanup()</code> interface now accepts <code>context</code>, <code>app_context</code>, <code>override_style</code>; all 5 existing backends were updated consistently.</li>
+          <li>Anthropic default model: <code>claude-3-5-haiku-20241022</code>.</li>
+          <li>Groq default model: <code>llama-3.1-8b-instant</code>.</li>
+        </ul>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>22 bugs from a deep QA audit (#3): debounce on the recording hotkey, auto-paste timing window, error reporting in <code>system.py</code>, and a long tail of small UX papercuts.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.1.1 <span class="release-date">· March 1, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>Rosetta + macOS compatibility. The launcher now smart-detects architecture (Apple Silicon vs Intel) and bootstraps the right venv.</li>
+          <li>First-launch dependency installation: <code>brew</code>, <code>whisper-cpp</code>, the <code>ggml-*.bin</code> model, and the Python venv now install on demand instead of failing if anything is missing.</li>
+          <li>DMG install path on Intel Macs.</li>
+          <li>Several broken GitHub URLs across the README and install scripts.</li>
+        </ul>
+      </details>
+      <details class="content-card"><summary><h2>v0.1.0 <span class="release-date">· February 22, 2026</span></h2></summary>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>13-module Python package (<code>voiceflow/</code>).</li>
+          <li>Local transcription via <code>whisper.cpp</code>. Audio never leaves the Mac.</li>
+          <li>Five LLM cleanup backends: Gemini, Groq, OpenAI, Anthropic, Ollama, plus a "none" pass-through.</li>
+          <li>tkinter onboarding wizard for first-run setup.</li>
+          <li>DMG installer (universal, with Rosetta fallback on Intel).</li>
+          <li>Hotkey-driven dictation with auto-paste at the cursor.</li>
+          <li>Configurable prompt, model, hotkey, language, and style.</li>
+          <li>MIT licensed.</li>
+        </ul>
+      </details>
+
+      <div class="hero-cta-row" style="margin-top:26px">
+        <a class="btn btn-primary btn-lg" href="download.html">Download for Mac — free</a>
+        <a class="btn btn-outline btn-lg" href="https://github.com/shimoverse/openvoiceflow" target="_blank" rel="noopener">View source on GitHub</a>
+      </div>
+    </div></section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="mission.html">Mission</a>
+        <a href="download.html">Download</a>
+        <a href="install.html">Install</a>
+        <a href="how-it-works.html">How it works</a>
+        <a href="docs/index.html">Docs</a>
+        <a href="blog/index.html">Blog</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="llms.txt">llms.txt</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="site.js"></script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://openvoiceflow.com/releases.html</loc>
+    <lastmod>2026-09-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
     <loc>https://openvoiceflow.com/blog/</loc>
     <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>

--- a/docs/style.css
+++ b/docs/style.css
@@ -202,6 +202,16 @@ img, canvas { max-width: 100%; }
 .nav-links a.btn-primary { color: var(--btn-ink); }
 .nav-links a.btn-primary:hover { color: var(--btn-ink); }
 
+.nav-links a.nav-github,
+.nav-drawer a.nav-github {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.nav-github-icon { flex: none; }
+
+.release-date { font-weight: 400; font-size: 13px; color: var(--ink-2); }
+
 /* Hamburger (mobile) */
 .nav-hamburger {
   display: none;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,4 +72,5 @@ ignore = []
 # the output is HTML, where line length means nothing.
 "scripts/docs_content.py" = ["E501"]
 "scripts/build_docs.py" = ["E501"]  # page chrome (nav, analytics tags) verbatim
+"scripts/build_releases.py" = ["E501"]  # releases.html chrome (nav, analytics tags) verbatim
 "scripts/analytics_dashboard.py" = ["E501"]  # self-contained private dashboard HTML/CSS template

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -93,13 +93,28 @@ ANALYTICS = """  <script>
   <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
   <script defer src="/_vercel/speed-insights/script.js"></script>"""
 
-NAVBAR = """  <nav class="nav" id="nav" aria-label="Main">
+GITHUB_ICON = ('<svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" '
+               'aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 '
+               '2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-'
+               '.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 '
+               '2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-'
+               '.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 '
+               '.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 '
+               '1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg>')
+GITHUB_REPO = "https://github.com/shimoverse/openvoiceflow"
+GITHUB_LINK_NAV = (f'        <li><a href="{GITHUB_REPO}" class="nav-github" target="_blank" '
+                    f'rel="noopener">{GITHUB_ICON}<span>GitHub</span></a></li>')
+GITHUB_LINK_DRAWER = (f'      <a href="{GITHUB_REPO}" class="nav-github" target="_blank" '
+                      f'rel="noopener">{GITHUB_ICON}<span>GitHub</span></a>')
+
+NAVBAR = f"""  <nav class="nav" id="nav" aria-label="Main">
     <div class="nav-inner container">
       <a href="../index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
       <ul class="nav-links">
         <li><a href="../mission.html">Mission</a></li>
         <li><a href="index.html">Docs</a></li>
         <li><a href="../blog/index.html">Blog</a></li>
+{GITHUB_LINK_NAV}
         <li><a href="../download.html" class="btn btn-primary">Download</a></li>
       </ul>
       <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
@@ -111,6 +126,7 @@ NAVBAR = """  <nav class="nav" id="nav" aria-label="Main">
       <a href="index.html">Docs</a>
       <a href="../how-it-works.html">How it works</a>
       <a href="../blog/index.html">Blog</a>
+{GITHUB_LINK_DRAWER}
       <a href="../download.html" class="btn btn-primary">Download for Mac</a>
     </div>
   </nav>"""
@@ -125,6 +141,7 @@ FOOTER = """  <footer class="footer">
         <a href="index.html">Docs</a>
         <a href="../how-it-works.html">How it works</a>
         <a href="../blog/index.html">Blog</a>
+        <a href="../releases.html">Releases</a>
         <a href="../privacy.html">Privacy</a>
         <a href="../llms.txt">llms.txt</a>
       </nav>

--- a/scripts/build_releases.py
+++ b/scripts/build_releases.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Generate docs/releases.html from CHANGELOG.md.
+
+Why a generator: CHANGELOG.md is already the maintainers' authoritative,
+human-written release notes — re-typing them into a second hand-maintained
+HTML page is exactly how a website goes stale the next time someone ships a
+release and forgets the second copy. This script re-renders the page from
+the changelog every time, so "add a CHANGELOG entry" is the only step that
+keeps the public Releases page current.
+
+Run:  python3 scripts/build_releases.py
+Then: python3 -m pytest tests/test_docs_seo.py -q
+"""
+from __future__ import annotations
+
+import html
+import re
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = ROOT / "CHANGELOG.md"
+OUT = ROOT / "docs" / "releases.html"
+CANONICAL = "https://openvoiceflow.com"
+REPO = "https://github.com/shimoverse/openvoiceflow"
+VERSION = "0.5.20"
+
+MONTHS = ["January", "February", "March", "April", "May", "June", "July",
+          "August", "September", "October", "November", "December"]
+
+# Versions dated within this many days of the newest entry render expanded;
+# older ones render collapsed (still readable, one click away) so the page
+# opens on recent activity instead of thirty-five expanded release cards.
+OPEN_WINDOW_DAYS = 21
+
+
+def format_date(iso: str) -> str:
+    y, m, d = (int(x) for x in iso.split("-"))
+    return f"{MONTHS[m - 1]} {d}, {y}"
+
+
+def inline_md(text: str) -> str:
+    text = html.escape(text, quote=False)
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+    return text
+
+
+def parse_changelog() -> list[dict]:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    body = text.split("\n## Compare links", 1)[0]
+
+    headers = list(re.finditer(r"^## \[(.+?)\](?: — (\d{4}-\d{2}-\d{2}))?\s*$", body, re.M))
+    releases = []
+    for i, m in enumerate(headers):
+        version, iso_date = m.group(1), m.group(2)
+        if version == "Unreleased":
+            continue
+        start = m.end()
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(body)
+        block = body[start:end]
+
+        sections = []
+        for sm in re.finditer(r"^### (.+)$", block, re.M):
+            sstart = sm.end()
+            send_idx = block.find("\n### ", sstart)
+            send_idx = len(block) if send_idx == -1 else send_idx
+            section_body = block[sstart:send_idx]
+            bullets = []
+            for bm in re.finditer(r"^- (.+(?:\n {2}.+)*)", section_body, re.M):
+                raw = " ".join(line.strip() for line in bm.group(1).split("\n"))
+                bullets.append(inline_md(raw))
+            if bullets:
+                sections.append((sm.group(1).strip(), bullets))
+
+        if not sections:
+            continue
+        releases.append({"version": version, "date": iso_date, "sections": sections})
+    return releases
+
+
+def render_release(rel: dict, open_by_default: bool) -> str:
+    date_html = f' <span class="release-date">· {format_date(rel["date"])}</span>' if rel["date"] else ""
+    parts = [
+        f'      <details class="content-card"{" open" if open_by_default else ""}>'
+        f'<summary><h2>v{rel["version"]}{date_html}</h2></summary>'
+    ]
+    for title, bullets in rel["sections"]:
+        parts.append(f"        <h3>{html.escape(title)}</h3>")
+        parts.append('        <ul class="check-list">')
+        for b in bullets:
+            parts.append(f"          <li>{b}</li>")
+        parts.append("        </ul>")
+    parts.append("      </details>")
+    return "\n".join(parts)
+
+
+def render(releases: list[dict]) -> str:
+    newest = next((r["date"] for r in releases if r["date"]), None)
+    cutoff = (datetime.strptime(newest, "%Y-%m-%d").date() - timedelta(days=OPEN_WINDOW_DAYS)) if newest else date.min
+
+    cards = []
+    for rel in releases:
+        rel_date = datetime.strptime(rel["date"], "%Y-%m-%d").date() if rel["date"] else date.min
+        cards.append(render_release(rel, open_by_default=rel_date >= cutoff))
+    cards_html = "\n".join(cards)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Releases — OpenVoiceFlow Version History</title>
+  <meta name="description" content="Every OpenVoiceFlow release with its notes, newest first: what shipped, what changed, and what was fixed, straight from the project's changelog." />
+  <meta property="og:title" content="OpenVoiceFlow release history" />
+  <meta property="og:description" content="Every OpenVoiceFlow release with its notes, newest first — see exactly what shipped and when." />
+  <meta property="og:url" content="{CANONICAL}/releases.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://openvoiceflow.com/assets/og-card.png" />
+  <link rel="canonical" href="{CANONICAL}/releases.html" />
+  <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="favicon-48.png" sizes="48x48" type="image/png" />
+  <link rel="icon" href="favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+  <style>.nav-hamburger,.docs-sidebar-toggle{{display:none}}</style>
+  <link rel="stylesheet" href="style.css" />
+  <script type="application/ld+json">
+  {{
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": "OpenVoiceFlow release history",
+    "url": "{CANONICAL}/releases.html",
+    "description": "Every OpenVoiceFlow release with its notes, newest first: what shipped, what changed, and what was fixed.",
+    "isPartOf": {{"@type": "WebSite", "name": "OpenVoiceFlow", "url": "{CANONICAL}/"}}
+  }}
+  </script>
+  <script>
+    window.va = window.va || function () {{ (window.vaq = window.vaq || []).push(arguments); }};
+  </script>
+  <script defer src="https://va.vercel-scripts.com/v1/script.js" data-view-endpoint="https://vitals.vercel-analytics.com/v1/view?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD" data-event-endpoint="https://vitals.vercel-analytics.com/v1/event?dsn=hbQ2mG8dCYsBmC0cvPE6eVdkD"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
+</head>
+<body>
+  <nav class="nav" id="nav" aria-label="Main">
+    <div class="nav-inner container">
+      <a href="index.html" class="nav-logo"><canvas class="nav-glyph" data-wf="glyph" aria-hidden="true"></canvas><span class="nav-logo-text">OpenVoiceFlow</span></a>
+      <ul class="nav-links">
+        <li><a href="mission.html">Mission</a></li>
+        <li><a href="how-it-works.html">How it works</a></li>
+        <li><a href="install.html">Install</a></li>
+        <li><a href="docs/index.html">Docs</a></li>
+        <li><a href="blog/index.html">Blog</a></li>
+        <li><a href="{REPO}" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a></li>
+        <li><a href="download.html" class="btn btn-primary">Download</a></li>
+      </ul>
+      <button class="nav-hamburger" id="navHamburger" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer"><span></span><span></span><span></span></button>
+    </div>
+    <div class="nav-drawer" id="navDrawer">
+      <a href="index.html">Home</a>
+      <a href="mission.html">Mission</a>
+      <a href="download.html">Download</a>
+      <a href="install.html">Install</a>
+      <a href="how-it-works.html">How it works</a>
+      <a href="docs/index.html">Docs</a>
+      <a href="blog/index.html">Blog</a>
+      <a href="{REPO}" class="nav-github" target="_blank" rel="noopener"><svg class="nav-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.63 5.47 7.71.4.08.55-.18.55-.4 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.83.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1 .16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .22.15.46.55.4A8.13 8.13 0 0 0 16 8.13C16 3.64 12.42 0 8 0z"/></svg><span>GitHub</span></a>
+      <a href="download.html" class="btn btn-primary">Download for Mac</a>
+    </div>
+  </nav>
+
+  <main>
+    <section class="page-hero"><div class="container hero-inner">
+      <h1 class="hero-title">Releases</h1>
+      <p class="hero-sub answer-block">OpenVoiceFlow ships often — every release below is real, shipped, and notarized, newest first. Notes come straight from the project's changelog, so this list is exactly as current as the code. Want the raw commit history or to file an issue? <a href="{REPO}/releases">See every release on GitHub</a>.</p>
+
+{cards_html}
+
+      <div class="hero-cta-row" style="margin-top:26px">
+        <a class="btn btn-primary btn-lg" href="download.html">Download for Mac — free</a>
+        <a class="btn btn-outline btn-lg" href="{REPO}" target="_blank" rel="noopener">View source on GitHub</a>
+      </div>
+    </div></section>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer-inner">
+      <canvas class="footer-glyph" data-wf="glyph" aria-hidden="true"></canvas>
+      <p class="footer-copy">© 2026 OpenVoiceFlow contributors. MIT License.</p>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="mission.html">Mission</a>
+        <a href="download.html">Download</a>
+        <a href="install.html">Install</a>
+        <a href="how-it-works.html">How it works</a>
+        <a href="docs/index.html">Docs</a>
+        <a href="blog/index.html">Blog</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="llms.txt">llms.txt</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="site.js"></script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    releases = parse_changelog()
+    assert releases, "no releases parsed from CHANGELOG.md"
+    OUT.write_text(render(releases), encoding="utf-8")
+    print(f"wrote {OUT} ({len(releases)} releases)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docs_content.py
+++ b/scripts/docs_content.py
@@ -405,6 +405,16 @@ PAGES["dashboard"] = {
           </tbody>
         </table>
 
+        <h2 id="feedback-leaderboard">Feedback and Leaderboard</h2>
+        <p>Two more rows sit below Settings in the sidebar:</p>
+        <table>
+          <thead><tr><th scope="col">Pane</th><th scope="col">What it is for</th></tr></thead>
+          <tbody>
+            <tr><td>Feedback</td><td>A short form (bug, idea, praise, or other, plus an optional reply email) that opens a <code>mailto:</code> on Send with a small aggregate usage snapshot attached — never dictation text.</td></tr>
+            <tr><td>Leaderboard</td><td>Your rank by <strong>time back</strong> against other installations sharing usage, with a display name you can change. Sharing is on by default since 0.5.7 — see <a href="privacy-architecture.html#analytics">Analytics &amp; leaderboard</a> for exactly what that sends and how to turn it off.</td></tr>
+          </tbody>
+        </table>
+
         <h2 id="menubar">The menu-bar menu</h2>
         <p>The waveform icon at the top right gives you the fast controls without opening the dashboard: pause listening for an hour, change the hotkey, change the cleanup backend, open permission settings, and check for updates.</p>
         <div class="callout tip">
@@ -1002,6 +1012,8 @@ PAGES["settings"] = {
             <tr><td>Reveal in Finder</td><td>—</td><td>Opens the folder holding your settings, history, and personalization files.</td></tr>
             <tr><td>Delete history…</td><td>—</td><td>Clears dictation history, with the option to keep your first-ever transcript.</td></tr>
             <tr><td>Show what was typed in the HUD</td><td>On</td><td>Echoes the tail of inserted text. Turn off when dictating sensitive material — the HUD shows a word count instead.</td></tr>
+            <tr><td>Share anonymous usage &amp; leaderboard rank</td><td>On</td><td>Powers the in-app Leaderboard. On by default since 0.5.7 — full detail in <a href="privacy-architecture.html#analytics">Analytics &amp; leaderboard</a>.</td></tr>
+            <tr><td>Delete my leaderboard data</td><td>—</td><td>Removes a past leaderboard submission outright; does not itself turn off future sharing.</td></tr>
             <tr><td>Automatic updates</td><td>On</td><td>Checks for signed updates in the background daily and installs them on next launch — see <a href="updates.html">Updates</a>.</td></tr>
           </tbody>
         </table>

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -25,6 +25,7 @@ MAIN_PAGES = [
     "install.html",
     "how-it-works.html",
     "privacy.html",
+    "releases.html",
 ]
 ARTICLES = sorted(
     p.name for p in (DOCS / "blog").glob("*.html") if p.name != "index.html"
@@ -288,29 +289,33 @@ def test_the_product_film_ships_with_its_plumbing():
     assert "demo_play" in site_js, "film plays must be visible in analytics"
 
 
-def test_the_website_ui_carries_no_github_links():
-    """Maintainer decision (July 2026): the website should not send visitors
-    to GitHub — no nav item, no footer Source link, no in-prose repo links,
-    and no fork-promotion copy. The project stays MIT/open-source and the
-    site still says so; only the links and CTAs were removed. site.js keeps
-    its inert github_click handler for the observability contract."""
+def test_every_page_links_the_public_github_repo():
+    """Maintainer decision (September 2026, superseding the July 2026 "no
+    GitHub links" call): every page now carries a clearly-labeled GitHub nav
+    item — logo plus "GitHub" — linking straight to the public repository,
+    alongside the Releases page that surfaces the changelog as version
+    history. site.js's github_click handler, previously inert, now fires for
+    real."""
+    repo = "https://github.com/shimoverse/openvoiceflow"
     for rel in ALL_PAGES:
         html = read(rel)
-        # GitHub remains intentionally absent from rendered UI and copy.
-        # JSON-LD may identify the canonical source repository for search and
-        # answer engines without exposing another user-facing destination.
-        rendered_html = re.sub(
-            r'<script type="application/ld\+json">.*?</script>',
-            "",
-            html,
-            flags=re.DOTALL,
-        )
-        assert "github" not in rendered_html.lower(), f"{rel}: GitHub reference present"
-    llms = read("llms.txt")
-    assert "github" not in llms.lower(), "llms.txt: GitHub reference present"
-    # the credit-and-tell-us ask replaces the repo link as the reuse policy
-    assert "shimoverse@gmail.com" in llms
+        assert 'class="nav-github"' in html, f"{rel}: missing the GitHub nav link"
+        assert html.count(repo) >= 1, f"{rel}: GitHub nav link does not point at {repo}"
     assert "shimoverse@gmail.com" in read("mission.html")
+
+
+def test_releases_page_lists_recent_versions_with_notes():
+    """The Releases page is generated from CHANGELOG.md by
+    scripts/build_releases.py — it must actually list real, dated release
+    notes (not just link out to GitHub) so visitors can see the project is
+    actively maintained without leaving the site."""
+    html = read("releases.html")
+    for version in ["0.5.20", "0.5.19", "0.5.8"]:
+        assert f"v{version}" in html, f"releases.html missing v{version}"
+    assert html.count('<details class="content-card"') >= 20, (
+        "releases.html should list a substantial version history"
+    )
+    assert "https://github.com/shimoverse/openvoiceflow/releases" in html
 
 
 def test_homepage_structured_data_links_the_project_to_its_repository():


### PR DESCRIPTION
## What this changes (for the user)

- **GitHub nav link.** Every page (root pages, blog posts, and the generated manual) now carries a "GitHub" item in the nav — octocat logo plus label — linking to `github.com/shimoverse/openvoiceflow`, sitting right next to Blog before the Download CTA. This intentionally reverses a July 2026 "no GitHub links on the site" decision (`tests/test_docs_seo.py`'s old `test_the_website_ui_carries_no_github_links`), which I've replaced with a test asserting the link is present instead.
- **Releases page.** New `docs/releases.html`, generated by `scripts/build_releases.py` straight from `CHANGELOG.md`, so it never has to be hand-maintained separately. It lists every release newest-first with real notes; the most recent ~2-3 weeks render expanded, older ones collapse into `<details>` so the page stays scannable while still showing full version history. Linked from every page's footer and from the new nav. `RELEASE.md` now has a step to regenerate it after each release.
- **Docs gaps for features shipped in the last two weeks.** The Dashboard manual page didn't mention the **Feedback** or **Leaderboard** sidebar panes at all (shipped 0.5.7–0.5.20), and the Settings reference page was missing the **"Share anonymous usage & leaderboard rank"** toggle and **"Delete my leaderboard data"** button entirely. Both are now documented, cross-linking to the existing Privacy architecture ▸ Analytics & leaderboard section.

## How it was verified

- [x] `python3 -m pytest tests/test_docs_seo.py tests/test_docs_distribution.py -q` — 32 passed
- [x] `python3 scripts/build_docs.py` and `python3 scripts/build_releases.py` re-run cleanly and produce no further diff (idempotent generation)
- [x] Screenshot-verified in a real headless-Chromium render, light and dark: nav GitHub link renders with logo + label on desktop; Releases page cards, checkmark bullets, and collapse/expand boundary all render correctly in both themes
- [ ] No version bumps or new dependencies — confirmed, this is website-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfsZBm5b75CKh6uLSZekF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHfsZBm5b75CKh6uLSZekF)_