### PR TITLE
chore: verify OpenVoiceFlow in Google Search Console

### DIFF
--- a/docs/googlee983d17a4bf861be.html
+++ b/docs/googlee983d17a4bf861be.html
@@ -1,0 +1,1 @@
+google-site-verification: googlee983d17a4bf861be.html

--- a/tests/test_website_behavior_analytics.py
+++ b/tests/test_website_behavior_analytics.py
@@ -38,7 +38,7 @@ def test_every_interactive_site_page_loads_analytics_but_embedded_release_notes_
     missing = []
     for page in (ROOT / "docs").rglob("*.html"):
         html = page.read_text(encoding="utf-8")
-        if "release-notes" in page.parts:
+        if "release-notes" in page.parts or html.strip().startswith("google-site-verification:"):
             assert "site.js" not in html
             continue
         if "site.js" not in html:


### PR DESCRIPTION
## Summary
- add Google Search Console HTML verification file
- exempt non-interactive verification files from the site analytics contract

## Verification
- `python3 -m pytest -q` — 325 passed, 1 skipped