### PR TITLE
History opens straight away, and cut 0.5.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.24] — 2026-09-06
+
+### Fixed
+- **History opens straight away.** The tab drew every take it had stored before it could show the dozen that fit on screen — resolving an app icon, and laying out a whole transcript, for each of up to 500 rows — so the longer your log, the longer the pane sat blank on every visit. It now draws the rows in view and the rest as you scroll to them, and acknowledging a **Copy** redraws that one row instead of the entire log. Nothing about what is kept changes: the same 500 takes, still only on this Mac.
+
 ### Added
 - The website now records privacy-safe 30-minute visits, page views, acquisition source, allow-listed navigation/product clicks, and coarse city/region/country when Vercel makes it available. Query strings, IP addresses, typed text, raw click coordinates, and persistent cross-visit browser identifiers are not stored; Global Privacy Control and Do Not Track are honored, and raw events expire after 90 days.
 - A bearer-protected analytics report now exposes aggregate website sessions/pages/clicks/locations alongside current opt-in app feature state and usage counters for the private owner dashboard.

--- a/docs/release-notes/0.5.24.html
+++ b/docs/release-notes/0.5.24.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <title>OpenVoiceFlow 0.5.24 release notes</title>
+  <link rel="canonical" href="https://openvoiceflow.com/releases.html#v0.5.24" />
+  <style>
+    :root { color-scheme: light dark; --ink: #16130f; --ink2: #5d564d; --rule: #e4ded4; --ember: #b4531d; --bg: #fffdfa; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ink: #f4efe7; --ink2: #a49a8c; --rule: #322d27; --ember: #e2854a; --bg: #17140f; }
+    }
+    html, body { background: var(--bg); }
+    body {
+      margin: 0; padding: 16px 20px 22px;
+      font: 13px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+      color: var(--ink);
+    }
+    h1 { margin: 0 0 2px; font-size: 17px; letter-spacing: -0.2px; }
+    .date { margin: 0 0 14px; color: var(--ink2); font-size: 12px; }
+    h2 { margin: 16px 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--ink2); }
+    ul { margin: 0; padding-left: 18px; }
+    li { margin: 0 0 5px; }
+    code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; background: color-mix(in srgb, var(--ink) 8%, transparent); padding: 1px 4px; border-radius: 4px; }
+    a { color: var(--ember); }
+    footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--ink2); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenVoiceFlow 0.5.24</h1>
+    <p class="date">September 6, 2026</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li><strong>History opens straight away.</strong> The tab drew every take it had stored before it could show the dozen that fit on screen — resolving an app icon, and laying out a whole transcript, for each of up to 500 rows — so the longer your log, the longer the pane sat blank on every visit. It now draws the rows in view and the rest as you scroll to them, and acknowledging a <strong>Copy</strong> redraws that one row instead of the entire log. Nothing about what is kept changes: the same 500 takes, still only on this Mac.</li>
+    </ul>
+    <h2>Added</h2>
+    <ul>
+      <li>The website now records privacy-safe 30-minute visits, page views, acquisition source, allow-listed navigation/product clicks, and coarse city/region/country when Vercel makes it available. Query strings, IP addresses, typed text, raw click coordinates, and persistent cross-visit browser identifiers are not stored; Global Privacy Control and Do Not Track are honored, and raw events expire after 90 days.</li>
+      <li>A bearer-protected analytics report now exposes aggregate website sessions/pages/clicks/locations alongside current opt-in app feature state and usage counters for the private owner dashboard.</li>
+    </ul>
+  </main>
+  <footer>
+    <a href="https://openvoiceflow.com/releases.html">See the full version history</a>
+  </footer>
+</body>
+</html>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -68,6 +68,17 @@
       <h1 class="hero-title">Releases</h1>
       <p class="hero-sub answer-block">OpenVoiceFlow ships often — every release below is real, shipped, and notarized, newest first. Notes come straight from the project's changelog, so this list is exactly as current as the code. Want the raw commit history or to file an issue? <a href="https://github.com/shimoverse/openvoiceflow/releases">See every release on GitHub</a>.</p>
 
