### PR TITLE
Guard the telemetry JSONB casts with CASE, not AND

### DIFF
--- a/api/_db.js
+++ b/api/_db.js
@@ -177,15 +177,21 @@ export async function readInstallStats({ activeDays = 30, recentDays = 7, limit 
     GROUP BY 1 ORDER BY total DESC, key ASC LIMIT ${limit}
   `;
 
-  // jsonb_typeof guards the cast: a malformed value is skipped rather than
-  // failing the whole query.
+  // CASE, not `jsonb_typeof(...) = 'number' AND (...)::numeric > 0`: SQL's AND
+  // does not short-circuit, so the planner is free to attempt the cast on a
+  // row the type check would have excluded and fail the whole query with
+  // "cannot cast jsonb string to type numeric". CASE is defined to skip the
+  // branches it does not select. Rows written by an older or buggy client are
+  // exactly where a non-number shows up, so this has to hold for real data.
   const [features] = await query`
     SELECT
       COUNT(*) FILTER (WHERE feature_usage->>'cleanupEnabled' = 'true')::int AS cleanup_enabled,
-      COUNT(*) FILTER (WHERE jsonb_typeof(feature_usage->'snippetsCount') = 'number'
-                         AND (feature_usage->>'snippetsCount')::numeric > 0)::int AS uses_snippets,
-      COUNT(*) FILTER (WHERE jsonb_typeof(feature_usage->'dictionaryCount') = 'number'
-                         AND (feature_usage->>'dictionaryCount')::numeric > 0)::int AS uses_dictionary,
+      COUNT(*) FILTER (WHERE CASE WHEN jsonb_typeof(feature_usage->'snippetsCount') = 'number'
+                                  THEN (feature_usage->'snippetsCount')::numeric > 0
+                                  ELSE false END)::int AS uses_snippets,
+      COUNT(*) FILTER (WHERE CASE WHEN jsonb_typeof(feature_usage->'dictionaryCount') = 'number'
+                                  THEN (feature_usage->'dictionaryCount')::numeric > 0
+                                  ELSE false END)::int AS uses_dictionary,
       COUNT(*) FILTER (WHERE feature_usage->>'hasKnowMeProfile' = 'true')::int AS has_profile
     FROM devices
   `;
@@ -194,12 +200,15 @@ export async function readInstallStats({ activeDays = 30, recentDays = 7, limit 
   // installs touched it at all — the more honest adoption number, since a
   // single heavy user can dominate a raw total.
   const events = await query`
-    SELECT entry.key AS key,
-           SUM((entry.value)::numeric)::bigint AS total,
-           COUNT(*)::int AS devices
-    FROM devices, LATERAL jsonb_each(devices.events) AS entry
-    WHERE jsonb_typeof(entry.value) = 'number' AND (entry.value)::numeric > 0
-    GROUP BY entry.key ORDER BY total DESC, key ASC LIMIT ${limit}
+    SELECT key, SUM(value)::bigint AS total, COUNT(*)::int AS devices
+    FROM (
+      SELECT entry.key AS key,
+             CASE WHEN jsonb_typeof(entry.value) = 'number'
+                  THEN (entry.value)::numeric ELSE 0 END AS value
+      FROM devices, LATERAL jsonb_each(devices.events) AS entry
+    ) counted
+    WHERE value > 0
+    GROUP BY key ORDER BY total DESC, key ASC LIMIT ${limit}
   `;
 
   const rank = (rows) => rows.map((row) => ({ key: String(row.key), total: Number(row.total) }));

--- a/tests/test_analytics_sql_guards.py
+++ b/tests/test_analytics_sql_guards.py
@@ -1,0 +1,67 @@
+"""SQL-level guards for the aggregate telemetry queries.
+
+These queries read two JSONB columns written by clients across many app
+versions, so a value of the wrong type is a normal thing to find, not a
+corruption. The first version of `readInstallStats` guarded its casts with
+`jsonb_typeof(x) = 'number' AND (x)::numeric > 0` — which reads as safe and is
+not. SQL's AND does not short-circuit: the planner may evaluate the cast on a
+row the type check would have excluded, and one `{"pane.home": "lots"}` row
+anywhere in the table fails the whole query with
+
+    ERROR: cannot cast jsonb string to type numeric
+
+Verified against PostgreSQL 16 with a mixed-type fixture: the AND form errored,
+the CASE form returned correct totals with the bad values ignored. CASE is
+defined to skip unselected branches, so it is the form that actually holds.
+
+The unit tests run against an in-memory JavaScript double that cannot reproduce
+this — it is a property of the SQL, not of the handler — so it is asserted here
+on the query text.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DB = ROOT / "api" / "_db.js"
+
+
+def stats_sql() -> str:
+    """The query text only. Comments are stripped first: the code comments here
+    quote the broken form in order to explain it, and a scan that reads prose
+    would flag the explanation instead of the SQL."""
+    source = DB.read_text(encoding="utf-8")
+    assert "export async function readInstallStats" in source
+    body = source.split("export async function readInstallStats", 1)[1]
+    lines = [line for line in body.splitlines() if not line.lstrip().startswith(("//", "--"))]
+    return "\n".join(lines)
+
+
+def test_no_jsonb_cast_is_guarded_only_by_and():
+    """The exact shape that fails: a type check ANDed with a cast."""
+    sql = stats_sql()
+    offenders = re.findall(r"jsonb_typeof\([^)]*\)\s*=\s*'number'\s*\n?\s*AND[^\n]*::numeric", sql)
+    assert not offenders, (
+        "AND does not short-circuit in SQL — guard the cast with CASE WHEN "
+        f"jsonb_typeof(...) = 'number' THEN ... ELSE ... END instead: {offenders}"
+    )
+
+
+def test_every_jsonb_numeric_cast_sits_inside_a_case_guard():
+    sql = stats_sql()
+    casts = re.findall(r"\((?:entry\.value|feature_usage->'[A-Za-z]+')\)::numeric", sql)
+    assert casts, "expected the feature/event queries to cast JSONB values to numeric"
+    guards = re.findall(r"CASE WHEN jsonb_typeof\(", sql)
+    assert len(guards) >= len(casts), (
+        f"{len(casts)} JSONB numeric casts but only {len(guards)} CASE guards — "
+        "every cast of a client-written JSONB value needs one"
+    )
+
+
+def test_event_totals_are_summed_over_a_type_checked_subquery():
+    """Casting inside a subquery and comparing outside keeps the type check and
+    the arithmetic in separate steps, so neither can be reordered into the
+    other."""
+    sql = stats_sql()
+    assert "FROM devices, LATERAL jsonb_each(devices.events) AS entry" in sql
+    assert "WHERE value > 0" in sql
+    assert "SUM(value)::bigint" in sql


### PR DESCRIPTION
## What this changes (for the user)

Fixes a bug that would have hit on the **very first** request to `/api/analytics/stats` — i.e. the moment you set `ANALYTICS_STATS_TOKEN` and tried to read install counts.

`readInstallStats` (shimoverse/openvoiceflow#136) guarded its JSONB casts like this:

```sql
WHERE jsonb_typeof(entry.value) = 'number' AND (entry.value)::numeric > 0
```

That reads as safe and isn't. **SQL's `AND` does not short-circuit** — the planner may apply the cast to a row the type check would have excluded. One `{"pane.home": "lots"}` anywhere in the table fails the entire query:

```
ERROR: cannot cast jsonb string to type numeric
```

The feature-adoption query had the identical shape and happened to survive on plan order alone — the same bug, one planner decision away from firing.

This matters because both columns are written by clients across many app versions, so a value of the wrong type is an ordinary thing to find in `devices`, not corruption. `CASE` is defined to skip the branches it doesn't select, so it holds regardless of plan. Event totals now cast inside a subquery and compare outside, keeping the type check and the arithmetic in separate steps.

## How it was verified

Found and confirmed by running the real queries against **PostgreSQL 16** with a deliberately mixed-type fixture — the only way this surfaces, since the unit tests run against an in-memory JavaScript double and the SQL itself had never executed anywhere.

| | before | after |
| --- | --- | --- |
| events query on mixed types | `ERROR: cannot cast jsonb string to type numeric` | 4 rows, correct totals |
| `action.dictation_completed` | — | 150 across 2 devices (null row ignored) |
| `pane.home` | — | 15 across 2 devices (`"lots"` ignored) |

- [x] CI green (pytest for website/Python) — `ruff check .` clean; `pytest tests/`: 279 passed (up from 276); `node --test api/__tests__/*.test.js`: 13 passed. The 14 failures + 17 errors are pre-existing here (no `numpy`/`pynput`), unchanged from `main`.
- [x] New `tests/test_analytics_sql_guards.py` verified in both directions: passes on the fix, **fails all three assertions** when reverted to the AND form.
- [ ] Screenshot or recording attached for UI changes — n/a.
- [x] No version bumps or new dependencies.

Nothing shipped ever ran this code — the endpoint 404s until the token is configured — so this repairs a first-request failure, not a live one. No app rebuild needed: it deploys with the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR)_