### PR TITLE
fix: clear homepage schema validation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,6 @@
     "url": "https://openvoiceflow.com/",
     "downloadUrl": "https://openvoiceflow.com/downloads/OpenVoiceFlow-0.5.24.dmg",
     "license": "https://opensource.org/licenses/MIT",
-    "codeRepository": "https://github.com/shimoverse/openvoiceflow",
     "sameAs": "https://github.com/shimoverse/openvoiceflow"
   }
   </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -145,9 +145,9 @@
         <a class="btn btn-primary btn-lg" href="download.html">Download for Mac</a>
         <a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a>
       </div>
-      <div class="hero-rating" aria-label="Rated 5.0 out of 5 from more than 10,800 user ratings">
+      <div class="hero-rating" aria-label="Rated 5.0 out of 5 from 10,800 user ratings">
         <span class="hero-rating-stars" aria-hidden="true">★★★★★</span>
-        <span><strong>5.0</strong> from 10.8K+ user ratings</span>
+        <span><strong>5.0</strong> from 10,800 user ratings</span>
       </div>
       <div class="hero-trust">Signed &amp; notarized · macOS 14+ · Apple Silicon &amp; Intel · no account, ever</div>
 

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -359,7 +359,7 @@ def test_homepage_structured_data_links_the_project_to_its_repository():
     repository = "https://github.com/shimoverse/openvoiceflow"
 
     assert software["license"] == "https://opensource.org/licenses/MIT"
-    assert software["codeRepository"] == repository
+    assert "codeRepository" not in software
     assert software["sameAs"] == repository
     assert organization["sameAs"] == [repository, "https://github.com/shimoverse"]
 

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -423,9 +423,10 @@ def test_homepage_search_copy_leads_with_free_and_private():
 
 
 def test_homepage_publishes_the_verified_app_rating_visibly_and_in_schema():
-    """The maintainer confirmed at least 10,800 distinct 5/5 user-rating
-    submissions on 2026-09-06. Keep the visible claim and SoftwareApplication
-    schema aligned; never attach a self-serving rating to Organization."""
+    """The maintainer confirmed the published baseline of 10,800 distinct
+    5/5 user-rating submissions on 2026-09-06. Keep the visible claim and
+    SoftwareApplication schema exact and aligned; never attach a self-serving
+    rating to Organization."""
     html = read("index.html")
     blocks = [
         json.loads(raw)
@@ -438,7 +439,8 @@ def test_homepage_publishes_the_verified_app_rating_visibly_and_in_schema():
     software = next(block for block in blocks if block.get("@type") == "SoftwareApplication")
     organization = next(block for block in blocks if block.get("@type") == "Organization")
 
-    assert software["aggregateRating"] == {
+    rating = software["aggregateRating"]
+    assert rating == {
         "@type": "AggregateRating",
         "ratingValue": "5.0",
         "ratingCount": 10800,
@@ -446,9 +448,13 @@ def test_homepage_publishes_the_verified_app_rating_visibly_and_in_schema():
         "worstRating": "1",
     }
     assert "aggregateRating" not in organization
-    assert 'aria-label="Rated 5.0 out of 5 from more than 10,800 user ratings"' in html
+    count_label = f'{rating["ratingCount"]:,}'
+    assert (
+        f'aria-label="Rated 5.0 out of 5 from {count_label} user ratings"'
+        in html
+    )
     visible_text = re.sub(r"<[^>]+>", "", html)
-    assert "5.0 from 10.8K+ user ratings" in visible_text
+    assert f"5.0 from {count_label} user ratings" in visible_text
 
 
 def png_dimensions(name: str) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- Remove the unsupported `SoftwareApplication.codeRepository` property while retaining the canonical GitHub source through `sameAs`.
- Align the visible, accessible, and structured rating count on the exact published baseline of **10,800 user ratings**.
- Derive the presentation assertion from JSON-LD `ratingCount` so future count changes cannot silently drift.

## Verification
- 328 Python tests passed; 1 optional dependency test skipped
- 22 API tests passed
- production build passed
- static security scan clean
- `git diff --check` passed
- Vercel preview passed
- full GitHub CI matrix passed, including native build

## Review follow-up
Resolves the independent review blocker from PR #147: visible `10.8K+`, accessible “more than 10,800,” and structured `10800` no longer disagree.
