### PR TITLE
Sidebar footer offers "Update" when a newer build exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The dashboard sidebar footer now says whether the running build is current instead of always reading "auto-updating". When the appcast offers a newer version it shows an **Update** action that installs it; when the build is the latest, it reads "Up to date" with nothing to click. Before a check has finished — including when automatic updates are off, which stays an opt-out of background checks — the footer shows the version alone rather than claiming a freshness nothing verified.
+
 ## [0.5.20] — 2026-09-02
 
 ### Changed

--- a/docs/docs/updates.html
+++ b/docs/docs/updates.html
@@ -172,7 +172,7 @@
         </div>
 
         <h2 id="version">Checking your version</h2>
-        <p>The dashboard sidebar footer shows your version, marked <em>auto-updating</em> when background checks are on. <strong>Settings</strong> shows it too, alongside the manual check button. This documentation describes <strong>0.5.20</strong>.</p>
+        <p>The dashboard sidebar footer shows your version and whether it is current: <em>Up to date</em> when the latest release is the one you are running, or an <em>Update</em> link that installs the new version when there is one. <strong>Settings</strong> shows the version too, alongside the manual check button. This documentation describes <strong>0.5.20</strong>.</p>
 
         <h2 id="downgrade">Reinstalling or going back</h2>
         <p>To reinstall, download the current DMG from the <a href="../download.html">download page</a> and replace the copy in Applications; your settings, history, and personalization are stored separately and survive. There is no supported downgrade path — older builds are not hosted, and installing one would disable the fixes that came after it.</p>

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -103,6 +103,9 @@ struct DashboardView: View {
                 .background(dark ? DT.winDark : DT.winLight)
         }
         .frame(minWidth: 1000, minHeight: 768)
+        // Re-probe the appcast whenever the window comes back, so the footer
+        // reflects a release published since the app launched.
+        .onAppear { updater.refreshUpdateStatus() }
     }
 
     // MARK: sidebar (212 pt, dot + label rows)
@@ -178,18 +181,47 @@ struct DashboardView: View {
 
             Spacer()
 
-            HStack(spacing: 6) {
-                Circle().fill(DT.moss).frame(width: 6, height: 6)
-                Text(controller.settings.automaticUpdates
-                     ? "v\(updater.appVersion) · auto-updating"
-                     : "v\(updater.appVersion)")
-                    .font(.system(size: 11)).foregroundStyle(ink2)
-            }
-            .padding(.bottom, 12)
+            versionFooter
+                .padding(.bottom, 12)
         }
         .padding(.horizontal, 10)
         .frame(width: 212)
         .background(dark ? DT.sideDark : DT.sideLight)
+    }
+
+    // MARK: sidebar footer (version + update state)
+    //
+    // Three states, and only one of them is clickable: a new version to
+    // install offers "Update"; a verified-current build says "Up to date" and
+    // asks nothing of the user; before any check has finished (or with
+    // automatic checks off) the version stands alone rather than claiming a
+    // freshness nobody confirmed.
+
+    @ViewBuilder private var versionFooter: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(updater.updateAvailable ? accent : DT.moss)
+                .frame(width: 6, height: 6)
+            if updater.updateAvailable {
+                Text("v\(updater.appVersion) ·")
+                    .font(.system(size: 11)).foregroundStyle(ink2)
+                Button { updater.installAvailableUpdate() } label: {
+                    Text("Update")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(dark ? DT.emberDark : DT.emberLight)
+                }
+                .buttonStyle(.plain)
+                .disabled(!updater.canCheckForUpdates)
+                .help(updater.availableVersion.map { "Update to v\($0)" } ?? "Update")
+            } else if updater.hasCheckedForUpdates {
+                Text("v\(updater.appVersion) · Up to date")
+                    .font(.system(size: 11)).foregroundStyle(ink2)
+            } else {
+                Text("v\(updater.appVersion)")
+                    .font(.system(size: 11)).foregroundStyle(ink2)
+            }
+            Spacer(minLength: 0)
+        }
     }
 
     // MARK: content router