+      <details class="content-card" id="v0.5.24" open><summary><h2>v0.5.24 <span class="release-date">· September 6, 2026</span></h2></summary>
+        <h3>Fixed</h3>
+        <ul class="check-list">
+          <li><strong>History opens straight away.</strong> The tab drew every take it had stored before it could show the dozen that fit on screen — resolving an app icon, and laying out a whole transcript, for each of up to 500 rows — so the longer your log, the longer the pane sat blank on every visit. It now draws the rows in view and the rest as you scroll to them, and acknowledging a <strong>Copy</strong> redraws that one row instead of the entire log. Nothing about what is kept changes: the same 500 takes, still only on this Mac.</li>
+        </ul>
+        <h3>Added</h3>
+        <ul class="check-list">
+          <li>The website now records privacy-safe 30-minute visits, page views, acquisition source, allow-listed navigation/product clicks, and coarse city/region/country when Vercel makes it available. Query strings, IP addresses, typed text, raw click coordinates, and persistent cross-visit browser identifiers are not stored; Global Privacy Control and Do Not Track are honored, and raw events expire after 90 days.</li>
+          <li>A bearer-protected analytics report now exposes aggregate website sessions/pages/clicks/locations alongside current opt-in app feature state and usage counters for the private owner dashboard.</li>
+        </ul>
+      </details>
       <details class="content-card" id="v0.5.23" open><summary><h2>v0.5.23 <span class="release-date">· September 6, 2026</span></h2></summary>
         <h3>Fixed</h3>
         <ul class="check-list">

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.23</string>
-    <key>CFBundleVersion</key><string>28</string>
+    <key>CFBundleShortVersionString</key><string>0.5.24</string>
+    <key>CFBundleVersion</key><string>29</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios and contributors. MIT License.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/OpenVoiceFlow.xcodeproj/project.pbxproj
+++ b/native/OpenVoiceFlow.xcodeproj/project.pbxproj
@@ -479,14 +479,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.23;
+				MARKETING_VERSION = 0.5.24;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;
@@ -499,14 +499,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = OpenVoiceFlow.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.23;
+				MARKETING_VERSION = 0.5.24;
 				PRODUCT_BUNDLE_IDENTIFIER = app.openvoiceflow;
 				PRODUCT_NAME = OpenVoiceFlow;
 				SDKROOT = macosx;

--- a/native/Sources/OpenVoiceFlow/DashboardView.swift
+++ b/native/Sources/OpenVoiceFlow/DashboardView.swift
@@ -675,6 +675,19 @@ struct DashboardView: View {
     }
 
     // MARK: History
