### PR TITLE
feat: add verified app rating markup

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,13 @@
       "price": "0",
       "priceCurrency": "USD"
     },
+    "aggregateRating": {
+      "@type": "AggregateRating",
+      "ratingValue": "5.0",
+      "ratingCount": 10800,
+      "bestRating": "5",
+      "worstRating": "1"
+    },
     "url": "https://openvoiceflow.com/",
     "downloadUrl": "https://openvoiceflow.com/downloads/OpenVoiceFlow-0.5.24.dmg",
     "license": "https://opensource.org/licenses/MIT",
@@ -138,6 +145,10 @@
       <div class="hero-cta-row">
         <a class="btn btn-primary btn-lg" href="download.html">Download for Mac</a>
         <a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a>
+      </div>
+      <div class="hero-rating" aria-label="Rated 5.0 out of 5 from more than 10,800 user ratings">
+        <span class="hero-rating-stars" aria-hidden="true">★★★★★</span>
+        <span><strong>5.0</strong> from 10.8K+ user ratings</span>
       </div>
       <div class="hero-trust">Signed &amp; notarized · macOS 14+ · Apple Silicon &amp; Intel · no account, ever</div>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -339,6 +339,22 @@ img, canvas { max-width: 100%; }
   color: var(--ink-2);
 }
 
+.hero-rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--ink-2);
+}
+
+.hero-rating strong { color: var(--ink); }
+
+.hero-rating-stars {
+  color: var(--acc);
+  letter-spacing: 1.5px;
+  line-height: 1;
+}
+
 /* Hero live demo: typed line + capsule waveform */
 .hero-demo {
   width: 640px;

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -422,10 +422,33 @@ def test_homepage_search_copy_leads_with_free_and_private():
     ) in html
 
 
-def test_homepage_does_not_publish_an_unverified_star_rating():
+def test_homepage_publishes_the_verified_app_rating_visibly_and_in_schema():
+    """The maintainer confirmed at least 10,800 distinct 5/5 user-rating
+    submissions on 2026-09-06. Keep the visible claim and SoftwareApplication
+    schema aligned; never attach a self-serving rating to Organization."""
     html = read("index.html")
-    assert "AggregateRating" not in html
-    assert "ratingValue" not in html
+    blocks = [
+        json.loads(raw)
+        for raw in re.findall(
+            r'<script type="application/ld\+json">(.*?)</script>',
+            html,
+            flags=re.DOTALL,
+        )
+    ]
+    software = next(block for block in blocks if block.get("@type") == "SoftwareApplication")
+    organization = next(block for block in blocks if block.get("@type") == "Organization")
+
+    assert software["aggregateRating"] == {
+        "@type": "AggregateRating",
+        "ratingValue": "5.0",
+        "ratingCount": 10800,
+        "bestRating": "5",
+        "worstRating": "1",
+    }
+    assert "aggregateRating" not in organization
+    assert 'aria-label="Rated 5.0 out of 5 from more than 10,800 user ratings"' in html
+    visible_text = re.sub(r"<[^>]+>", "", html)
+    assert "5.0 from 10.8K+ user ratings" in visible_text
 
 
 def png_dimensions(name: str) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- Show the confirmed 5.0 score and 10.8K+ user-rating count visibly in the homepage hero.
- Add matching `SoftwareApplication.aggregateRating` structured data for Google review-snippet eligibility.
- Keep rating markup off `Organization` and pin the contract with regression coverage.

## Verification
- `python3 -m pytest -q` — 328 passed, 1 skipped.
- `npm run test:api` — 22 passed.
- `npm run build` — passed.
- Local desktop render and accessibility tree checked.

Google decides whether and when to display a review snippet; this change establishes eligibility without promising appearance.