--- a/native/Sources/OpenVoiceFlow/Updater.swift
+++ b/native/Sources/OpenVoiceFlow/Updater.swift
@@ -1,6 +1,25 @@
 import Combine
 import Sparkle
 
+/// Receives Sparkle's appcast results.
+///
+/// Sparkle wants its delegate at construction time, before `UpdaterController`
+/// finishes initializing, so this is a small forwarding object rather than the
+/// controller itself. The protocol is main-actor annotated, hence `@MainActor`.
+@MainActor
+private final class UpdaterProbe: NSObject, SPUUpdaterDelegate {
+    var onFound: ((SUAppcastItem) -> Void)?
+    var onNotFound: (() -> Void)?
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        onFound?(item)
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        onNotFound?()
+    }
+}
+
 /// In-app updates via Sparkle 2 with an EdDSA-signed appcast.
 ///
 /// `SUFeedURL` (the appcast) and `SUPublicEDKey` (the signature-verification
@@ -17,6 +36,7 @@ final class UpdaterController: ObservableObject {
     static let shared = UpdaterController()
 
     private let controller: SPUStandardUpdaterController
+    private let probe: UpdaterProbe
     private var canCheckObservation: NSKeyValueObservation?
 
     /// Mirrors Sparkle's `canCheckForUpdates` so SwiftUI re-renders the
@@ -25,13 +45,36 @@ final class UpdaterController: ObservableObject {
     /// the view happened to reload.
     @Published private(set) var canCheckForUpdates = false
 
+    /// True once the appcast has offered a version newer than the running one.
+    /// Drives the sidebar's "Update" call to action.
+    @Published private(set) var updateAvailable = false
+
+    /// The version waiting to be installed, when one is (e.g. "0.5.21").
+    @Published private(set) var availableVersion: String?
+
+    /// False until a check has actually finished. The sidebar stays quiet
+    /// rather than claiming "Up to date" on a version it has not verified.
+    @Published private(set) var hasCheckedForUpdates = false
+
     private init() {
+        let probe = UpdaterProbe()
+        self.probe = probe
         // startingUpdater: true → background appcast checks begin immediately.
         controller = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: probe,
             userDriverDelegate: nil
         )
+        probe.onFound = { [weak self] item in
+            self?.hasCheckedForUpdates = true
+            self?.updateAvailable = true
+            self?.availableVersion = item.displayVersionString
+        }
+        probe.onNotFound = { [weak self] in
+            self?.hasCheckedForUpdates = true
+            self?.updateAvailable = false
+            self?.availableVersion = nil
+        }
         // Honor the user's saved preference for automatic updates.
         apply(automatic: Settings.load().automaticUpdates)
         // Keep the published flag in sync with Sparkle's KVO-observable state.
@@ -42,6 +85,9 @@ final class UpdaterController: ObservableObject {
             guard let value = change.newValue else { return }
             Task { @MainActor in self?.canCheckForUpdates = value }
         }
+        // Sparkle explicitly allows a check on the runloop cycle that starts
+        // the updater, so the sidebar label is honest from the first window.
+        refreshUpdateStatus()
     }
 
     /// The running app's marketing version (e.g. "0.4.2"), read from the bundle
@@ -50,13 +96,41 @@ final class UpdaterController: ObservableObject {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
     }
 
+    /// Silent appcast probe: no Sparkle UI, just the delegate callbacks that
+    /// tell the sidebar whether this build is the latest one.
+    ///
+    /// Skipped when the user has turned automatic updates off — that switch is
+    /// an opt-out of background network checks, not just of silent installs —
+    /// and while a check is already running, where Sparkle would ignore it.
+    func refreshUpdateStatus() {
+        guard controller.updater.automaticallyChecksForUpdates,
+              !controller.updater.sessionInProgress else { return }
+        controller.updater.checkForUpdateInformation()
+    }
+
     /// Manual "Check for Updates…" / "Check for updates now" — shows Sparkle's
     /// standard UI so an on-demand check always has clear feedback.
     func checkForUpdates() { controller.checkForUpdates(nil) }
 
+    /// The sidebar's "Update" action. Sparkle owns the download, signature and
+    /// notarization checks, and the relaunch, so this hands the user straight
+    /// to that flow for the version the probe already found.
+    func installAvailableUpdate() { checkForUpdates() }
+
     /// Toggle automatic updates (Settings ▸ Automatic updates): both the daily
     /// scheduled check and the silent background download+install.
-    func setAutomaticChecks(_ enabled: Bool) { apply(automatic: enabled) }
+    func setAutomaticChecks(_ enabled: Bool) {
+        apply(automatic: enabled)
+        if enabled {
+            refreshUpdateStatus()
+        } else {
+            // The status was learned from a check the user has now opted out
+            // of; stop asserting it rather than letting it go stale.
+            hasCheckedForUpdates = false
+            updateAvailable = false
+            availableVersion = nil
+        }
+    }
 
     /// "Automatic" means check on the schedule AND download+install in the
     /// background (installed on next relaunch). Sparkle requires downloads to be

--- a/native/Sources/OpenVoiceFlow/Updater.swift
+++ b/native/Sources/OpenVoiceFlow/Updater.swift
@@ -10,6 +10,7 @@ import Sparkle
 private final class UpdaterProbe: NSObject, SPUUpdaterDelegate {
     var onFound: ((SUAppcastItem) -> Void)?
     var onNotFound: (() -> Void)?
+    var onAborted: (() -> Void)?
 
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
         onFound?(item)
@@ -17,6 +18,15 @@ private final class UpdaterProbe: NSObject, SPUUpdaterDelegate {
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
         onNotFound?()
+    }
+
+    /// Every ended check lands here, including the ones that ended badly — an
+    /// appcast that wouldn't load or parse reports neither found nor
+    /// not-found, so this is the only signal that the check told us nothing.
+    /// "No update found" aborts through here too; the controller tells the
+    /// cases apart by whether a result already arrived.
+    func updater(_ updater: SPUUpdater, didAbortWithError error: any Error) {
+        onAborted?()
     }
 }
 
@@ -56,6 +66,11 @@ final class UpdaterController: ObservableObject {
     /// rather than claiming "Up to date" on a version it has not verified.
     @Published private(set) var hasCheckedForUpdates = false
 
+    /// True from the moment a silent probe starts until the appcast answers
+    /// it. A probe that aborts while this is set answered nothing, so the
+    /// status it was meant to refresh is dropped rather than left to go stale.
+    private var probeAwaitingResult = false
+
     private init() {
         let probe = UpdaterProbe()
         self.probe = probe
@@ -66,14 +81,26 @@ final class UpdaterController: ObservableObject {
             userDriverDelegate: nil
         )
         probe.onFound = { [weak self] item in
-            self?.hasCheckedForUpdates = true
-            self?.updateAvailable = true
-            self?.availableVersion = item.displayVersionString
+            guard let self else { return }
+            self.probeAwaitingResult = false
+            self.hasCheckedForUpdates = true
+            self.updateAvailable = true
+            self.availableVersion = item.displayVersionString
         }
         probe.onNotFound = { [weak self] in
-            self?.hasCheckedForUpdates = true
-            self?.updateAvailable = false
-            self?.availableVersion = nil
+            guard let self else { return }
+            self.probeAwaitingResult = false
+            self.hasCheckedForUpdates = true
+            self.updateAvailable = false
+            self.availableVersion = nil
+        }
+        probe.onAborted = { [weak self] in
+            // A result already in hand means this is the abort that follows
+            // "no update found" — the status stands. Otherwise the check
+            // failed, and an unverified status is worse than none.
+            guard let self, self.probeAwaitingResult else { return }
+            self.probeAwaitingResult = false
+            self.clearVerifiedStatus()
         }
         // Honor the user's saved preference for automatic updates.
         apply(automatic: Settings.load().automaticUpdates)
@@ -105,6 +132,7 @@ final class UpdaterController: ObservableObject {
     func refreshUpdateStatus() {
         guard controller.updater.automaticallyChecksForUpdates,
               !controller.updater.sessionInProgress else { return }
+        probeAwaitingResult = true
         controller.updater.checkForUpdateInformation()
     }
 
@@ -126,10 +154,17 @@ final class UpdaterController: ObservableObject {
         } else {
             // The status was learned from a check the user has now opted out
             // of; stop asserting it rather than letting it go stale.
-            hasCheckedForUpdates = false
-            updateAvailable = false
-            availableVersion = nil
+            probeAwaitingResult = false
+            clearVerifiedStatus()
         }
+    }
+
+    /// Drop what the last check established, so the footer falls back to the
+    /// bare version instead of vouching for a build nothing verified.
+    private func clearVerifiedStatus() {
+        hasCheckedForUpdates = false
+        updateAvailable = false
+        availableVersion = nil
     }
 
     /// "Automatic" means check on the schedule AND download+install in the

--- a/scripts/docs_content.py
+++ b/scripts/docs_content.py
@@ -1132,7 +1132,7 @@ PAGES["updates"] = {
         </div>
 
         <h2 id="version">Checking your version</h2>
-        <p>The dashboard sidebar footer shows your version, marked <em>auto-updating</em> when background checks are on. <strong>Settings</strong> shows it too, alongside the manual check button. This documentation describes <strong>0.5.20</strong>.</p>
+        <p>The dashboard sidebar footer shows your version and whether it is current: <em>Up to date</em> when the latest release is the one you are running, or an <em>Update</em> link that installs the new version when there is one. <strong>Settings</strong> shows the version too, alongside the manual check button. This documentation describes <strong>0.5.20</strong>.</p>
 
         <h2 id="downgrade">Reinstalling or going back</h2>
         <p>To reinstall, download the current DMG from the <a href="%s">download page</a> and replace the copy in Applications; your settings, history, and personalization are stored separately and survive. There is no supported downgrade path — older builds are not hosted, and installing one would disable the fixes that came after it.</p>

--- a/tests/test_native_update_status_label.py
+++ b/tests/test_native_update_status_label.py
@@ -1,0 +1,75 @@
+"""Contracts for the sidebar's version/update footer.
+
+The footer used to read "v0.5.20 · auto-updating" whether or not the running
+build was actually the latest one — a status that told the user nothing they
+could act on. It now has three states: an "Update" button when the appcast
+offers a newer version, plain "Up to date" when it doesn't, and the bare
+version before any check has finished.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+NATIVE_SOURCES = ROOT / "native" / "Sources" / "OpenVoiceFlow"
+
+
+def source(name: str) -> str:
+    return (NATIVE_SOURCES / name).read_text(encoding="utf-8")
+
+
+def test_updater_probes_the_appcast_for_the_latest_version() -> None:
+    updater = source("Updater.swift")
+
+    # A silent probe (no Sparkle UI) is what tells the footer whether this
+    # build is current.
+    assert "func refreshUpdateStatus()" in updater
+    assert "controller.updater.checkForUpdateInformation()" in updater
+    # Sparkle reports the result through its delegate.
+    assert "SPUUpdaterDelegate" in updater
+    assert "didFindValidUpdate item: SUAppcastItem" in updater
+    assert "func updaterDidNotFindUpdate(_ updater: SPUUpdater)" in updater
+
+
+def test_updater_publishes_the_state_the_footer_renders() -> None:
+    updater = source("Updater.swift")
+
+    assert "@Published private(set) var updateAvailable = false" in updater
+    assert "@Published private(set) var hasCheckedForUpdates = false" in updater
+    assert "@Published private(set) var availableVersion: String?" in updater
+    assert "func installAvailableUpdate()" in updater
+
+
+def test_probe_respects_the_automatic_updates_opt_out() -> None:
+    """The switch is an opt-out of background checks, not just of installs."""
+    updater = source("Updater.swift")
+
+    assert "guard controller.updater.automaticallyChecksForUpdates," in updater
+    assert "!controller.updater.sessionInProgress else { return }" in updater
+
+
+def test_footer_offers_update_only_when_one_is_available() -> None:
+    dashboard = source("DashboardView.swift")
+
+    assert "auto-updating" not in dashboard
+    assert "private var versionFooter: some View" in dashboard
+    assert "if updater.updateAvailable {" in dashboard
+    assert 'Button { updater.installAvailableUpdate() } label: {' in dashboard
+    assert 'Text("Update")' in dashboard
+
+
+def test_footer_states_up_to_date_without_a_call_to_action() -> None:
+    dashboard = source("DashboardView.swift")
+
+    footer = dashboard.split("private var versionFooter: some View", 1)[1]
+    up_to_date = footer.split("} else if updater.hasCheckedForUpdates {", 1)[1]
+    up_to_date = up_to_date.split("} else {", 1)[0]
+
+    assert "Up to date" in up_to_date
+    # The "already current" state is a statement, never a button.
+    assert "Button" not in up_to_date
+
+
+def test_dashboard_refreshes_update_status_when_it_appears() -> None:
+    dashboard = source("DashboardView.swift")
+
+    assert ".onAppear { updater.refreshUpdateStatus() }" in dashboard

--- a/tests/test_native_update_status_label.py
+++ b/tests/test_native_update_status_label.py
@@ -39,6 +39,23 @@ def test_updater_publishes_the_state_the_footer_renders() -> None:
     assert "func installAvailableUpdate()" in updater
 
 
+def test_a_failed_probe_drops_the_status_it_could_not_verify() -> None:
+    """No network (or an unparseable appcast) must not read as "Up to date"."""
+    updater = source("Updater.swift")
+
+    # Sparkle reports a check that ended badly through didAbortWithError —
+    # neither didFindValidUpdate nor updaterDidNotFindUpdate runs.
+    assert "func updater(_ updater: SPUUpdater, didAbortWithError error: any Error)" in updater
+    assert "private var probeAwaitingResult = false" in updater
+    assert "private func clearVerifiedStatus()" in updater
+
+    aborted = updater.split("probe.onAborted = {", 1)[1].split("\n        }", 1)[0]
+    # Only an abort with no result in hand clears — the abort that trails
+    # "no update found" must leave the verified status alone.
+    assert "self.probeAwaitingResult else { return }" in aborted
+    assert "self.clearVerifiedStatus()" in aborted
+
+
 def test_probe_respects_the_automatic_updates_opt_out() -> None:
     """The switch is an opt-out of background checks, not just of installs."""
     updater = source("Updater.swift")


### PR DESCRIPTION
## What this changes (for the user)

The dashboard sidebar footer used to read `v0.5.20 · auto-updating` regardless of whether that build was actually the latest one — the same reassurance for a stale install as for a current one, with nothing to act on either way.

It now reports the real state, and only one state is clickable:

- **A newer version is available** → `v0.5.20 · Update`, where **Update** hands the user to Sparkle's standard download → signature/notarization check → relaunch flow.
- **Already the latest** → `v0.5.20 · Up to date`, plain text, no call to action.
- **No check has finished yet** → the version alone, rather than claiming a freshness nothing verified.

How it knows: `UpdaterController` runs Sparkle's silent probe (`checkForUpdateInformation()`) at launch and whenever the dashboard appears, and publishes what the appcast delegate reports (`updateAvailable`, `availableVersion`, `hasCheckedForUpdates`). The probe is skipped when **Automatic updates** is off — that switch is an opt-out of background network checks, not only of silent installs — and turning it off drops the remembered status instead of letting it go stale. A manual "Check for updates now" from Settings still refreshes the footer, so the CTA can appear for opted-out users too.

Docs (`updates.html` and its source in `scripts/docs_content.py`) now describe the new footer states.

## How it was verified

- `tests/test_native_update_status_label.py` — new source contracts: the probe exists and respects the automatic-updates opt-out, the published state the footer renders, the "Update" button appears only under `updateAvailable`, and the "Up to date" branch contains no `Button`.
- Full pytest run: the pre-existing failures in this container are missing `numpy`/`sounddevice`/`rumps` imports, unrelated to this change; docs, updater, and native-source suites pass.
- Swift is not compiled here (no macOS toolchain in this environment) — `native-build` on CI is the check for it.

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes
- [x] No version bumps or new dependencies (discuss those in an issue first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gmvabkQVTyhBorisBvh4i

---
_Generated by [Claude Code](https://claude.ai/code/session_014gmvabkQVTyhBorisBvh4i)_