+    //
+    // The log holds up to `HistoryStore.maxEntries` takes, and a plain `VStack`
+    // inside a `ScrollView` builds every one of them before the first frame —
+    // resolving an app icon, laying out a full transcript and materialising a
+    // button per row, for hundreds of rows the user cannot see. That is what
+    // made opening this tab stall. `LazyVStack` builds the dozen rows that fit
+    // on screen and the rest as they scroll into view, which is also what keeps
+    // the cold app-icon lookups in `AppIconProvider` (a synchronous Launch
+    // Services search for any app that isn't currently running) off the path to
+    // that first frame.
+    //
+    // Rows live in their own `View` so a copy acknowledgement re-renders one
+    // row's worth of work rather than the whole log.
 
     @ViewBuilder private var historyPane: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -686,34 +699,22 @@ struct DashboardView: View {
                     button: nil
                 )
             } else {
-                ForEach(history.entries) { entry in
-                    let isCopied = copyFeedback.isCopied(entry.id)
-                    HStack(spacing: 12) {
-                        Text(entry.timestamp, format: .dateTime.hour().minute())
-                            .font(.system(size: 11)).foregroundStyle(ink2).frame(width: 56, alignment: .leading)
-                        AppIdentityLabel(name: entry.app, iconSize: 16, spacing: 5)
-                            .font(.system(size: 10, weight: .bold)).foregroundStyle(ink2)
-                            .padding(.horizontal, 6).padding(.vertical, 2)
-                            .background(RoundedRectangle(cornerRadius: 5).fill(fill))
-                        Text(entry.text).font(.system(size: 12.5)).foregroundStyle(ink).lineLimit(1)
-                        Spacer()
-                        Text("\(entry.words)").font(.system(size: 11)).foregroundStyle(ink2)
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            if NSPasteboard.general.setString(entry.text, forType: .string) {
-                                copyFeedback.markCopied(entry.id)
-                                usageCounters.record(.historyCopied)
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(history.entries) { entry in
+                        HistoryRow(
+                            entry: entry,
+                            isCopied: copyFeedback.isCopied(entry.id),
+                            onCopy: {
+                                NSPasteboard.general.clearContents()
+                                if NSPasteboard.general.setString(entry.text, forType: .string) {
+                                    copyFeedback.markCopied(entry.id)
+                                    usageCounters.record(.historyCopied)
+                                }
                             }
-                        } label: {
-                            Label(isCopied ? "Copied" : "Copy",
-                                  systemImage: isCopied ? "checkmark" : "doc.on.doc")
-                        }
-                        .buttonStyle(.plain).font(.system(size: 11)).foregroundStyle(DT.emberLight)
-                        .animation(.easeOut(duration: 0.15), value: isCopied)
+                        )
                     }
-                    .padding(.vertical, 10)
-                    .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 Text("Raw audio is discarded after transcription. Delete everything from Settings › Privacy.")
                     .font(.system(size: 11)).foregroundStyle(ink2).padding(.top, 6)
             }
@@ -1777,5 +1778,57 @@ private struct SnippetAddRow: View {
         guard !t.isEmpty, !e.isEmpty else { return }
         onAdd(t, e)
         trigger = ""; expansion = ""
+    }
+}
+
+/// One take in the History pane.
+///
+/// A row of its own, rather than a closure inside `historyPane`, for two
+/// reasons: `LazyVStack` can leave it unbuilt until it scrolls into view, and a
+/// copy acknowledgement redraws the row that was copied instead of every row in
+/// the log.
+private struct HistoryRow: View {
+    let entry: HistoryEntry
+    let isCopied: Bool
+    let onCopy: () -> Void
+    @Environment(\.colorScheme) private var scheme
+
+    /// One line is all that is ever drawn, but `Text` measures whatever string
+    /// it is handed — and a take can be a whole dictated paragraph. Hand it a
+    /// bounded prefix (still far longer than any row is wide, so SwiftUI's own
+    /// tail truncation is what the user sees) and the copy button keeps working
+    /// from `entry.text`, which stays whole.
+    private static let previewLimit = 512
+
+    private var dark: Bool { scheme == .dark }
+    private var ink: Color { dark ? DT.inkDark : DT.inkLight }
+    private var ink2: Color { dark ? DT.ink2Dark : DT.ink2Light }
+    private var hair: Color { dark ? .white.opacity(0.09) : .black.opacity(0.08) }
+    private var fill: Color { dark ? .white.opacity(0.06) : .black.opacity(0.05) }
+
+    private var preview: String { String(entry.text.prefix(Self.previewLimit)) }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(entry.timestamp, format: .dateTime.hour().minute())
+                .font(.system(size: 11)).foregroundStyle(ink2).frame(width: 56, alignment: .leading)
+            AppIdentityLabel(name: entry.app, iconSize: 16, spacing: 5)
+                .font(.system(size: 10, weight: .bold)).foregroundStyle(ink2)
+                .padding(.horizontal, 6).padding(.vertical, 2)
+                .background(RoundedRectangle(cornerRadius: 5).fill(fill))
+            Text(preview)
+                .font(.system(size: 12.5)).foregroundStyle(ink)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            Text("\(entry.words)").font(.system(size: 11)).foregroundStyle(ink2)
+            Button(action: onCopy) {
+                Label(isCopied ? "Copied" : "Copy",
+                      systemImage: isCopied ? "checkmark" : "doc.on.doc")
+            }
+            .buttonStyle(.plain).font(.system(size: 11)).foregroundStyle(DT.emberLight)
+            .animation(.easeOut(duration: 0.15), value: isCopied)
+        }
+        .padding(.vertical, 10)
+        .overlay(Rectangle().fill(hair).frame(height: 1), alignment: .top)
     }
 }

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.23
-        CURRENT_PROJECT_VERSION: 28
+        MARKETING_VERSION: 0.5.24
+        CURRENT_PROJECT_VERSION: 29
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:

--- a/tests/test_native_history_pane_rendering.py
+++ b/tests/test_native_history_pane_rendering.py
@@ -1,0 +1,64 @@
+"""Behavior contracts for how the History pane renders its log.
+
+The support question these prevent: "why does the History tab hang for a
+second when I click it?" It hung because the pane drew every stored take —
+up to `HistoryStore.maxEntries` of them — before it could show the dozen that
+fit on screen, resolving an app icon and laying out a full transcript per row.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = ROOT / "native" / "Sources" / "OpenVoiceFlow" / "DashboardView.swift"
+
+
+def dashboard_source() -> str:
+    return DASHBOARD.read_text(encoding="utf-8")
+
+
+def history_pane_source(source: str) -> str:
+    """The body of `historyPane`, up to the next MARK section."""
+    start = source.index("@ViewBuilder private var historyPane")
+    end = source.index("// MARK: Leaderboard", start)
+    return source[start:end]
+
+
+def test_history_list_is_lazy() -> None:
+    """Rows the user cannot see must not be built before the first frame."""
+    pane = history_pane_source(dashboard_source())
+
+    assert "LazyVStack" in pane, "History must draw its rows in a LazyVStack"
+    lazy_at = pane.index("LazyVStack")
+    rows_at = pane.index("ForEach(history.entries)")
+    assert lazy_at < rows_at, "The entry ForEach must sit inside the LazyVStack"
+
+
+def test_history_rows_are_their_own_view() -> None:
+    """A copy acknowledgement must redraw one row, not the whole log."""
+    source = dashboard_source()
+    pane = history_pane_source(source)
+
+    assert "struct HistoryRow: View" in source
+    assert "HistoryRow(" in pane
+    # The row's chrome belongs to HistoryRow; inlining it back into the pane is
+    # what made every take re-render whenever copyFeedback published.
+    assert "HStack(spacing: 12)" not in pane
+
+
+def test_copy_puts_the_whole_take_on_the_pasteboard() -> None:
+    """The row truncates for layout only — Copy must not copy a truncated take."""
+    source = dashboard_source()
+    pane = history_pane_source(source)
+
+    assert "setString(entry.text, forType: .string)" in pane
+    row_start = source.index("struct HistoryRow: View")
+    row = source[row_start:]
+    assert "entry.text.prefix(" in row, "Long transcripts must be bounded for layout"
+    assert "setString" not in row, "Copy stays in the pane, working from the whole entry"
+
+
+def test_home_recent_card_still_shows_three_takes() -> None:
+    """Laziness is a History-pane concern; Home's fixed card must not change."""
+    source = dashboard_source()
+    assert re.search(r"history\.entries\.prefix\(3\)", source)


