### PR TITLE
Fix four review findings in the usage counters

### DIFF
--- a/api/_db.js
+++ b/api/_db.js
@@ -97,10 +97,32 @@ export async function upsertDevice(device) {
       minutes_saved = EXCLUDED.minutes_saved,
       streak_days = EXCLUDED.streak_days,
       feature_usage = EXCLUDED.feature_usage,
-      -- The app sends lifetime totals, so a late or duplicated sync can only
-      -- repeat a number, never inflate one. Taking the larger of the two also
-      -- keeps counters intact if a device's local store is reset.
-      events = CASE WHEN EXCLUDED.events = '{}'::jsonb THEN devices.events ELSE EXCLUDED.events END,
+      -- Merge per key, taking the larger value. Counters are lifetime totals,
+      -- so the larger number is always the newer one — but "newer" is not the
+      -- same as "arrives second": syncIfDue, the leaderboard open and a
+      -- nickname commit can all be in flight at once, and if an older request
+      -- lands last, wholesale replacement would roll every counter backwards
+      -- and drop any key the newer snapshot had added. A per-key MAX is
+      -- order-independent, so it does not matter which request wins the race.
+      -- Non-numeric values (an older or buggy client) collapse to 0 rather
+      -- than failing the upsert; CASE is required because AND does not
+      -- short-circuit in SQL.
+      events = (
+        SELECT COALESCE(jsonb_object_agg(key, to_jsonb(value)), '{}'::jsonb)
+        FROM (
+          SELECT key, MAX(value) AS value
+          FROM (
+            SELECT key, CASE WHEN jsonb_typeof(value) = 'number'
+                             THEN (value)::numeric ELSE 0 END AS value
+            FROM jsonb_each(devices.events)
+            UNION ALL
+            SELECT key, CASE WHEN jsonb_typeof(value) = 'number'
+                             THEN (value)::numeric ELSE 0 END
+            FROM jsonb_each(EXCLUDED.events)
+          ) pairs
+          GROUP BY key
+        ) largest
+      ),
       country = COALESCE(EXCLUDED.country, devices.country),
       app_version = EXCLUDED.app_version,
       first_use_date = COALESCE(devices.first_use_date, EXCLUDED.first_use_date),

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -112,6 +112,9 @@ struct DashboardView: View {
             // The window opens on Home without a selection change, so count
             // that visit here or Home would look like the least-used pane.
             usageCounters.record(DashboardView.event(for: pane))
+            if pane == .personalize {
+                usageCounters.record(DashboardView.event(for: personalizeTab))
+            }
         }
         // Counted on change rather than on render: a pane's body re-runs for
         // any state it reads, and a visit is a navigation, not a redraw.
@@ -119,6 +122,13 @@ struct DashboardView: View {
             usageCounters.recordIfChanged(
                 DashboardView.event(for: current), from: DashboardView.event(for: previous)
             )
+            // Entering Personalize shows a tab immediately, and that tab's own
+            // onChange does not fire because the selection did not change.
+            // Without this the default tab is the only one never counted on
+            // arrival, which reads as "nobody uses Dictionary".
+            if current == .personalize {
+                usageCounters.record(DashboardView.event(for: personalizeTab))
+            }
         }
         .onChange(of: personalizeTab) { previous, current in
             usageCounters.recordIfChanged(
@@ -692,6 +702,7 @@ struct DashboardView: View {
                             NSPasteboard.general.clearContents()
                             if NSPasteboard.general.setString(entry.text, forType: .string) {
                                 copyFeedback.markCopied(entry.id)
+                                usageCounters.record(.historyCopied)
                             }
                         } label: {
                             Label(isCopied ? "Copied" : "Copy",
@@ -991,7 +1002,10 @@ struct DashboardView: View {
 
     private func styleBinding(for app: String) -> Binding<String> {
         Binding(get: { styleStore.map[app] ?? "default" },
-                set: { styleStore.map[app] = $0 })
+                set: {
+                    styleStore.map[app] = $0
+                    usageCounters.record(.styleApplied)
+                })
     }
 
     // MARK: Know-Me

--- a/native/Sources/OpenVoiceFlow/FeedbackView.swift
+++ b/native/Sources/OpenVoiceFlow/FeedbackView.swift
@@ -112,6 +112,7 @@ struct FeedbackView: View {
         if let url = components.url {
             NSWorkspace.shared.open(url)
         }
+        controller.usageCounters.record(.feedbackSent)
         onDismiss()
     }
 

--- a/native/Sources/OpenVoiceFlow/KnowMeInterview.swift
+++ b/native/Sources/OpenVoiceFlow/KnowMeInterview.swift
@@ -115,6 +115,7 @@ struct KnowMeInterview: View {
     private func finish() {
         commit()
         controller.profileStore.profile = draft
+        controller.usageCounters.record(.knowMeInterviewFinished)
         // Double coverage: names + terms also seed the dictionary.
         controller.dictionaryStore.seed(with: controller.profileStore.dictionaryWords)
         dismiss()

--- a/native/Sources/OpenVoiceFlow/OnboardingView.swift
+++ b/native/Sources/OpenVoiceFlow/OnboardingView.swift
@@ -134,6 +134,7 @@ struct OnboardingView: View {
             pill("Start using it", disabled: !helloDone) {
                 controller.settings.didOnboard = true
                 controller.settings.save()
+                controller.usageCounters.record(.onboardingCompleted)
                 _ = controller.startListening()
                 LoginItem.apply(controller.settings.launchAtLogin)
                 NSApplication.shared.keyWindow?.close()

--- a/scripts/analytics_dashboard.py
+++ b/scripts/analytics_dashboard.py
@@ -706,6 +706,23 @@ def render_dashboard(snapshot: Dict[str, Any]) -> str:
             "telemetry API token was not configured — not because the app sends nothing."
         )
 
+    # The hero used to assert "Actual users are not [visible]" unconditionally.
+    # With app telemetry in hand that is simply false, and a page that
+    # contradicts its own headline metric is worse than one that says less.
+    if app.get("available"):
+        hero_headline = "Installs are visible.<br>People are not."
+        hero_value = adoption["verified_installs"]
+        hero_label = "Opted-in installs"
+        hero_caption = (
+            f"{adoption['active_users']} active in {app_days} days · devices, not people · "
+            f"{adoption['high_confidence_external_interest']} high-confidence external interest"
+        )
+    else:
+        hero_headline = "Interest is visible.<br>Actual users are not."
+        hero_value = adoption["high_confidence_external_interest"]
+        hero_label = "High-confidence external interest"
+        hero_caption = "App telemetry unavailable · install count not read"
+
     limitations = "".join(f"<li>{_esc(item)}</li>" for item in snapshot["limitations"])
     referrer_rows = _ranked_rows(gh["popular_referrers"], "No GitHub referrers reported")
     release_rows = "".join(
@@ -728,7 +745,7 @@ def render_dashboard(snapshot: Dict[str, Any]) -> str:
 </head>
 <body><main class="shell">
 <header><div class="brand"><div class="glyph">|||</div><div><strong>OpenVoiceFlow Analytics</strong><span>Private maintainer view</span></div></div><div class="stamp">Updated<br>{_esc(updated_date)}<span class="stamp-time"> · {_esc(updated_time)}</span></div></header>
-<section class="hero"><div><span class="eyebrow">Adoption, without false precision</span><h1>Interest is visible.<br>Actual users are not.</h1><p>Repository and website signals in one place, with CI noise and low-signal activity kept separate from genuine adoption.</p></div><div class="answer"><strong>{_metric(adoption['high_confidence_external_interest'])}</strong><span>High-confidence external interest</span><small>No verified install data · exact real-user count unknown</small></div></section>
+<section class="hero"><div><span class="eyebrow">Adoption, without false precision</span><h1>{hero_headline}</h1><p>Repository, website and app signals in one place, with CI noise and low-signal activity kept separate from genuine adoption.</p></div><div class="answer"><strong>{_metric(hero_value)}</strong><span>{_esc(hero_label)}</span><small>{_esc(hero_caption)}</small></div></section>
 <section class="metrics" aria-label="Key metrics">
 <div class="metric"><span>Verified installs</span><strong>{_metric(adoption['verified_installs'])}</strong><small>{_esc(install_caption)}</small></div>
 <div class="metric"><span>Active installs</span><strong>{_metric(adoption['active_users'])}</strong><small>{_esc(active_caption)}</small></div>

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -143,6 +143,26 @@ def test_install_counts_come_from_app_telemetry_when_it_is_available():
     assert "intentionally sends no telemetry" not in html
 
 
+def test_hero_does_not_contradict_the_install_metric():
+    """The hero asserted "Actual users are not [visible]" unconditionally, right
+    above a card showing a real install count. A page that argues with its own
+    headline number is worse than one that claims less."""
+    with_app = render_dashboard(
+        build_snapshot(github_fixture(), vercel_fixture(), now=NOW,
+                       owner_logins={"shimoverse"}, app=app_fixture())
+    )
+    assert "Actual users are not" not in with_app
+    assert "No verified install data" not in with_app
+    assert "Installs are visible" in with_app
+    # Still refuses to call devices people.
+    assert "devices, not people" in with_app
+
+    without_app = render_dashboard(
+        build_snapshot(github_fixture(), vercel_fixture(), now=NOW, owner_logins={"shimoverse"})
+    )
+    assert "Actual users are not" in without_app
+
+
 def test_app_section_reports_screens_and_features_separately():
     snapshot = build_snapshot(
         github_fixture(), vercel_fixture(), now=NOW, owner_logins={"shimoverse"}, app=app_fixture()

--- a/tests/test_usage_counters_contract.py
+++ b/tests/test_usage_counters_contract.py
@@ -68,6 +68,34 @@ def test_every_counter_is_grouped_by_the_dashboard():
         )
 
 
+def test_every_declared_counter_is_actually_recorded_somewhere():
+    """A case in the enum is a promise that the dashboard will have data for it.
+    Five counters shipped in 0.5.22 declared but never wired — history copies,
+    style applications, finished interviews, sent feedback, completed
+    onboarding — so those metrics could only ever render as absent, which reads
+    on the dashboard as "nobody does this" rather than "nobody measured it".
+
+    Panes and tabs are recorded through the `event(for:)` mappings rather than
+    by name, so they are satisfied by that indirection instead."""
+    sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "native" / "Sources" / "OpenVoiceFlow").glob("*.swift")
+    )
+    recorded = set(re.findall(r"record\((?:IfChanged\()?\.(\w+)", sources))
+    mapped = set(re.findall(r"return \.(\w+)", sources))
+    declared = re.findall(r"case (\w+) = \"([^\"]+)\"", SWIFT.read_text(encoding="utf-8"))
+
+    missing = [
+        name for name, raw in declared
+        if name not in recorded
+        and not (raw.startswith(("pane.", "tab.")) and name in mapped)
+    ]
+    assert not missing, (
+        "declared but never recorded, so the dashboard can only show them as "
+        f"absent — wire them to their UI action or drop the case: {missing}"
+    )
+
+
 def test_counters_ride_the_existing_opt_out_switch():
     """No second network path and no second consent: counters go out with the
     payload that Settings ▸ Privacy already gates, and a data deletion clears


### PR DESCRIPTION
## What this changes (for the user)

Codex reviewed shimoverse/openvoiceflow#136 after it had already merged. **Four of its five findings are real.** Each is fixed here with a test; the fifth is a process matter for you, at the bottom.

### 1. Five counters were declared but wired to nothing

`history_copied`, `style_applied`, `know_me_interview_finished`, `feedback_sent`, `onboarding_completed` existed in the enum and the server allowlist and were never recorded. Those metrics could only ever render as absent — which on a dashboard reads as *"nobody does this"*, not *"nobody measured it"*. All five now record at their completion points.

My contract test only checked that the Swift and JS name lists matched, which is exactly why it passed. It now also asserts every declared counter is recorded somewhere; verified by deleting one wiring and confirming it names `feedbackSent`.

### 2. Personalize's default tab was never counted on arrival

Entering the pane shows the Dictionary tab *without changing the selection*, so `onChange` never fired — the tab was counted only after you left and came back. Systematically under-reported the default. Now recorded on entry, in both the `onChange` and `onAppear` paths.

### 3. Out-of-order syncs rolled counters backwards

`syncIfDue`, opening the leaderboard, and committing a nickname can all be in flight at once. The upsert replaced the entire `events` object with whichever request landed last, so a stale one **lowered every total and dropped keys the newer snapshot had added**. The comment above it claimed the larger value was kept; it did not.

Now a per-key `MAX` across stored and incoming, which is order-independent. Verified against **PostgreSQL 16** — newer snapshot, then a stale one:

| key | stale request said | stored result |
| --- | --- | --- |
| `pane.home` | 4 | **10** ✅ |
| `action.dictation_completed` | 90 | **120** ✅ |
| `tab.styles` | *(absent)* | **9** ✅ survived |
| malformed `"garbage"` | — | collapsed to 0, no error ✅ |

Two syntax errors surfaced on the way — nested aggregates, and `both` being a reserved word — that no JavaScript test would have caught.

### 4. The dashboard hero contradicted its own metric

It asserted *"Actual users are not [visible]"* and *"No verified install data"* directly above a real install count. Now telemetry-aware in both directions, and still refuses to call devices people.

## How it was verified

- [x] CI green (`native-build` for Swift changes, pytest for website/Python) — `ruff check .` clean; `pytest tests/`: **281 passed** (up from 279); `node --test api/__tests__/*.test.js`: 13 passed. The 14 failures + 17 errors are pre-existing here (no `numpy`/`pynput`), unchanged from `main`.
- [x] Upsert race and malformed-value handling executed against a real PostgreSQL 16 instance, not the in-memory double.
- [x] New wiring test verified to fail, by name, when a counter is unwired.
- [ ] Screenshot or recording attached for UI changes — the app changes are counter increments; nothing renders differently.
- [x] No version bumps or new dependencies. The server-side fix (#3) deploys with the site; the app-side fixes ship with the next release.

## ⚠️ Finding #5 is yours, not mine to close

Codex flagged this against [AGENTS.md L31-33](https://github.com/shimoverse/openvoiceflow/blob/main/AGENTS.md#L31-L33):

> Privacy defaults are one-way: changes that make defaults *more* private are ordinary PRs; anything more permissive needs **explicit maintainer sign-off in the PR description**.

shimoverse/openvoiceflow#136 expanded default-on collection to new categories of behavioural data and I did not record that sign-off. You asked for this telemetry directly in the session, so the consent exists in substance — but the repo's rule is about it being *written down in the PR*, and it wasn't. That's my miss.

It is already shipped in 0.5.22, so the options are: reply here confirming sign-off for the record, or have me make the new counters opt-in (a separate switch, defaulting off) and ship that as 0.5.23. Say which and I'll do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmFh3hzLmxAS7zEW1CMnLR)_