### PR TITLE
Point Sparkle's "Version History" button at the Releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.21] — 2026-09-06
+
+### Fixed
+- The **Version History** button on the "You're up to date!" update alert now opens the [Releases page](https://openvoiceflow.com/releases.html) instead of the "How it works" marketing page, which listed no versions at all. Sparkle fills that button from the appcast's `fullReleaseNotesLink`, which the feed never set, so it fell back to a `releaseNotesLink` that pointed at marketing copy. The appcast now sets both, and this fix reaches every installed build the moment the site deploys — the button reads the website's feed, not the app.
+- The release notes shown inside the update sheet are now that version's actual notes, generated from this changelog, rather than the same marketing page.
+
+### Added
+- Settings ▸ "You're on vX.Y.Z" now has a **Version history** link that opens the Releases page at the running version, so the notes no longer sit behind an update check that reports there is nothing to install.
+- Every release on the Releases page is individually linkable (`releases.html#v0.5.21`), and opening such a link expands that release rather than landing on a collapsed card.
+
 ### Changed
 - The dashboard sidebar footer now says whether the running build is current instead of always reading "auto-updating". When the appcast offers a newer version it shows an **Update** action that installs it; when the build is the latest, it reads "Up to date" with nothing to click. Before a check has finished — including when automatic updates are off, which stays an opt-out of background checks — the footer shows the version alone rather than claiming a freshness nothing verified.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,13 +31,20 @@ The release workflow's classify step hard-fails on any mismatch.
    `pytest tests/test_docs_distribution.py`, PR, merge. **This merge is the
    moment users start updating** — the app polls the website's appcast, not
    GitHub.
-5. **Verify live**: the site serves the new appcast build number and the DMG
-   sha256 matches the notarized artifact byte-for-byte.
-6. Add a CHANGELOG entry; prune the previous version's DMG from
-   `docs/downloads/` and add its redirect in `vercel.json`. Then regenerate
-   `docs/releases.html` with `python3 scripts/build_releases.py` — it renders
-   straight from CHANGELOG.md, so this is the only way the public Releases
-   page picks up the new entry.
+
+   The same PR must add the CHANGELOG entry and regenerate the release pages
+   with `python3 scripts/build_releases.py`. That writes `docs/releases.html`
+   (what Sparkle's **Version History** button opens) and
+   `docs/release-notes/<version>.html` (what its update sheet loads), and the
+   appcast published in this PR links to both by URL — ship the appcast
+   without them and every updating user gets a 404 where the notes should be.
+   `test_appcast_release_notes_links_point_at_pages_that_exist` fails the PR
+   if they are missing.
+5. **Verify live**: the site serves the new appcast build number, the DMG
+   sha256 matches the notarized artifact byte-for-byte, and
+   `https://openvoiceflow.com/release-notes/<version>.html` resolves.
+6. Prune the previous version's DMG from `docs/downloads/` and add its
+   redirect in `vercel.json`.
 
 Never regenerate the Sparkle keypair — every shipped app pins the public key,
 and a new pair permanently breaks updates for every existing install.

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,7 +7,8 @@
     <language>en</language>
     <item>
       <title>Version 0.5.20</title>
-      <sparkle:releaseNotesLink>https://openvoiceflow.com/how-it-works.html</sparkle:releaseNotesLink>
+      <sparkle:releaseNotesLink>https://openvoiceflow.com/release-notes/0.5.20.html</sparkle:releaseNotesLink>
+      <sparkle:fullReleaseNotesLink>https://openvoiceflow.com/releases.html</sparkle:fullReleaseNotesLink>
       <pubDate>Wed, 02 Sep 2026 04:40:31 +0000</pubDate>
       <sparkle:version>25</sparkle:version>
       <sparkle:shortVersionString>0.5.20</sparkle:shortVersionString>

--- a/docs/release-notes/0.1.0.html
+++ b/docs/release-notes/0.1.0.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.1.0 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.1.0" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.1.0</h1>
+    <p class="date">February 22, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>13-module Python package (<code>voiceflow/</code>).</li>
+      <li>Local transcription via <code>whisper.cpp</code>. Audio never leaves the Mac.</li>
+      <li>Five LLM cleanup backends: Gemini, Groq, OpenAI, Anthropic, Ollama, plus a "none" pass-through.</li>
+      <li>tkinter onboarding wizard for first-run setup.</li>
+      <li>DMG installer (universal, with Rosetta fallback on Intel).</li>
+      <li>Hotkey-driven dictation with auto-paste at the cursor.</li>
+      <li>Configurable prompt, model, hotkey, language, and style.</li>
+      <li>MIT licensed.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.1.1.html
+++ b/docs/release-notes/0.1.1.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.1.1 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.1.1" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.1.1</h1>
+    <p class="date">March 1, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Rosetta + macOS compatibility. The launcher now smart-detects architecture (Apple Silicon vs Intel) and bootstraps the right venv.</li>
+      <li>First-launch dependency installation: <code>brew</code>, <code>whisper-cpp</code>, the <code>ggml-*.bin</code> model, and the Python venv now install on demand instead of failing if anything is missing.</li>
+      <li>DMG install path on Intel Macs.</li>
+      <li>Several broken GitHub URLs across the README and install scripts.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.2.0.html
+++ b/docs/release-notes/0.2.0.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.2.0 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.2.0" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.2.0</h1>
+    <p class="date">March 15, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li><strong>Know Me</strong> — tkinter onboarding interview. Captures name, occupation, industry, frequently-mentioned names/tools, communication style. Output is injected into every LLM cleanup prompt as system context.</li>
+      <li><strong>Auto-learn</strong> — watches the focused text field via the macOS Accessibility API for 30 seconds after every paste and learns word-level substitutions from your edits. Levenshtein-gated, substitutions only (never inserts/deletes), 5-sample minimum.</li>
+      <li><strong>Streaming transcription</strong> via <code>whisper-stream</code> with refinement-replacement and Jaccard-overlap deduplication. Falls back to non-streaming for the canonical text.</li>
+      <li><strong>Per-app context + per-app styles</strong> — frontmost-app detection via Apple events; the cleanup prompt picks up the right style automatically (e.g. terse in Slack, formal in Mail).</li>
+      <li><strong>Voice commands</strong> — say "new line", "period", "delete that", etc. Configurable via <code>--add-command</code> / <code>--remove-command</code> / <code>--list-commands</code> / <code>--voice-commands on/off</code>.</li>
+      <li><strong>Clipboard / selected-text context</strong> — whatever's selected when you start dictating gets handed to the LLM as context.</li>
+      <li><strong>History search</strong> — <code>--search QUERY</code> greps the daily transcript logs.</li>
+      <li><strong>Voice snippets</strong> — trigger-phrase → expansion. <code>--add-snippet</code> / <code>--remove-snippet</code> / <code>--list-snippets</code>.</li>
+      <li><strong>Personal dictionary</strong> — proper-noun and acronym table. <code>--add-word</code> / <code>--remove-word</code> / <code>--list-words</code>.</li>
+      <li><strong>Launch-at-login</strong> — <code>--autostart on/off</code>; writes a LaunchAgent plist.</li>
+      <li><strong>Statistics</strong> — <code>--stats</code> shows dictations, words, time saved.</li>
+      <li><strong>Auto-update notifier</strong> — once-a-day check against the GitHub Releases API; quiet on failure.</li>
+      <li><strong>Floating macOS overlay HUD</strong> — visual feedback during recording, streaming, and auto-learn moments.</li>
+      <li>New CLI flags across the board: <code>--version</code>, <code>--show-config</code>, <code>--set-prompt</code>, <code>--clear-prompt</code>, <code>--set-key</code>, <code>--app-style</code>, <code>--remove-app-style</code>, <code>--list-app-styles</code>, <code>--auto-style on/off</code>, <code>--streaming on/off</code>, <code>--auto-learn on/off</code>.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>DMG installer split into separate <code>arm64</code> and <code>x86_64</code> artifacts — one-click install on any Mac, no Rosetta dance.</li>
+      <li><code>pyproject.toml</code> gained an <code>[overlay]</code> extra for the optional PyObjC dependencies (Cocoa, Quartz). <code>rumps</code> (the menubar lib) transitively installs Cocoa, so menubar users get the HUD by default.</li>
+      <li>Codebase grew from ~13 modules to ~28. Backend <code>cleanup()</code> interface now accepts <code>context</code>, <code>app_context</code>, <code>override_style</code>; all 5 existing backends were updated consistently.</li>
+      <li>Anthropic default model: <code>claude-3-5-haiku-20241022</code>.</li>
+      <li>Groq default model: <code>llama-3.1-8b-instant</code>.</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>22 bugs from a deep QA audit (#3): debounce on the recording hotkey, auto-paste timing window, error reporting in <code>system.py</code>, and a long tail of small UX papercuts.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.0.html
+++ b/docs/release-notes/0.3.0.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.0 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.0" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.0</h1>
+    <p class="date">July 8, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>Pytest scaffold under <code>tests/</code> with regression tests for every Wave-1 ship-stopper (<code>test_python39_compat</code>, <code>test_install_sh</code>, <code>test_config_migration</code>, <code>test_onboarding</code>, <code>test_voice_commands_count</code>, <code>test_updater</code>) plus privacy invariants (<code>test_chmod_600</code>, <code>test_privacy_defaults</code>) and package smoke tests. 60 tests total, green on Python 3.9, 3.10, and 3.11.</li>
+      <li><code>[dev]</code> extras in <code>pyproject.toml</code> (pytest, pytest-cov, ruff, build, twine).</li>
+      <li>CI Python matrix: 3.9, 3.10, 3.11 on macos-latest. Lint is now a blocking step. A separate <code>build</code> job exercises <code>python -m build</code> and <code>twine check</code>.</li>
+      <li><code>--update-check on/off</code> CLI flag and matching <code>update_check</code> config key for opting out of the daily GitHub-Releases ping.</li>
+      <li><code>--log-transcripts on/off</code> CLI flag for explicit control of the <code>~/.openvoiceflow/logs/</code> daily files.</li>
+      <li>"Privacy at a glance" panel in the README that maps every on-disk file and every network egress in one table.</li>
+      <li><code>voiceflow/_secure_io.py</code> — <code>secure_write_json()</code> and <code>secure_chmod()</code> helpers that all config / profile / dictionary / snippets / stats / daily-log writes now go through, enforcing mode 600.</li>
+      <li>Community-health docs: SECURITY, PRIVACY, CONTRIBUTING, CODE_OF_CONDUCT, SUPPORT, VERSIONING, AGENTS, plus docs/COMPLIANCE, docs/COMPATIBILITY, docs/THREAT_MODEL, docs/ARCHITECTURE, docs/legal/DPA-template, docs/legal/THIRD_PARTY_NOTICES. ~14 files, ~2,100 lines.</li>
+      <li><code>RELEASE.md</code> — maintainer's three-command playbook plus when-things-go-wrong table.</li>
+      <li><code>.github/workflows/release.yml</code> rebuilt: tag-driven, Trusted Publisher PyPI publish on non-pre-release tags, split arm64/x86_64 DMG attach, <code>verify-version</code> gate that fails the release if tag ↔ pyproject ↔ <code>__version__</code> disagree.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li><strong>Config-key migration:</strong> <code>cleanup_prompt</code> → <code>llm_prompt</code>. Existing <code>~/.openvoiceflow/config.json</code> files are migrated transparently on load; the rename was the v0.2.0 schema change that previously dropped users' custom prompts on upgrade. (Fixes SS5.)</li>
+      <li><strong>Privacy defaults flipped to off for fresh installs.</strong> New users get <code>log_transcripts: False</code> and <code>auto_learn: False</code> until they opt in via the Know Me onboarding interview. <strong>Existing users keep their setting</strong> — the migration logic only applies the new defaults when no config exists.</li>
+      <li><code>install.sh</code> shim now <code>exec</code>s the pip-installed <code>openvoiceflow</code> console script directly instead of <code>python3 -m openvoiceflow</code> (which never existed — the module is <code>voiceflow</code>). (Fixes SS2.)</li>
+      <li><strong>Lint is now blocking in CI.</strong> Previously <code>ruff check</code> was advisory; the 43-finding backlog meant noise floor only ever climbed.</li>
+      <li>README hero rewritten so the privacy framing matches the actual data flow (audio is local; transcripts go to whatever LLM backend you pick; default Gemini is cloud, Ollama is local).</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li><strong>Code-review pass (2026-07)</strong> — full-codebase review; the notable fixes: - Streaming mode + snippet match no longer crashes with a <code>NameError</code> (the dictation was silently lost with only an error sound). - OpenAI, Anthropic, and Groq backends now honor per-app style and app context (previously silently dropped — the per-app style feature only worked on OpenRouter/Ollama). - Empty LLM responses fall back to the raw transcript instead of pasting nothing. - Custom voice commands containing backslashes no longer crash every dictation; command expansions are no longer re-processed by later commands (single-pass replacement). - Snippet triggers only match on word boundaries — a trigger like <code>sig</code> no longer swallows a dictation starting with "significant…". - Menu bar: LLM Backend / Hotkey / Style submenus are now populated at startup (previously empty until first use); Streaming/Auto-Style/ Auto-Learn toggles now apply to the running session; stopping or quitting aborts an in-flight recording instead of orphaning the whisper-stream process (hot mic). - Corrupt <code>config.json</code> no longer bricks every CLI entry point — the bad file is preserved as <code>config.json.corrupt</code> and defaults are restored. - Whisper model downloads use <code>curl --fail</code> with a temp file, so an HTTP error page or interrupted transfer can't be mistaken for a valid model forever after (fixed in <code>transcriber.py</code>, <code>install.sh</code>, and the DMG launcher). - Batch transcription timeout raised 30 s → 300 s so long dictations aren't discarded; Ollama cleanup timeout raised 30 s → 120 s for cold model loads. - Mic failures during recording start are surfaced (notification + error sound) instead of being silently swallowed with stale state. - Overlay no longer sticks on screen after too-short/no-speech/error aborts. - Selected-text capture no longer erases image/file clipboards when nothing was selected; <code>pbpaste</code>/<code>pbcopy</code> calls have timeouts. - <code>--show-config</code> no longer masks <code>hotkey</code> (over-broad secret matching); <code>--streaming-step</code> validates its value and <code>0</code> is no longer ignored; <code>--language</code> no longer crashes on a null <code>whisper_model</code>; env-var-only API-key setups aren't forced through onboarding on every launch. - Onboarding: re-running the wizard and switching backends no longer saves the old backend's key under the new backend's field; the Finish button survives a corrupt config; headless runs fail with instructions instead of a traceback (also fixed for <code>--profile</code>). - Interview: pressing Escape on the final screen no longer mislabels a saved profile as skipped. - <code>--autostart on</code> fails with a clear message when the executable can't be resolved (previously installed a LaunchAgent that silently never launched); the plist is generated with <code>plistlib</code> so paths containing <code>&amp;</code> can't produce invalid XML. - <code>install.sh</code> works under <code>curl | bash</code> (wizard prompts read from <code>/dev/tty</code>), installs from the script's own directory instead of the CWD, creates <code>~/.zshrc</code> when no shell rc exists, and uses <code>set -euo pipefail</code>. - Release workflow: DMG job sequenced after the PyPI job so the two release-upload steps can't race creating the same GitHub Release.</li>
+    </ul>
+    <h2>Changed (code-review pass)</h2>
+    <ul>
+      <li>The typed 🎙 recording indicator is now opt-in (<code>"recording_indicator": true</code>): it edits the frontmost document and could delete a user character when focus changed mid-dictation; the overlay HUD remains the default recording feedback.</li>
+      <li><code>paste_text</code> no longer moves the caret to end-of-line before pasting — text is pasted at the cursor, as documented.</li>
+      <li><code>--set-key BACKEND -</code> reads the key from stdin so it stays out of shell history and <code>ps</code> output (used by <code>install.sh</code>, which also hides key input).</li>
+    </ul>
+    <h2>Security (code-review pass)</h2>
+    <ul>
+      <li>Config/profile/dictionary writes are atomic and created with mode 600 from the first byte (previously created 644 then chmod'd — a crash mid-write could truncate the file or leave secrets world-readable).</li>
+      <li><code>~/.openvoiceflow/</code> is chmod 700; LaunchAgent stdout/stderr logs are pre-created with mode 600 (they capture dictated text via stdout).</li>
+      <li>Update-notification strings from the GitHub API are escaped before AppleScript interpolation (a crafted release tag/URL could otherwise break out of the string literal).</li>
+      <li>Internal <code>docs/superpowers/</code> documents removed from the repository, and the website build excludes any such directory as defense-in-depth.</li>
+      <li><strong>SS2</strong> — <code>install.sh</code> shim no longer crashes with <code>ModuleNotFoundError: No module named 'openvoiceflow'</code>.</li>
+      <li><strong>SS3</strong> — <code>from __future__ import annotations</code> added to all 30 modules using <code>X | None</code> syntax. <code>pip install .</code> and <code>openvoiceflow --version</code> now work on Python 3.9 (macOS 12 default) in addition to 3.10 / 3.11.</li>
+      <li><strong>SS5</strong> — Silent loss of custom <code>cleanup_prompt</code> on v0.1 → v0.2 upgrade. Migration now preserves the user's prompt under the new key.</li>
+      <li><strong>SS6</strong> — Onboarding "Personalize OpenVoiceFlow" button no longer silently swallows every exception from <code>interview.run_interview()</code>. Errors surface with a logged traceback and an in-app message.</li>
+      <li>The cargo-culted PyObjC import in <code>overlay.py</code> that broke the module for anyone installing without the <code>[overlay]</code> extra.</li>
+      <li>43 lint findings (37 unused imports, 4 placeholder-less f-strings, 1 multiple-statements, 1 unused variable). All resolved; lint now gates CI.</li>
+    </ul>
+    <h2>Security</h2>
+    <ul>
+      <li>All <code>~/.openvoiceflow/*.json</code> files (config, profile, dictionary, snippets, stats) and the daily transcript logs are written with mode 600 — owner-only — instead of inheriting umask 022. API keys and personal data are no longer world-readable on default macOS user accounts.</li>
+      <li>Lint gating in CI closes the "style debt grew silently" loop.</li>
+      <li>Twelve community-health files added so a procurement reviewer can find the answers they need without filing an issue: <code>SECURITY.md</code>, <code>PRIVACY.md</code>, <code>THREAT_MODEL.md</code>, <code>COMPLIANCE.md</code>, <code>CODE_OF_CONDUCT.md</code>, <code>CONTRIBUTING.md</code>, <code>SUPPORT.md</code>, <code>CHANGELOG.md</code> (this file), <code>VERSIONING.md</code>, <code>COMPATIBILITY.md</code>, <code>legal/DPA-template.md</code>, <code>legal/THIRD_PARTY_NOTICES.md</code>.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.1.html
+++ b/docs/release-notes/0.3.1.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.1 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.1" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.1</h1>
+    <p class="date">July 9, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The notarized macOS app now carries the hardened-runtime entitlements for microphone input and Apple Events, allowing recording and auto-paste to pass macOS privacy enforcement.</li>
+      <li>DMGs now use a small native launcher so macOS attributes Microphone and Accessibility consent to OpenVoiceFlow instead of its Python bootstrap.</li>
+      <li>First launch uses the native macOS consent prompts and no longer stacks two conflicting custom permission dialogs.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.2.html
+++ b/docs/release-notes/0.3.2.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.2 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.2" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.2</h1>
+    <p class="date">July 9, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The DMG bootstrap now executes the virtual-environment Python interpreter at its original path, preventing a silent dynamic-library crash on launch.</li>
+      <li>Native startup failures now show an alert with a direct link to the launcher log instead of making the app appear to do nothing.</li>
+      <li>First-run Tk onboarding runs in an isolated process, so an incompatible system Tk build falls back to local transcription without killing the app.</li>
+      <li>Menu-bar settings no longer clear uninitialized native submenus during startup.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.3.html
+++ b/docs/release-notes/0.3.3.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.3 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.3" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.3</h1>
+    <p class="date">July 10, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>The menu-bar menu now includes a persistent <strong>How to Use</strong> guide, and the first-run hotkey tip also appears in the floating HUD instead of relying only on a potentially hidden macOS notification.</li>
+      <li><code>voiceflow/platform_support.py</code>: one place for OS, macOS-version, architecture (Apple Silicon / Intel / Rosetta), and permission detection.</li>
+      <li>CLI platform gate: on Linux/Windows, <code>openvoiceflow</code> now prints a clear "macOS-only" explanation with uninstall guidance and exits cleanly instead of crashing with a traceback. <code>--doctor</code> and <code>--show-config</code> keep working so users can inspect state first.</li>
+      <li>New doctor checks: operating system + version, architecture (warns on Rosetta-translated Python and Intel Homebrew on Apple Silicon), and the three macOS permissions dictation depends on (Microphone, Accessibility, Input Monitoring) with click-to-fix System Settings links.</li>
+      <li>A launch below the supported macOS floor (12 Monterey) now prints an upgrade warning.</li>
+      <li>CI: new <code>non-macos-guard</code> job on <code>ubuntu-latest</code> pins the "friendly message, never a traceback" guarantee and runs the full suite on Linux.</li>
+      <li>Website: the download page now detects the visitor's OS. Windows, Linux, ChromeOS, Android, and iPhone/iPad visitors get an inert "Not available for &lt;OS&gt;" notice instead of a live DMG button; Safari-on-Mac visitors get an Apple Silicon / Intel recommendation via a WebGL renderer fallback (Chromium browsers already used architecture hints).</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Short streaming dictations no longer lose the final transcript fragment when <code>whisper-stream</code> exits without a trailing newline.</li>
+      <li>Fresh installs now use the reliable batch recorder by default. Experimental real-time streaming remains available through the menu bar or <code>--streaming on</code>. Existing v0.3.2 installs are reset to batch mode once and can opt back into streaming afterward.</li>
+      <li><code>voiceflow.recorder</code> no longer imports <code>sounddevice</code> at module load — the import crashed the whole app (<code>OSError: PortAudio library not found</code>) on machines without PortAudio before any error handling could run.</li>
+      <li><code>find_whisper_cpp</code> / the doctor's Homebrew check use <code>shutil.which</code> instead of spawning <code>which</code>, which crashed on Windows.</li>
+      <li>The keyboard-listener (pynput) import is now guarded in CLI and menu-bar modes: a missing input backend produces a clear error instead of a crash.</li>
+      <li>Clipboard/keystroke/sound helpers (<code>pbcopy</code>, <code>pbpaste</code>, <code>osascript</code>, <code>afplay</code>) no longer propagate <code>FileNotFoundError</code> when the binaries are missing; failures surface as user-visible notifications.</li>
+      <li><code>--autostart</code> refuses politely off-macOS instead of writing a <code>~/Library/LaunchAgents</code> folder on Linux; on macOS it now prefers the supported <code>launchctl bootstrap</code>/<code>bootout</code> verbs, falling back to the deprecated <code>load</code>/<code>unload</code>.</li>
+      <li><code>validate_setup</code> reports a broken audio backend (<code>OSError</code>) instead of only a missing <code>sounddevice</code> package.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.4.html
+++ b/docs/release-notes/0.3.4.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.4 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.4" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.4</h1>
+    <p class="date">July 10, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>A polished native menu-bar experience led by <strong>Open OpenVoiceFlow</strong>, with grouped Dictation Shortcut, AI Cleanup, Writing Style, Personalization, and Advanced menus.</li>
+      <li>A user-triggered <strong>Check for Updates…</strong> action that always reports whether a release is available, the app is current, or the service could not be reached.</li>
+      <li>Direct menu links to macOS Microphone and Accessibility settings.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>The status item now uses dark-mode-safe SF Symbols with accessible labels: a waveform while ready, a pause symbol while paused, and a warning symbol when setup needs attention. A visible <code>OpenVoiceFlow</code> text label remains as the fallback if symbols are unavailable.</li>
+      <li>Menu selections now use native macOS checkmarks, clean human-readable names, every supported dictation shortcut, standard separators, and <strong>⌘Q</strong> for <strong>Quit OpenVoiceFlow</strong> instead of emoji-prefixed labels.</li>
+      <li>The long-lived Python UI process now stays out of the Dock and uses the bundled OpenVoiceFlow icon for native dialogs. The Current App row refreshes as focus changes without mistaking the UI process for the user's app.</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The waveform status item is created before backend validation begins, so a slow local backend no longer makes launch look unresponsive.</li>
+      <li><strong>Edit Profile</strong> now runs its Tk interview in an isolated process instead of risking a native Tk crash in the menu-bar process.</li>
+      <li>The <strong>Download</strong> button in the update alert now recognizes AppKit's native button result and opens the release page correctly.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.5.html
+++ b/docs/release-notes/0.3.5.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.5 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.5" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.5</h1>
+    <p class="date">July 13, 2026</p>
+    <h2>Fixed — first launch could silently do nothing (no menu bar icon, no wizard)</h2>
+    <ul>
+      <li><strong>Stale bootstrap lock.</strong> <code>~/.openvoiceflow/.bootstrap.lock</code> survives reboots, and its stored pid could be reused by an unrelated live process — the alive check then matched, so every launch exited silently forever. The lock now only counts when the pid is alive *and* is really our <code>launcher.sh</code>.</li>
+      <li><strong>Command Line Tools stub.</strong> <code>command -v python3</code> always succeeds on macOS (Apple ships an installer stub), so a Mac without the Command Line Tools got past the check and failed later with no message. First launch now probes <code>xcode-select</code>, triggers the CLT installer, and shows instructions.</li>
+      <li><strong>Broken venv skipped as "installed".</strong> A macOS/CLT update can break the venv's interpreter or native wheels while the <code>.ovf-deps-installed</code> marker stays present, so the bootstrap was skipped and every launch died on import. The launcher now health-checks the venv (imports numpy/sounddevice/pynput/ rumps/objc) and rebuilds it when the check fails.</li>
+      <li><strong>Silent progress + silent fallbacks.</strong> First launch now shows an up-front dialog explaining the ~5-minute setup and where the menu bar icon appears (including the 14"/16" notch tip); the venv/pip steps fail with a visible dialog instead of exiting quietly; a skipped setup wizard and a menu-bar (rumps) failure now say so instead of dropping to an invisible background process.</li>
+      <li><strong>Input Monitoring permission (native launcher).</strong> The native launcher now proactively requests Input Monitoring (<code>IOHIDRequestAccess</code>) at first launch, in addition to Microphone and Accessibility, so the grant is in place before the dead-listener watchdog would ever need to fire.</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Startup now checks the <strong>Input Monitoring</strong> permission — the one the global hotkey listener actually needs. It was never verified (only the doctor knew about it), so a missing grant produced a "Ready" menu with a hotkey that silently never fired. A denied probe warns loudly with a one-click System Settings link but never blocks startup, because Accessibility trust can also grant listen access.</li>
+      <li>A new dead-listener watchdog catches the same failure by measuring reality: if no key events at all arrive within 15 seconds of the listener starting *and* macOS reports Input Monitoring denied, the menu bar shows a front-and-center alert with the fix. An idle user without the permission problem gets a one-time gentle tip instead. (Previously this self-check existed only for the fn/Globe key, never for the default Right Command hotkey.)</li>
+      <li>Setup failures at launch now surface as a <strong>modal alert</strong> with a one-click settings link instead of only a Notification Center banner — notifications require a permission of their own and the status item can hide behind a MacBook notch, so the old failure path could be entirely invisible.</li>
+      <li>A corrupt or wrong-shaped file in <code>~/.openvoiceflow/</code> (snippets, stats, profile, dictionary aliases, transcript logs, seen-tips) can no longer make every dictation fail with a generic error: all user-data loaders now validate shape, drop malformed entries, and degrade to safe defaults. <code>--show-profile</code> prints recovery guidance instead of a literal <code>null</code> when the profile file is corrupt.</li>
+      <li>Every <code>osascript</code>/<code>launchctl</code>/<code>open</code> subprocess call now has a timeout, so a pending macOS consent dialog or a wedged <code>launchd</code> can no longer freeze the hotkey thread permanently. If auto-paste times out, a notification explains that the text is already on the clipboard, ready for ⌘V.</li>
+      <li>Auto-learn no longer records ordinary content edits (e.g. "june" → "july") as permanent corrections: the word-similarity threshold was raised from 0.4 to 0.55, calibrated so genuine mishearings ("mir" → "Meer", "recieve" → "receive") are still learned.</li>
+      <li>Setup wizard: an <code>llm_backend</code> of <code>none</code> no longer breaks the backend screen; switching backends clears the previous backend's prefilled API key instead of finishing without saving a key; a failed final config write now shows an error dialog instead of a Finish button that silently does nothing.</li>
+      <li>Know Me interview: no longer clobbers a configured <code>--style</code> (the style radio preselects from config, and styles the interview can't express, like <code>code</code> or <code>email</code>, are preserved unless actively changed); Enter-key bindings no longer leak between screens; context-menu paste into multi-line fields is no longer dropped; a hand-edited profile can't crash the wizard.</li>
+      <li>Menu bar: notifications fall back to the osascript path when <code>rumps.notification</code> is unavailable (non-framework Python installs), and <strong>Check for Updates…</strong> can no longer get stuck on unexpected network/response errors. The duplicate startup update check in menu-bar mode was removed.</li>
+      <li>Overlay: the compact auto-learn pill no longer permanently shrinks the font of every subsequent HUD message.</li>
+      <li>CLI: value-taking flags now reject empty strings (<code>--search ""</code> used to launch the app; <code>--add-command ""</code> corrupted every dictation); config setters combined with an action flag now print a warning instead of being silently ignored; <code>--auto-learn</code>, <code>--update-check</code>, and <code>--log-transcripts</code> now compose on one command line.</li>
+      <li>Doctor: macOS version detection resolves the "10.16" Big Sur compatibility shim via <code>sysctl kern.osproductversion</code> and reports "unknown" (a WARN) rather than false-failing supported systems; bare-major versions ("12") no longer compare below the (12, 0) minimum.</li>
+    </ul>
+    <h2>Added</h2>
+    <ul>
+      <li>CI now compiles the native launcher (<code>clang -fsyntax-only</code>) and runs a functional test suite (<code>tests/test_launcher_flows.py</code>) that renders the real <code>launcher.sh</code> and exercises the stale-lock, missing-CLT, broken-venv, and first-run-visibility paths with shimmed macOS commands.</li>
+      <li>The menu-bar app now shows a <strong>Dock icon</strong> while running (toggleable via <strong>Advanced → Show in Dock</strong>, default on). A menu-bar-only icon can hide behind a MacBook notch, leaving no visible sign the app is running; clicking the Dock icon opens the native status summary with the active dictation shortcut.</li>
+      <li>17 regression tests pinning the defensive-loader, learner-threshold, updater, and macOS-version behaviors (<code>tests/test_defensive_loaders.py</code>), plus 12 pinning the Input Monitoring gate, dead-listener watchdog, and Dock default (<code>tests/test_visibility_and_watchdog.py</code>).</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>CI lint now covers the entire repository (<code>ruff check .</code>), not just <code>voiceflow/</code>.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.3.6.html
+++ b/docs/release-notes/0.3.6.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.3.6 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.3.6" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.3.6</h1>
+    <p class="date">July 18, 2026</p>
+    <h2>Fixed — Fn / 🌐 Globe key no longer fails silently</h2>
+    <ul>
+      <li><strong>Fn was never a working hotkey.</strong> macOS doesn't deliver the Fn/Globe key to <code>pynput</code>, so selecting it left dictation permanently dead with no feedback. Choosing Fn now surfaces an immediate modal explaining the limitation and pointing at Right Command (the default), the menu-bar picker hides Fn unless it's the current (legacy) selection, and onboarding no longer offers it.</li>
+    </ul>
+    <h2>Fixed — production-hardening pass (end-to-end audit follow-up)</h2>
+    <ul>
+      <li><strong>Hotkey can't be wedged by a consent dialog.</strong> The microphone is now armed on the event-tap thread and the ~150 ms of <code>osascript</code> context capture runs on a worker, so a stalled Automation/Accessibility dialog can no longer block (and let macOS disable) the global hotkey.</li>
+      <li><strong>Runaway recordings self-terminate.</strong> A max-duration watchdog force-stops a dictation whose key-release was lost, instead of leaving the mic and <code>whisper-stream</code> running indefinitely.</li>
+      <li><strong>No PortAudio stream leak.</strong> <code>recorder.stop()</code> always releases the audio stream even when the input device is unplugged mid-recording; that failure is now surfaced instead of silently freezing the overlay.</li>
+      <li><strong>Clipboard data-loss fixed.</strong> Selected-text capture no longer overwrites a non-text clipboard (image/file) and never restores empty text over the selection.</li>
+      <li><strong>Security defense-in-depth.</strong> Secrets are written with <code>O_EXCL|O_NOFOLLOW</code> (symlink-swap safe); <code>~/.openvoiceflow/logs/</code> is <code>0700</code>; LLM/Ollama responses are read with a 16 MB cap; <code>ollama_url</code> rejects non-HTTP schemes and warns when it points off-box. Hung <code>pbcopy</code> children are reaped, not orphaned.</li>
+      <li><strong>Upgrades actually reinstall dependencies.</strong> The DMG venv marker is now version-stamped, so a release that adds or bumps a dependency reinstalls for existing upgraders instead of breaking on import.</li>
+      <li><strong>Overlay polish.</strong> HUD timers run in the common run-loop mode (no freeze during menu tracking), fades honor Reduce Motion, and the window is ordered out after fading so it doesn't linger in every Space.</li>
+      <li><strong>Know-Me interview no longer self-destructs</strong> when Escape is pressed while a text field is focused.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.4.2.html
+++ b/docs/release-notes/0.4.2.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.4.2 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.4.2" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.4.2</h1>
+    <p class="date">July 25, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>Automatic background updates (Sparkle) with honest in-app update cues.</li>
+      <li>Per-app dictation breakdown ("Where you dictate").</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Failed pastes recover; the transcription model hot-swaps without restart.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.4.3.html
+++ b/docs/release-notes/0.4.3.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.4.3 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.4.3" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.4.3</h1>
+    <p class="date">July 26, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Dock presence obeys the setting; <code>fn</code> is the default hotkey; onboarding gives real feedback while permissions land.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.1.html
+++ b/docs/release-notes/0.5.1.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.1 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.1" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.1</h1>
+    <p class="date">July 26, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li><strong>The hotkey now works from launch.</strong> Previously nothing started the key listener after first run — every relaunch came up deaf until Start Dictation was clicked in the menu. The Start/Stop menu item is gone (Pause remains); a Turn On Dictation button appears only if a permission was revoked.</li>
+    </ul>
+    <h2>Added</h2>
+    <ul>
+      <li>PERMISSIONS card in dashboard Settings with live status per grant; re-granting revives dictation without a relaunch.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.10.html
+++ b/docs/release-notes/0.5.10.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.10 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.10" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.10</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>Dictionary, Snippets, and Styles are now one <strong>Personalize</strong> pane in the dashboard sidebar, switched with tabs instead of three separate rows. Each tab keeps its item count, the content area now sits in a single card, and switching tabs animates instead of jumping. No data or behavior changes — same stores, same add/remove actions, same empty states. Docs updated to describe the new location (<code>Dashboard ▸ Personalize</code>).</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.11.html
+++ b/docs/release-notes/0.5.11.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.11 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.11" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.11</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>The History pane now carries a subtitle: "Stored only on this Mac — never synced to a server." Scoped deliberately to what's true unconditionally (this list is local storage, full stop) rather than a blanket "nothing leaves this machine" claim, since cloud AI cleanup (opt-in, off by default) does send dictated text to the selected provider before it lands here — that's covered separately by the existing footer line and the privacy docs.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.12.html
+++ b/docs/release-notes/0.5.12.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.12 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.12" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.12</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>“Where you dictate” now shows each app’s real icon with a time-share ring, making the per-app breakdown easier to scan while preserving the existing local-only usage data and accessibility labels.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.13.html
+++ b/docs/release-notes/0.5.13.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.13 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.13" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.13</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>Settings no longer exposes the anonymous analytics device ID or the long leaderboard-sharing explanation, and the Feedback sheet no longer shows its usage-snapshot explainer. The sharing toggle, leaderboard name, deletion action, and feedback behavior are unchanged.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.14.html
+++ b/docs/release-notes/0.5.14.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.14 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.14" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.14</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>Simplified feedback to one optional email field in a native macOS popover that dismisses with Cancel, Send, Escape, or an outside click.</li>
+      <li>Moved Know Me into Personalize so related controls stay together.</li>
+      <li>Changed generated leaderboard aliases to compact one-token handles while preserving custom names during legacy migration.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.15.html
+++ b/docs/release-notes/0.5.15.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.15 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.15" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.15</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Restored Feedback as a centered native modal instead of a left-anchored popover, while retaining the always-visible optional email field and Cancel, Send, and Escape dismissal.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.16.html
+++ b/docs/release-notes/0.5.16.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.16 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.16" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.16</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Personalized Styles now shows recognizable Discord and Gmail icons, using installed app icons first and bundled brand marks when those apps are unavailable.</li>
+      <li>Clicking the dashboard outside the centered Feedback sheet now dismisses it, while clicks inside the sheet or in unrelated OpenVoiceFlow windows keep their normal behavior.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.17.html
+++ b/docs/release-notes/0.5.17.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.17 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.17" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.17</h1>
+    <p class="date">August 30, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>App names across Home, History, and Personalize now use recognizable app or company logos, including Claude, Discord, Notion, and Outlook. Installed macOS app icons remain the first choice, with bundled brand marks as reliable fallbacks.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>Leaderboard nicknames now save when Return is pressed or the field loses focus, immediately publish that installation's aggregate totals, and refresh the standings after a successful update. Each installation keeps its own row even when multiple computers use the same nickname.</li>
+      <li>Opening Leaderboard now republishes that installation's saved aggregate totals before fetching standings, restoring existing local usage without requiring another dictation or nickname change.</li>
+      <li>The leaderboard service now uses Neon's supported serverless database client and accepts both current and legacy Vercel database environment-variable names.</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>History's Copy action now changes to “Copied” with a checkmark after a successful copy and resets automatically after 1.5 seconds.</li>
+      <li>Leaderboard loading and nickname-sync failures now show an honest retry action instead of appearing as empty standings.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.18.html
+++ b/docs/release-notes/0.5.18.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.18 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.18" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.18</h1>
+    <p class="date">August 31, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Public leaderboard standings now include only rows with at least 60 minutes saved and show no more than five entries, while still showing your own row separately.</li>
+      <li>Legacy auto-generated leaderboard names now use the same exact 10–99 suffix range as the native app, preserving custom-looking names ending in 00–09.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.19.html
+++ b/docs/release-notes/0.5.19.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.19 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.19" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.19</h1>
+    <p class="date">September 2, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>The leaderboard now draws a fixed seven rows whatever the standings return, so the height of the card no longer reveals how many people use OpenVoiceFlow. Rows the service doesn't name are masked — a shimmering placeholder with no rank, name, or total — and the tail fades out rather than ending on a countable last row. The card states no rule and shows no threshold: naming the bar would let anyone counting the visible names work out what population they were counting.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.2.html
+++ b/docs/release-notes/0.5.2.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.2 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.2" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.2</h1>
+    <p class="date">July 26, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>Live transcript in the HUD while the key is held ("Show words as you speak", default on; respects the text-echo privacy setting).</li>
+      <li>Speech-engine choice in onboarding — four models with size and benefit, nothing preselected, nothing downloading until you pick.</li>
+      <li>Launch at login (SMAppService), default on, with a Settings toggle.</li>
+      <li>Onboarding's "I live up there" now anchors a callout to the real menu-bar icon, with a mock menu-bar illustration when the icon is squeezed out.</li>
+      <li>Dashboard banner explaining when macOS hides the menu-bar icon (full bar / notch) and the ⌘-drag fix.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>Onboarding ends in the dashboard instead of an empty desktop; the try-it card acknowledges key-down instantly.</li>
+      <li>The "names I'd get wrong" question moved out of onboarding (Know-Me keeps it).</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.20.html
+++ b/docs/release-notes/0.5.20.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.20 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.20" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.20</h1>
+    <p class="date">September 2, 2026</p>
+    <h2>Changed</h2>
+    <ul>
+      <li>The leaderboard now labels its figure "time back" instead of "time saved", matching Home, onboarding, and the manual. The number is how long the same words would have taken to type at 40 wpm; nothing subtracts the time dictating them actually took, so calling it a saving overstated it. The number itself is unchanged, as are the <code>minutesSaved</code> field and <code>minutes_saved</code> column that already-shipped clients depend on.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.21.html
+++ b/docs/release-notes/0.5.21.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.21 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.21" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.21</h1>
+    <p class="date">September 6, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The <strong>Version History</strong> button on the "You're up to date!" update alert now opens the <a href="https://openvoiceflow.com/releases.html">Releases page</a> instead of the "How it works" marketing page, which listed no versions at all. Sparkle fills that button from the appcast's <code>fullReleaseNotesLink</code>, which the feed never set, so it fell back to a <code>releaseNotesLink</code> that pointed at marketing copy. The appcast now sets both, and this fix reaches every installed build the moment the site deploys — the button reads the website's feed, not the app.</li>
+      <li>The release notes shown inside the update sheet are now that version's actual notes, generated from this changelog, rather than the same marketing page.</li>
+    </ul>
+    <h2>Added</h2>
+    <ul>
+      <li>Settings ▸ "You're on vX.Y.Z" now has a <strong>Version history</strong> link that opens the Releases page at the running version, so the notes no longer sit behind an update check that reports there is nothing to install.</li>
+      <li>Every release on the Releases page is individually linkable (<code>releases.html#v0.5.21</code>), and opening such a link expands that release rather than landing on a collapsed card.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>The dashboard sidebar footer now says whether the running build is current instead of always reading "auto-updating". When the appcast offers a newer version it shows an <strong>Update</strong> action that installs it; when the build is the latest, it reads "Up to date" with nothing to click. Before a check has finished — including when automatic updates are off, which stays an opt-out of background checks — the footer shows the version alone rather than claiming a freshness nothing verified.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.3.html
+++ b/docs/release-notes/0.5.3.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.3 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.3" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.3</h1>
+    <p class="date">July 27, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li><strong>Large turbo could never download.</strong> Its model id didn't exist in the WhisperKit repo; every user who chose it hit "no models found" disguised as a connection error. Correct id shipped, saved settings migrate silently.</li>
+      <li>Browsing the engine chooser no longer starts a download per click: a 1.5 s grace window ("Starting in a moment — switch engines freely") starts the transfer only once the choice rests, and switching cancels the superseded download outright. Model loads are single-flight, so overlapping transfers can no longer corrupt each other's cache.</li>
+      <li>Download failure copy points at Details instead of guessing "check your connection" — the guess was wrong exactly when it mattered.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.4.html
+++ b/docs/release-notes/0.5.4.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.4 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.4" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.4</h1>
+    <p class="date">July 27, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The download meter showed "0 of 0 MB · 0.0 MB/s" over a moving bar: WhisperKit reports abstract progress units for multi-file model downloads, not bytes. The meter now shows percent (and the always-honest ETA) when units can't be bytes, instead of inventing megabytes.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.5.html
+++ b/docs/release-notes/0.5.5.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.5 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.5" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.5</h1>
+    <p class="date">July 27, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The progress bar no longer parks at 100% with no way forward. WhisperKit compiles the model for your chip after the download — minutes on a first large-model run, with no progress signal — so the transfer now owns 0–90% and the compile creeps through the 90s under "Downloaded — now optimizing for your Mac. First run only." 100% arrives only with the Try It button.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>RECOMMENDED now adapts to the Mac: Large turbo on Apple Silicon with disk headroom, Small on Intel or a tight disk. No permissions involved.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.6.html
+++ b/docs/release-notes/0.5.6.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.6 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.6" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.6</h1>
+    <p class="date">August 25, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>The language picker now offers all 99 languages in Whisper's multilingual set (previously eleven), including Ukrainian. Tiny, Small, Medium, and Large turbo all share the same tokenizer, so the list applies to every engine offered in Settings.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.7.html
+++ b/docs/release-notes/0.5.7.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.7 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.7" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.7</h1>
+    <p class="date">August 28, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>A Feedback item in the sidebar, below Settings. Opens a short form (bug / idea / praise / other, plus an optional reply email) and, only on Send, opens a <code>mailto:</code> with the message and a small aggregate usage snapshot (words dictated, time saved, streak, last 7 days, first-use date) — never dictation text, snippets, dictionary entries, or the Know-Me profile, and nothing is sent until Send is pressed.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.8.html
+++ b/docs/release-notes/0.5.8.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.8 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.8" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.8</h1>
+    <p class="date">August 28, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>Anonymous usage sharing and an in-app Leaderboard, ranked by time saved. <strong>On by default</strong> — a real, disclosed change from every prior release, which sent nothing. Settings ▸ Privacy ▸ "Share anonymous usage &amp; leaderboard rank" turns it off, deletes nothing retroactively but stops every future request immediately; a "Delete my leaderboard data" button removes a past submission outright. What's sent: a random per-device ID, a display name you can change, aggregate word/time/streak/feature-usage counters already shown on Home, and a server-derived country (no IP stored). Never dictation text, snippets, dictionary entries, or the Know-Me profile. Full detail in <code>PRIVACY.md</code> §7 and the docs site's Privacy architecture ▸ Analytics &amp; leaderboard section.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>Docs and <code>PRIVACY.md</code> updated to describe the above plainly, replacing the "no telemetry" claims that were accurate through 0.5.7 and are not anymore.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/release-notes/0.5.9.html
+++ b/docs/release-notes/0.5.9.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.9 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.9" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.9</h1>
+    <p class="date">August 29, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>The Feedback sheet's category picker ("Something's broken" / "Feature idea" / "Just saying thanks" / "Something else") overflowed a 440pt-wide sheet, truncating the leading and trailing segments. Segmented control now shows short labels (Bug/Idea/Thanks/Other); the full wording still goes into the email subject and body. Sheet widened to 480pt for margin.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -68,26 +68,42 @@
       <h1 class="hero-title">Releases</h1>
       <p class="hero-sub answer-block">OpenVoiceFlow ships often — every release below is real, shipped, and notarized, newest first. Notes come straight from the project's changelog, so this list is exactly as current as the code. Want the raw commit history or to file an issue? <a href="https://github.com/shimoverse/openvoiceflow/releases">See every release on GitHub</a>.</p>
 
-      <details class="content-card" open><summary><h2>v0.5.20 <span class="release-date">· September 2, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.21" open><summary><h2>v0.5.21 <span class="release-date">· September 6, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li>The <strong>Version History</strong> button on the "You're up to date!" update alert now opens the <a href="https://openvoiceflow.com/releases.html">Releases page</a> instead of the "How it works" marketing page, which listed no versions at all. Sparkle fills that button from the appcast's <code>fullReleaseNotesLink</code>, which the feed never set, so it fell back to a <code>releaseNotesLink</code> that pointed at marketing copy. The appcast now sets both, and this fix reaches every installed build the moment the site deploys — the button reads the website's feed, not the app.</li>
+          <li>The release notes shown inside the update sheet are now that version's actual notes, generated from this changelog, rather than the same marketing page.</li>
+        </ul>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>Settings ▸ "You're on vX.Y.Z" now has a <strong>Version history</strong> link that opens the Releases page at the running version, so the notes no longer sit behind an update check that reports there is nothing to install.</li>
+          <li>Every release on the Releases page is individually linkable (<code>releases.html#v0.5.21</code>), and opening such a link expands that release rather than landing on a collapsed card.</li>
+        </ul>
+        <h3>Changed</h3>
+        <ul class="check-list">
+          <li>The dashboard sidebar footer now says whether the running build is current instead of always reading "auto-updating". When the appcast offers a newer version it shows an <strong>Update</strong> action that installs it; when the build is the latest, it reads "Up to date" with nothing to click. Before a check has finished — including when automatic updates are off, which stays an opt-out of background checks — the footer shows the version alone rather than claiming a freshness nothing verified.</li>
+        </ul>
+      </details>
+      <details class="content-card" id="v0.5.20" open><summary><h2>v0.5.20 <span class="release-date">· September 2, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>The leaderboard now labels its figure "time back" instead of "time saved", matching Home, onboarding, and the manual. The number is how long the same words would have taken to type at 40 wpm; nothing subtracts the time dictating them actually took, so calling it a saving overstated it. The number itself is unchanged, as are the <code>minutesSaved</code> field and <code>minutes_saved</code> column that already-shipped clients depend on.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.19 <span class="release-date">· September 2, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.19" open><summary><h2>v0.5.19 <span class="release-date">· September 2, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>The leaderboard now draws a fixed seven rows whatever the standings return, so the height of the card no longer reveals how many people use OpenVoiceFlow. Rows the service doesn't name are masked — a shimmering placeholder with no rank, name, or total — and the tail fades out rather than ending on a countable last row. The card states no rule and shows no threshold: naming the bar would let anyone counting the visible names work out what population they were counting.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.18 <span class="release-date">· August 31, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.18" open><summary><h2>v0.5.18 <span class="release-date">· August 31, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>Public leaderboard standings now include only rows with at least 60 minutes saved and show no more than five entries, while still showing your own row separately.</li>
           <li>Legacy auto-generated leaderboard names now use the same exact 10–99 suffix range as the native app, preserving custom-looking names ending in 00–09.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.17 <span class="release-date">· August 30, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.17" open><summary><h2>v0.5.17 <span class="release-date">· August 30, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>App names across Home, History, and Personalize now use recognizable app or company logos, including Claude, Discord, Notion, and Outlook. Installed macOS app icons remain the first choice, with bundled brand marks as reliable fallbacks.</li>
@@ -104,20 +120,20 @@
           <li>Leaderboard loading and nickname-sync failures now show an honest retry action instead of appearing as empty standings.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.16 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.16" open><summary><h2>v0.5.16 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>Personalized Styles now shows recognizable Discord and Gmail icons, using installed app icons first and bundled brand marks when those apps are unavailable.</li>
           <li>Clicking the dashboard outside the centered Feedback sheet now dismisses it, while clicks inside the sheet or in unrelated OpenVoiceFlow windows keep their normal behavior.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.15 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.15" open><summary><h2>v0.5.15 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>Restored Feedback as a centered native modal instead of a left-anchored popover, while retaining the always-visible optional email field and Cancel, Send, and Escape dismissal.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.14 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.14" open><summary><h2>v0.5.14 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>Simplified feedback to one optional email field in a native macOS popover that dismisses with Cancel, Send, Escape, or an outside click.</li>
@@ -125,37 +141,37 @@
           <li>Changed generated leaderboard aliases to compact one-token handles while preserving custom names during legacy migration.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.13 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.13" open><summary><h2>v0.5.13 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>Settings no longer exposes the anonymous analytics device ID or the long leaderboard-sharing explanation, and the Feedback sheet no longer shows its usage-snapshot explainer. The sharing toggle, leaderboard name, deletion action, and feedback behavior are unchanged.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.12 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.12" open><summary><h2>v0.5.12 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>“Where you dictate” now shows each app’s real icon with a time-share ring, making the per-app breakdown easier to scan while preserving the existing local-only usage data and accessibility labels.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.11 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.11" open><summary><h2>v0.5.11 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>The History pane now carries a subtitle: "Stored only on this Mac — never synced to a server." Scoped deliberately to what's true unconditionally (this list is local storage, full stop) rather than a blanket "nothing leaves this machine" claim, since cloud AI cleanup (opt-in, off by default) does send dictated text to the selected provider before it lands here — that's covered separately by the existing footer line and the privacy docs.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.10 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.10" open><summary><h2>v0.5.10 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Changed</h3>
         <ul class="check-list">
           <li>Dictionary, Snippets, and Styles are now one <strong>Personalize</strong> pane in the dashboard sidebar, switched with tabs instead of three separate rows. Each tab keeps its item count, the content area now sits in a single card, and switching tabs animates instead of jumping. No data or behavior changes — same stores, same add/remove actions, same empty states. Docs updated to describe the new location (<code>Dashboard ▸ Personalize</code>).</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.9 <span class="release-date">· August 29, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.9" open><summary><h2>v0.5.9 <span class="release-date">· August 29, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>The Feedback sheet's category picker ("Something's broken" / "Feature idea" / "Just saying thanks" / "Something else") overflowed a 440pt-wide sheet, truncating the leading and trailing segments. Segmented control now shows short labels (Bug/Idea/Thanks/Other); the full wording still goes into the email subject and body. Sheet widened to 480pt for margin.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.8 <span class="release-date">· August 28, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.8" open><summary><h2>v0.5.8 <span class="release-date">· August 28, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>Anonymous usage sharing and an in-app Leaderboard, ranked by time saved. <strong>On by default</strong> — a real, disclosed change from every prior release, which sent nothing. Settings ▸ Privacy ▸ "Share anonymous usage &amp; leaderboard rank" turns it off, deletes nothing retroactively but stops every future request immediately; a "Delete my leaderboard data" button removes a past submission outright. What's sent: a random per-device ID, a display name you can change, aggregate word/time/streak/feature-usage counters already shown on Home, and a server-derived country (no IP stored). Never dictation text, snippets, dictionary entries, or the Know-Me profile. Full detail in <code>PRIVACY.md</code> §7 and the docs site's Privacy architecture ▸ Analytics &amp; leaderboard section.</li>
@@ -165,19 +181,19 @@
           <li>Docs and <code>PRIVACY.md</code> updated to describe the above plainly, replacing the "no telemetry" claims that were accurate through 0.5.7 and are not anymore.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.7 <span class="release-date">· August 28, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.7" open><summary><h2>v0.5.7 <span class="release-date">· August 28, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>A Feedback item in the sidebar, below Settings. Opens a short form (bug / idea / praise / other, plus an optional reply email) and, only on Send, opens a <code>mailto:</code> with the message and a small aggregate usage snapshot (words dictated, time saved, streak, last 7 days, first-use date) — never dictation text, snippets, dictionary entries, or the Know-Me profile, and nothing is sent until Send is pressed.</li>
         </ul>
       </details>
-      <details class="content-card" open><summary><h2>v0.5.6 <span class="release-date">· August 25, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.6" open><summary><h2>v0.5.6 <span class="release-date">· August 25, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>The language picker now offers all 99 languages in Whisper's multilingual set (previously eleven), including Ukrainian. Tiny, Small, Medium, and Large turbo all share the same tokenizer, so the list applies to every engine offered in Settings.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.5.5 <span class="release-date">· July 27, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.5"><summary><h2>v0.5.5 <span class="release-date">· July 27, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>The progress bar no longer parks at 100% with no way forward. WhisperKit compiles the model for your chip after the download — minutes on a first large-model run, with no progress signal — so the transfer now owns 0–90% and the compile creeps through the 90s under "Downloaded — now optimizing for your Mac. First run only." 100% arrives only with the Try It button.</li>
@@ -187,13 +203,13 @@
           <li>RECOMMENDED now adapts to the Mac: Large turbo on Apple Silicon with disk headroom, Small on Intel or a tight disk. No permissions involved.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.5.4 <span class="release-date">· July 27, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.4"><summary><h2>v0.5.4 <span class="release-date">· July 27, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>The download meter showed "0 of 0 MB · 0.0 MB/s" over a moving bar: WhisperKit reports abstract progress units for multi-file model downloads, not bytes. The meter now shows percent (and the always-honest ETA) when units can't be bytes, instead of inventing megabytes.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.5.3 <span class="release-date">· July 27, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.3"><summary><h2>v0.5.3 <span class="release-date">· July 27, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li><strong>Large turbo could never download.</strong> Its model id didn't exist in the WhisperKit repo; every user who chose it hit "no models found" disguised as a connection error. Correct id shipped, saved settings migrate silently.</li>
@@ -201,7 +217,7 @@
           <li>Download failure copy points at Details instead of guessing "check your connection" — the guess was wrong exactly when it mattered.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.5.2 <span class="release-date">· July 26, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.2"><summary><h2>v0.5.2 <span class="release-date">· July 26, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>Live transcript in the HUD while the key is held ("Show words as you speak", default on; respects the text-echo privacy setting).</li>
@@ -216,7 +232,7 @@
           <li>The "names I'd get wrong" question moved out of onboarding (Know-Me keeps it).</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.5.1 <span class="release-date">· July 26, 2026</span></h2></summary>
+      <details class="content-card" id="v0.5.1"><summary><h2>v0.5.1 <span class="release-date">· July 26, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li><strong>The hotkey now works from launch.</strong> Previously nothing started the key listener after first run — every relaunch came up deaf until Start Dictation was clicked in the menu. The Start/Stop menu item is gone (Pause remains); a Turn On Dictation button appears only if a permission was revoked.</li>
@@ -226,13 +242,13 @@
           <li>PERMISSIONS card in dashboard Settings with live status per grant; re-granting revives dictation without a relaunch.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.4.3 <span class="release-date">· July 26, 2026</span></h2></summary>
+      <details class="content-card" id="v0.4.3"><summary><h2>v0.4.3 <span class="release-date">· July 26, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>Dock presence obeys the setting; <code>fn</code> is the default hotkey; onboarding gives real feedback while permissions land.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.4.2 <span class="release-date">· July 25, 2026</span></h2></summary>
+      <details class="content-card" id="v0.4.2"><summary><h2>v0.4.2 <span class="release-date">· July 25, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>Automatic background updates (Sparkle) with honest in-app update cues.</li>
@@ -243,7 +259,7 @@
           <li>Failed pastes recover; the transcription model hot-swaps without restart.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.6 <span class="release-date">· July 18, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.6"><summary><h2>v0.3.6 <span class="release-date">· July 18, 2026</span></h2></summary>
         <h3>Fixed — Fn / 🌐 Globe key no longer fails silently</h3>
         <ul class="check-list">
           <li><strong>Fn was never a working hotkey.</strong> macOS doesn't deliver the Fn/Globe key to <code>pynput</code>, so selecting it left dictation permanently dead with no feedback. Choosing Fn now surfaces an immediate modal explaining the limitation and pointing at Right Command (the default), the menu-bar picker hides Fn unless it's the current (legacy) selection, and onboarding no longer offers it.</li>
@@ -260,7 +276,7 @@
           <li><strong>Know-Me interview no longer self-destructs</strong> when Escape is pressed while a text field is focused.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.5 <span class="release-date">· July 13, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.5"><summary><h2>v0.3.5 <span class="release-date">· July 13, 2026</span></h2></summary>
         <h3>Fixed — first launch could silently do nothing (no menu bar icon, no wizard)</h3>
         <ul class="check-list">
           <li><strong>Stale bootstrap lock.</strong> <code>~/.openvoiceflow/.bootstrap.lock</code> survives reboots, and its stored pid could be reused by an unrelated live process — the alive check then matched, so every launch exited silently forever. The lock now only counts when the pid is alive *and* is really our <code>launcher.sh</code>.</li>
@@ -295,7 +311,7 @@
           <li>CI lint now covers the entire repository (<code>ruff check .</code>), not just <code>voiceflow/</code>.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.4 <span class="release-date">· July 10, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.4"><summary><h2>v0.3.4 <span class="release-date">· July 10, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>A polished native menu-bar experience led by <strong>Open OpenVoiceFlow</strong>, with grouped Dictation Shortcut, AI Cleanup, Writing Style, Personalization, and Advanced menus.</li>
@@ -315,7 +331,7 @@
           <li>The <strong>Download</strong> button in the update alert now recognizes AppKit's native button result and opens the release page correctly.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.3 <span class="release-date">· July 10, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.3"><summary><h2>v0.3.3 <span class="release-date">· July 10, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>The menu-bar menu now includes a persistent <strong>How to Use</strong> guide, and the first-run hotkey tip also appears in the floating HUD instead of relying only on a potentially hidden macOS notification.</li>
@@ -338,7 +354,7 @@
           <li><code>validate_setup</code> reports a broken audio backend (<code>OSError</code>) instead of only a missing <code>sounddevice</code> package.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.2 <span class="release-date">· July 9, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.2"><summary><h2>v0.3.2 <span class="release-date">· July 9, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>The DMG bootstrap now executes the virtual-environment Python interpreter at its original path, preventing a silent dynamic-library crash on launch.</li>
@@ -347,7 +363,7 @@
           <li>Menu-bar settings no longer clear uninitialized native submenus during startup.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.1 <span class="release-date">· July 9, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.1"><summary><h2>v0.3.1 <span class="release-date">· July 9, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>The notarized macOS app now carries the hardened-runtime entitlements for microphone input and Apple Events, allowing recording and auto-paste to pass macOS privacy enforcement.</li>
@@ -355,7 +371,7 @@
           <li>First launch uses the native macOS consent prompts and no longer stacks two conflicting custom permission dialogs.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.3.0 <span class="release-date">· July 8, 2026</span></h2></summary>
+      <details class="content-card" id="v0.3.0"><summary><h2>v0.3.0 <span class="release-date">· July 8, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>Pytest scaffold under <code>tests/</code> with regression tests for every Wave-1 ship-stopper (<code>test_python39_compat</code>, <code>test_install_sh</code>, <code>test_config_migration</code>, <code>test_onboarding</code>, <code>test_voice_commands_count</code>, <code>test_updater</code>) plus privacy invariants (<code>test_chmod_600</code>, <code>test_privacy_defaults</code>) and package smoke tests. 60 tests total, green on Python 3.9, 3.10, and 3.11.</li>
@@ -407,7 +423,7 @@
           <li>Twelve community-health files added so a procurement reviewer can find the answers they need without filing an issue: <code>SECURITY.md</code>, <code>PRIVACY.md</code>, <code>THREAT_MODEL.md</code>, <code>COMPLIANCE.md</code>, <code>CODE_OF_CONDUCT.md</code>, <code>CONTRIBUTING.md</code>, <code>SUPPORT.md</code>, <code>CHANGELOG.md</code> (this file), <code>VERSIONING.md</code>, <code>COMPATIBILITY.md</code>, <code>legal/DPA-template.md</code>, <code>legal/THIRD_PARTY_NOTICES.md</code>.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.2.0 <span class="release-date">· March 15, 2026</span></h2></summary>
+      <details class="content-card" id="v0.2.0"><summary><h2>v0.2.0 <span class="release-date">· March 15, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li><strong>Know Me</strong> — tkinter onboarding interview. Captures name, occupation, industry, frequently-mentioned names/tools, communication style. Output is injected into every LLM cleanup prompt as system context.</li>
@@ -438,7 +454,7 @@
           <li>22 bugs from a deep QA audit (#3): debounce on the recording hotkey, auto-paste timing window, error reporting in <code>system.py</code>, and a long tail of small UX papercuts.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.1.1 <span class="release-date">· March 1, 2026</span></h2></summary>
+      <details class="content-card" id="v0.1.1"><summary><h2>v0.1.1 <span class="release-date">· March 1, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">
           <li>Rosetta + macOS compatibility. The launcher now smart-detects architecture (Apple Silicon vs Intel) and bootstraps the right venv.</li>
@@ -447,7 +463,7 @@
           <li>Several broken GitHub URLs across the README and install scripts.</li>
         </ul>
       </details>
-      <details class="content-card"><summary><h2>v0.1.0 <span class="release-date">· February 22, 2026</span></h2></summary>
+      <details class="content-card" id="v0.1.0"><summary><h2>v0.1.0 <span class="release-date">· February 22, 2026</span></h2></summary>
         <h3>Added</h3>
         <ul class="check-list">
           <li>13-module Python package (<code>voiceflow/</code>).</li>
@@ -487,5 +503,23 @@
   </footer>
 
   <script src="site.js"></script>
+  <script>
+    // Deep links carry a version anchor (releases.html#v0.5.20) — the app's
+    // update sheet and the changelog both link that way. A collapsed <details>
+    // is invisible to the browser's own fragment scroll, so open the targeted
+    // release first, then jump to it.
+    (function () {
+      function revealTarget() {
+        var id = location.hash.slice(1);
+        if (!id) return;
+        var card = document.getElementById(id);
+        if (!card || card.tagName !== "DETAILS") return;
+        card.open = true;
+        card.scrollIntoView({ block: "start" });
+      }
+      window.addEventListener("hashchange", revealTarget);
+      revealTarget();
+    })();
+  </script>
 </body>
 </html>

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.20</string>
-    <key>CFBundleVersion</key><string>25</string>
+    <key>CFBundleShortVersionString</key><string>0.5.21</string>
+    <key>CFBundleVersion</key><string>26</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -1133,10 +1133,21 @@ struct DashboardView: View {
                 }
                 settingsToggle("Automatic updates", isOn: autoUpdateBinding)
                 settingsRow("You're on v\(updater.appVersion)") {
-                    Button("Check for updates now") { updater.checkForUpdates() }
-                        .buttonStyle(.plain).foregroundStyle(DT.emberLight)
-                        .font(.system(size: 12))
-                        .disabled(!updater.canCheckForUpdates)
+                    HStack(spacing: 14) {
+                        // Reaching the release notes shouldn't require running
+                        // an update check first — on a current build Sparkle
+                        // buries them behind the "You're up to date" alert.
+                        // Anchored at the running version, so the page opens on
+                        // "what am I actually on" rather than the newest entry.
+                        Button("Version history") {
+                            NSWorkspace.shared.open(ReleaseNotes.url(forVersion: updater.appVersion))
+                        }
+                        .buttonStyle(.plain).foregroundStyle(ink2)
+                        Button("Check for updates now") { updater.checkForUpdates() }
+                            .buttonStyle(.plain).foregroundStyle(DT.emberLight)
+                            .disabled(!updater.canCheckForUpdates)
+                    }
+                    .font(.system(size: 12))
                 }
             }
         }

--- a/native/Sources/OpenVoiceFlow/Updater.swift
+++ b/native/Sources/OpenVoiceFlow/Updater.swift
@@ -1,5 +1,22 @@
 import Combine
+import Foundation
 import Sparkle
+
+/// Where the app sends people for release notes.
+///
+/// The same page backs Sparkle's "Version History" button — the appcast's
+/// `sparkle:fullReleaseNotesLink` points here, and Sparkle offers that button
+/// on the "You're up to date!" alert. Kept in one place so the in-app link and
+/// the feed can't drift onto different pages. The page itself is generated
+/// from CHANGELOG.md by scripts/build_releases.py.
+enum ReleaseNotes {
+    static let historyURL = URL(string: "https://openvoiceflow.com/releases.html")!
+
+    /// The notes for one specific version, as an anchored card on that page.
+    static func url(forVersion version: String) -> URL {
+        URL(string: "https://openvoiceflow.com/releases.html#v\(version)") ?? historyURL
+    }
+}
 
 /// Receives Sparkle's appcast results.
 ///

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.20
-        CURRENT_PROJECT_VERSION: 25
+        MARKETING_VERSION: 0.5.21
+        CURRENT_PROJECT_VERSION: 26
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:

--- a/native/scripts/appcast.sh
+++ b/native/scripts/appcast.sh
@@ -12,6 +12,8 @@
 #   SPARKLE_ED_PRIVATE_KEY the exported EdDSA private key string   [REQUIRED — fails if unset]
 #   OVF_DOWNLOAD_BASE      URL prefix the DMG will be served from
 #                          [default https://openvoiceflow.com/downloads]
+#   OVF_SITE_BASE          website root the release-notes links point at
+#                          [default https://openvoiceflow.com]
 #   SPARKLE_VERSION        Sparkle release to pull sign_update from [default 2.9.4]
 #
 # REQUIRED for a release: fails loudly if SPARKLE_ED_PRIVATE_KEY is unset, since
@@ -35,6 +37,14 @@ BUILD="${OVF_BUILD:-$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' Info.p
 DOWNLOAD_BASE="${OVF_DOWNLOAD_BASE:-https://openvoiceflow.com/downloads}"
 # The feed's own URL — must match Info.plist SUFeedURL (served at the site root).
 FEED_URL="${OVF_APPCAST_URL:-https://openvoiceflow.com/appcast.xml}"
+# Where the website is served from. Sparkle reads two release-notes links off
+# the item: releaseNotesLink fills the WebView in the update sheet, and
+# fullReleaseNotesLink is what the "Version History" button opens — including
+# on the "You're up to date!" alert, which is the only place a current user
+# ever sees it. Both must be real pages; scripts/build_releases.py generates
+# them from CHANGELOG.md, so the changelog entry has to land before this
+# appcast goes live (RELEASE.md).
+SITE_BASE="${OVF_SITE_BASE:-https://openvoiceflow.com}"
 SPARKLE_VERSION="${SPARKLE_VERSION:-2.9.4}"
 
 DMG="dist/OpenVoiceFlow-$OVF_VERSION.dmg"
@@ -73,7 +83,8 @@ cat > dist/appcast.xml <<XML
     <language>en</language>
     <item>
       <title>Version $OVF_VERSION</title>
-      <sparkle:releaseNotesLink>https://openvoiceflow.com/how-it-works.html</sparkle:releaseNotesLink>
+      <sparkle:releaseNotesLink>$SITE_BASE/release-notes/$OVF_VERSION.html</sparkle:releaseNotesLink>
+      <sparkle:fullReleaseNotesLink>$SITE_BASE/releases.html</sparkle:fullReleaseNotesLink>
       <pubDate>$PUBDATE</pubDate>
       <sparkle:version>$BUILD</sparkle:version>
       <sparkle:shortVersionString>$OVF_VERSION</sparkle:shortVersionString>

--- a/scripts/build_releases.py
+++ b/scripts/build_releases.py
@@ -248,7 +248,6 @@ def render_notes(rel: dict) -> str:
     two copies never compete in search.
     """
     version = rel["version"]
-    dated = f" — {format_date(rel['date'])}" if rel["date"] else ""
     body = []
     for title, bullets in rel["sections"]:
         body.append(f"    <h2>{html.escape(title)}</h2>")

--- a/scripts/build_releases.py
+++ b/scripts/build_releases.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate docs/releases.html from CHANGELOG.md.
+"""Generate docs/releases.html (and docs/release-notes/*.html) from CHANGELOG.md.
 
 Why a generator: CHANGELOG.md is already the maintainers' authoritative,
 human-written release notes — re-typing them into a second hand-maintained
@@ -8,8 +8,18 @@ release and forgets the second copy. This script re-renders the page from
 the changelog every time, so "add a CHANGELOG entry" is the only step that
 keeps the public Releases page current.
 
+Two outputs, one source:
+  docs/releases.html            the public Releases page, one anchored card
+                                per version (#v0.5.20), newest first.
+  docs/release-notes/<v>.html   a bare, self-contained page per version, sized
+                                for the small WebView Sparkle embeds in its
+                                update sheet. The appcast's releaseNotesLink
+                                points here and its fullReleaseNotesLink points
+                                at releases.html, which is what fills Sparkle's
+                                "Version History" button.
+
 Run:  python3 scripts/build_releases.py
-Then: python3 -m pytest tests/test_docs_seo.py -q
+Then: python3 -m pytest tests/test_docs_seo.py tests/test_docs_distribution.py -q
 """
 from __future__ import annotations
 
@@ -21,9 +31,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 CHANGELOG = ROOT / "CHANGELOG.md"
 OUT = ROOT / "docs" / "releases.html"
+NOTES_DIR = ROOT / "docs" / "release-notes"
 CANONICAL = "https://openvoiceflow.com"
 REPO = "https://github.com/shimoverse/openvoiceflow"
-VERSION = "0.5.20"
 
 MONTHS = ["January", "February", "March", "April", "May", "June", "July",
           "August", "September", "October", "November", "December"]
@@ -83,7 +93,7 @@ def parse_changelog() -> list[dict]:
 def render_release(rel: dict, open_by_default: bool) -> str:
     date_html = f' <span class="release-date">· {format_date(rel["date"])}</span>' if rel["date"] else ""
     parts = [
-        f'      <details class="content-card"{" open" if open_by_default else ""}>'
+        f'      <details class="content-card" id="v{rel["version"]}"{" open" if open_by_default else ""}>'
         f'<summary><h2>v{rel["version"]}{date_html}</h2></summary>'
     ]
     for title, bullets in rel["sections"]:
@@ -204,16 +214,115 @@ def render(releases: list[dict]) -> str:
   </footer>
 
   <script src="site.js"></script>
+  <script>
+    // Deep links carry a version anchor (releases.html#v0.5.20) — the app's
+    // update sheet and the changelog both link that way. A collapsed <details>
+    // is invisible to the browser's own fragment scroll, so open the targeted
+    // release first, then jump to it.
+    (function () {{
+      function revealTarget() {{
+        var id = location.hash.slice(1);
+        if (!id) return;
+        var card = document.getElementById(id);
+        if (!card || card.tagName !== "DETAILS") return;
+        card.open = true;
+        card.scrollIntoView({{ block: "start" }});
+      }}
+      window.addEventListener("hashchange", revealTarget);
+      revealTarget();
+    }})();
+  </script>
 </body>
 </html>
 """
+
+
+def render_notes(rel: dict) -> str:
+    """One version's notes as a standalone page for Sparkle's update sheet.
+
+    Sparkle loads `sparkle:releaseNotesLink` into a small WebView inside the
+    update dialog, so this is deliberately not the marketing site: no nav, no
+    footer, no external stylesheet (the sheet appears before anything is
+    downloaded, and a page that half-loads there looks broken). It is marked
+    noindex and canonicalised to the anchored card on the Releases page so the
+    two copies never compete in search.
+    """
+    version = rel["version"]
+    dated = f" — {format_date(rel['date'])}" if rel["date"] else ""
+    body = []
+    for title, bullets in rel["sections"]:
+        body.append(f"    <h2>{html.escape(title)}</h2>")
+        body.append("    <ul>")
+        for b in bullets:
+            body.append(f"      <li>{b}</li>")
+        body.append("    </ul>")
+    body_html = "\n".join(body)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow {version} release notes</title>
+  <link rel="canonical" href="{CANONICAL}/releases.html#v{version}" />
+  <style>
+    :root {{ color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }}
+    @media (prefers-color-scheme: dark) {{
+      :root {{ --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }}
+    }}
+    html, body {{ background: var(--bg); }}
+    body {{
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }}
+    h1 {{ margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }}
+    .date {{ margin: 0 0 14px; color: var(--ink2); font-size: 12px; }}
+    h2 {{ margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }}
+    ul {{ margin: 0; padding-left: 18px; }}
+    li {{ margin: 0 0 5px; }}
+    code {{ font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }}
+    a {{ color: var(--ember); }}
+    footer {{ margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow {version}</h1>
+    <p class="date">{format_date(rel["date"]) if rel["date"] else "Unreleased"}</p>
+{body_html}
+  </main>
+  <footer>
+    <a href="{CANONICAL}/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>
+"""
+
+
+def write_notes(releases: list[dict]) -> int:
+    """Refresh docs/release-notes/, dropping pages for versions the changelog
+    no longer carries so a renamed version can't leave a stale page behind."""
+    NOTES_DIR.mkdir(parents=True, exist_ok=True)
+    keep = set()
+    for rel in releases:
+        path = NOTES_DIR / f"{rel['version']}.html"
+        path.write_text(render_notes(rel), encoding="utf-8")
+        keep.add(path.name)
+    for stale in NOTES_DIR.glob("*.html"):
+        if stale.name not in keep:
+            stale.unlink()
+    return len(keep)
 
 
 def main() -> None:
     releases = parse_changelog()
     assert releases, "no releases parsed from CHANGELOG.md"
     OUT.write_text(render(releases), encoding="utf-8")
+    count = write_notes(releases)
     print(f"wrote {OUT} ({len(releases)} releases)")
+    print(f"wrote {NOTES_DIR} ({count} per-version notes pages)")
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_distribution.py
+++ b/tests/test_docs_distribution.py
@@ -69,6 +69,39 @@ def test_appcast_is_present_and_signed_for_the_final_native_release():
     )
 
 
+def test_appcast_release_notes_links_point_at_pages_that_exist():
+    """Sparkle's "Version History" button opens `fullReleaseNotesLink`, and its
+    update sheet loads `releaseNotesLink` — the two links a user reaches from
+    Settings ▸ "Check for updates now". Both once pointed at how-it-works.html,
+    a marketing page with no version history on it at all, which is invisible
+    until someone clicks the button. Both must be real, generated pages.
+    """
+    appcast = (DOCS / "appcast.xml").read_text(encoding="utf-8")
+
+    def link(tag: str) -> str:
+        return appcast.split(f"<sparkle:{tag}>")[1].split(f"</sparkle:{tag}>")[0]
+
+    assert link("fullReleaseNotesLink") == f"{CANONICAL}/releases.html"
+    assert (DOCS / "releases.html").exists()
+
+    notes = link("releaseNotesLink")
+    assert notes == f"{CANONICAL}/release-notes/{RELEASE_VERSION}.html"
+    # The publish PR ships the appcast; the notes page it points at is
+    # generated from CHANGELOG.md, so the changelog entry has to land in the
+    # same PR or the update sheet 404s for everyone (RELEASE.md).
+    notes_page = DOCS / "release-notes" / f"{RELEASE_VERSION}.html"
+    assert notes_page.exists(), (
+        f"missing {notes_page.relative_to(ROOT)} — add the CHANGELOG entry for "
+        f"{RELEASE_VERSION} and run python3 scripts/build_releases.py"
+    )
+    assert RELEASE_VERSION in notes_page.read_text(encoding="utf-8")
+
+    # Whatever the next release generates must keep both links.
+    script = (ROOT / "native" / "scripts" / "appcast.sh").read_text(encoding="utf-8")
+    assert "<sparkle:fullReleaseNotesLink>$SITE_BASE/releases.html<" in script
+    assert "<sparkle:releaseNotesLink>$SITE_BASE/release-notes/$OVF_VERSION.html<" in script
+
+
 def test_legacy_split_downloads_redirect_to_the_universal_native_dmg():
     redirects = {item["source"]: item for item in json.loads((ROOT / "vercel.json").read_text())["redirects"]}
     for previous in ["0.2.0", "0.3.2", "0.3.3", "0.3.4", "0.3.5"]:

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -318,6 +318,33 @@ def test_releases_page_lists_recent_versions_with_notes():
     assert "https://github.com/shimoverse/openvoiceflow/releases" in html
 
 
+def test_every_release_card_is_deep_linkable():
+    """Each release renders as a collapsed-by-default <details>, and a browser
+    will not scroll to — or reveal — a fragment inside a closed one. The app's
+    Settings link and the appcast both address versions as releases.html#vX.Y.Z,
+    so every card carries that id and the page opens the targeted one."""
+    html = read("releases.html")
+    versions = re.findall(r'<summary><h2>v([0-9.]+)', html)
+    assert len(versions) >= 20
+    for version in versions:
+        assert f'id="v{version}"' in html, f"releases.html: v{version} has no anchor"
+    assert "hashchange" in html, "releases.html must open the release named by the URL fragment"
+
+
+def test_per_version_release_notes_pages_are_self_contained_and_unindexed():
+    """These pages exist for the WebView Sparkle embeds in its update sheet:
+    no nav, no external stylesheet (nothing else is loaded yet), and noindex +
+    canonical so they don't compete with releases.html in search."""
+    for version in ["0.5.20", "0.5.19"]:
+        page = DOCS / "release-notes" / f"{version}.html"
+        assert page.exists(), f"missing release notes page for {version}"
+        html = page.read_text(encoding="utf-8")
+        assert 'name="robots" content="noindex' in html
+        assert f'<link rel="canonical" href="{CANONICAL}/releases.html#v{version}" />' in html
+        assert 'rel="stylesheet"' not in html
+        assert f"{CANONICAL}/releases.html" in html, "must link back to the full history"
+
+
 def test_homepage_structured_data_links_the_project_to_its_repository():
     blocks = [
         json.loads(raw)


### PR DESCRIPTION
## What this changes (for the user)

Settings ▸ "You're on v0.5.20 · Check for updates now" ends on Sparkle's **"You're up to date!"** alert. Its **Version History** button opened `how-it-works.html` — a marketing page with no version list on it at all.

**Root cause.** Sparkle fills that button from the appcast's `sparkle:fullReleaseNotesLink` ([SPUStandardUserDriver.m#L680](https://github.com/sparkle-project/Sparkle/blob/2.9.4/Sparkle/SPUStandardUserDriver.m)). Our feed never set one, so Sparkle fell through to `releaseNotesLink` — which pointed at `how-it-works.html`. The Releases page already existed (added in shimoverse/openvoiceflow#130); nothing had ever pointed the app at it.

**What the user sees now:**

| Surface | Before | After |
| --- | --- | --- |
| "Version History" on the up-to-date alert | how-it-works.html | `/releases.html` — the real version history |
| Release notes inside the update sheet | how-it-works.html | `/release-notes/<version>.html` — that version's actual notes |
| Settings ▸ "You're on vX.Y.Z" | one action: check for updates | adds a **Version history** link, anchored at the running version |
| `releases.html#v0.5.20` | landed on a collapsed card | expands that release and scrolls to it |

**This reaches users without a new app build.** The button reads the website's appcast, not the app, so every already-installed 0.5.20 gets the fixed link the moment `main` deploys.

**Also in this PR:**

- `scripts/build_releases.py` now emits `docs/release-notes/<version>.html` beside `docs/releases.html`, from the same CHANGELOG source. These are deliberately bare — no nav, no external stylesheet — because Sparkle loads them into a small embedded WebView before anything is downloaded; they're `noindex` + canonicalised to `releases.html#vX.Y.Z` so they don't compete with the Releases page in search.
- `native/scripts/appcast.sh` writes both links for every future release, so this can't silently regress.
- `RELEASE.md`: the CHANGELOG entry and regenerated pages must now land in the **publish** PR rather than after it — the appcast published in that PR links to those pages by URL, so shipping it first would 404 the update sheet for everyone updating.
- Version bump to **0.5.21 / build 26** (all four fields), and the `Unreleased` changelog section cut into `[0.5.21]` — the in-app Settings link needs a build to ship in. See the note below.

## How it was verified

- [x] CI green (pytest for website/Python) — `pytest tests/` locally: 268 passed, 3 of them new; the 14 failures + 17 errors are pre-existing in this environment (no `numpy`/`pynput` installed) and identical with the changes stashed.
- [ ] Screenshot or recording attached for UI changes — **not attached:** the Settings row and the Sparkle alert are macOS-only and there is no Xcode toolchain in this environment, so the Swift change is unbuilt here and needs `native-build` plus a look on a Mac before merge.
- [ ] No version bumps or new dependencies — **this PR does bump the version**, deliberately: the appcast fix ships with the website, but the in-app "Version history" link only reaches users in a build, and the request was to get these into a new release. Step 1 of RELEASE.md is exactly this bump. Happy to split the bump out if you'd rather cut 0.5.21 separately. No new dependencies.

New tests pinning the behaviour:

- `test_appcast_release_notes_links_point_at_pages_that_exist` — both appcast links resolve to pages that exist in `docs/`, and `appcast.sh` still generates both.
- `test_every_release_card_is_deep_linkable` — every release has a `#vX.Y.Z` anchor and the page opens the one the URL names.
- `test_per_version_release_notes_pages_are_self_contained_and_unindexed`.

## Still needed for the release

This PR is step 1 of RELEASE.md. After merge, 0.5.21 needs the **Create release tag** → **Release (native app)** → publish sequence, which requires the Apple signing secrets and `SPARKLE_ED_PRIVATE_KEY`. The website half of the fix is live as soon as this merges and Vercel deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR)_