### PR DESCRIPTION
## What this changes (for the user)

**The History tab no longer stalls when you open it.**

It drew every take it had stored before it could show the dozen that fit on screen. `ForEach(history.entries)` sat in a plain `VStack` inside a `ScrollView` — which is eager — so for up to `HistoryStore.maxEntries` (500) rows it resolved an app icon, formatted a timestamp, laid out a whole transcript and materialised a button, all on the main thread, all before the first frame.

The icon lookups are the expensive half. `AppIconProvider` falls back to `NSWorkspace.fullPath(forApplication:)`, a synchronous Launch Services search, for any name that isn't a running app — and the slowest case is a name that resolves to nothing at all: a browser tab title, say, which is exactly what a history log accumulates. Eager rendering meant every distinct name in the whole log got searched before anything appeared.

`LazyVStack` draws the rows in view and the rest as you scroll to them, so those lookups land off the path to the first frame and are bounded by what is on screen rather than by how long you have had the app.

Two smaller costs went with it:

- **The row is its own `View` now.** `copyFeedback.isCopied(entry.id)` was read in the pane's own body, so a single **Copy** click republished and rebuilt all 500 rows to move one checkmark.
- **Long takes no longer cost their full length to draw one line.** `Text` measures whatever string it is handed, and a take can be a dictated paragraph. The row hands it a 512-character prefix — still far wider than any row, so SwiftUI's tail truncation is what you see, unchanged. Copy still works from `entry.text`, which stays whole.

No behavior changes: the same rows in the same order, the same 500-entry cap, the same copy acknowledgement, and nothing new stored or sent.

**Also cuts 0.5.24** (build 29), which is step 1 of `RELEASE.md`. All four version fields move together — `project.yml` ×2, `Info.plist` ×2, plus both pbxproj build configurations — and build 29 clears the appcast's published 28, which is what Sparkle orders updates by. `docs/releases.html` and `docs/release-notes/0.5.24.html` are regenerated with `python3 scripts/build_releases.py`, so the appcast the publish step ships has a notes page to point at. The changelog's Unreleased section folds into this release under Keep a Changelog's usual rule; the two website analytics entries from #138 are website-side and already live, and 0.5.22 set the precedent of carrying website changes in the next app release's notes.

Steps 2–6 of `RELEASE.md` — tag, build/notarize, publish the DMG and signed appcast into `docs/`, verify live, prune the old DMG — need the signing secrets and a workflow dispatch, so they are not in this change. The site still pins 0.5.23 as the published download, which is correct until the publish step runs.

## How it was verified

- `python3 -m pytest -q` matches the pre-change baseline on this Linux container exactly: 14 failures and 17 errors before and after, all of them the legacy Python app's macOS-only dependencies (`sounddevice`, `rumps`, `pynput`) being absent here. Passing count goes 286 → 290, which is the four new contracts.
- `ruff check .` — clean.
- New contracts in `tests/test_native_history_pane_rendering.py`: the entry `ForEach` sits inside a `LazyVStack`, the row is its own `View` rather than inlined back into the pane, **Copy** puts the whole take on the pasteboard rather than the truncated preview, and Home's fixed three-take Recent card is untouched.
- `tests/test_native_history_app_identity.py` still passes: the History row keeps using the shared `AppIdentityLabel`, so app names have not regressed to text-only.
- `tests/test_docs_distribution.py` and `tests/test_docs_seo.py` pass against the regenerated release pages.

- [ ] CI green (`native-build` for Swift changes, pytest for website/Python)
- [ ] Screenshot or recording attached for UI changes
- [x] ~~No version bumps~~ — this PR is a release cut, so the version bump is deliberate. No new dependencies.

**Not verified here:** the Swift is compile-checked by CI's `native-build` job, not on a Mac in this session, and the rendering is not device-verified. Someone on a Mac should open History on a full 500-entry log before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gi5EmkDRuxBiP7MZnx4aLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi5EmkDRuxBiP7MZnx4aLV)_