### PR TITLE
release: carry 0.5.21 into the committed project.pbxproj

### DIFF
--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -479,14 +479,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.20;
+				MARKETING_VERSION = 0.5.21;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;
@@ -499,14 +499,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.20;
+				MARKETING_VERSION = 0.5.21;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;


### PR DESCRIPTION
## What this changes (for the user)

Nothing user-visible — a version-field cleanup ahead of the 0.5.21 build.

shimoverse/openvoiceflow#132 bumped `native/project.yml` and `native/Info.plist` to 0.5.21 / build 26 but left the committed generated `native/OpenVoiceFlow.xcodeproj/project.pbxproj` on 0.5.20 / 25. Every previous bump (e.g. shimoverse/openvoiceflow#128) moved all five together.

The DMG was never at risk: `native/scripts/build-app.sh` runs `xcodegen generate` before `xcodebuild`, so the pbxproj is regenerated from `project.yml` at build time, and the release workflow's classify step reads `project.yml` + `Info.plist` — both already correct. This is about a checkout that opens the `.xcodeproj` directly reporting the right version, and about the file not drifting from its generator.

Same four lines, both build configurations, as the 0.5.20 bump touched.

## How it was verified

- [x] CI green (`native-build` for Swift changes, pytest for website/Python) — `ruff check .` clean; docs + native contract tests pass locally (40 passed, 2 skipped — the skips need the macOS Xcode toolchain). `native-build` in CI is the real check here, since it regenerates this file.
- [ ] Screenshot or recording attached for UI changes — n/a, no UI change.
- [x] No version bumps or new dependencies — no *new* bump; this completes the 0.5.21 bump already merged in shimoverse/openvoiceflow#132. No new dependencies.

Tag `native-v0.5.21` is moved onto this commit before the release build, so the tagged tree is self-consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR)_