### PR TITLE
Automatically exclude owner browser from analytics

### DIFF
--- a/api/__tests__/website-analytics.test.js
+++ b/api/__tests__/website-analytics.test.js
@@ -2,11 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  createOwnerExclusionSignature,
   normalizeWebsiteEvent,
   readEdgeLocation,
   isAuthorizedReportRequest,
 } from "../_websiteAnalytics.js";
 import { createWebsiteEventHandler } from "../analytics/event.js";
+import { createOwnerOptOutHandler } from "../analytics/owner-opt-out.js";
 import { createAnalyticsReportHandler } from "../analytics/report.js";
 import { createAnalyticsRetentionHandler } from "../cron/analytics-retention.js";
 
@@ -135,6 +137,71 @@ test("event endpoint records same-site human events with server-derived location
   assert.equal(inserted[0].sessionId, SESSION_ID);
   assert.deepEqual(inserted[0].location, { country: "US", region: "CA", city: "Tracy" });
   assert.match(response.headers["cache-control"], /no-store/);
+});
+
+test("event endpoint ignores an owner browser without storing or comparing IP addresses", async () => {
+  let databaseCalls = 0;
+  const handler = createWebsiteEventHandler({
+    async ensureSchema() { databaseCalls += 1; },
+    async insertWebsiteEvent() { databaseCalls += 1; },
+  });
+  const response = await call(handler, {
+    method: "POST",
+    body: pageView(),
+    headers: {
+      origin: "https://openvoiceflow.com",
+      "sec-fetch-site": "same-origin",
+      cookie: "theme=dark; ovf_owner_analytics_excluded=1",
+      "x-forwarded-for": "203.0.113.10",
+    },
+  });
+
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(response.body, { ok: true, ignored: true });
+  assert.equal(databaseCalls, 0);
+});
+
+test("owner opt-out requires a fresh dashboard-signed POST and sets a first-party HttpOnly cookie", async () => {
+  const secret = "report-secret";
+  const now = 1_800_000_000_000;
+  const timestamp = String(now);
+  const signature = createOwnerExclusionSignature(timestamp, secret);
+  const handler = createOwnerOptOutHandler({ secret, now: () => now });
+
+  let response = await call(handler, {
+    method: "GET",
+    body: { timestamp, signature },
+    headers: { origin: "https://openvoiceflow-analytics.vercel.app" },
+  });
+  assert.equal(response.statusCode, 405);
+
+  response = await call(handler, {
+    method: "POST",
+    body: { timestamp, signature },
+    headers: { origin: "https://example.com" },
+  });
+  assert.equal(response.statusCode, 403);
+
+  response = await call(handler, {
+    method: "POST",
+    body: { timestamp, signature: `${signature}0` },
+    headers: { origin: "https://openvoiceflow-analytics.vercel.app" },
+  });
+  assert.equal(response.statusCode, 403);
+
+  response = await call(handler, {
+    method: "POST",
+    body: { timestamp, signature },
+    headers: { origin: "https://openvoiceflow-analytics.vercel.app" },
+  });
+  assert.equal(response.statusCode, 303);
+  assert.equal(response.headers.location, "https://openvoiceflow-analytics.vercel.app/?owner_excluded=1");
+  assert.match(response.headers["set-cookie"], /^ovf_owner_analytics_excluded=1;/);
+  assert.match(response.headers["set-cookie"], /Max-Age=31536000/);
+  assert.match(response.headers["set-cookie"], /HttpOnly/);
+  assert.match(response.headers["set-cookie"], /Secure/);
+  assert.match(response.headers["set-cookie"], /SameSite=Lax/);
+  assert.doesNotMatch(response.headers["set-cookie"], /Domain=/);
 });
 
 test("event endpoint rejects cross-site, bot, and malformed events", async () => {

--- a/api/_websiteAnalytics.js
+++ b/api/_websiteAnalytics.js
@@ -2,6 +2,9 @@ import crypto from "node:crypto";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_PATH_RE = /^\/(?:[A-Za-z0-9._~-]+\/?)*$/;
+const OWNER_EXCLUSION_MESSAGE = "openvoiceflow-owner-exclusion:v1";
+export const OWNER_EXCLUSION_COOKIE = "ovf_owner_analytics_excluded";
+export const OWNER_EXCLUSION_MAX_AGE_MS = 5 * 60 * 1000;
 
 export const ALLOWED_WEBSITE_EVENTS = Object.freeze([
   "page_view",
@@ -122,6 +125,40 @@ export function normalizeWebsiteEvent(input) {
 function readHeader(headers, name) {
   const value = headers?.[name] ?? headers?.[name.toLowerCase()];
   return Array.isArray(value) ? value[0] : value;
+}
+
+export function hasOwnerExclusionCookie(headers) {
+  const cookieHeader = String(readHeader(headers, "cookie") || "");
+  return cookieHeader.split(";").some((part) => {
+    const [name, ...valueParts] = part.trim().split("=");
+    return name === OWNER_EXCLUSION_COOKIE && valueParts.join("=") === "1";
+  });
+}
+
+export function createOwnerExclusionSignature(timestamp, secret) {
+  if (!secret || typeof secret !== "string") return "";
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${OWNER_EXCLUSION_MESSAGE}:${timestamp}`)
+    .digest("hex");
+}
+
+export function isAuthorizedOwnerExclusion(body, secret, now = Date.now()) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  const timestamp = String(body.timestamp || "");
+  const signature = String(body.signature || "");
+  if (!/^\d{13}$/.test(timestamp) || !/^[0-9a-f]{64}$/.test(signature)) return false;
+
+  const issuedAt = Number(timestamp);
+  if (!Number.isSafeInteger(issuedAt) || issuedAt > now + 30_000 || now - issuedAt > OWNER_EXCLUSION_MAX_AGE_MS) {
+    return false;
+  }
+
+  const expected = createOwnerExclusionSignature(timestamp, secret);
+  const actualBuffer = Buffer.from(signature, "hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+  return actualBuffer.length === expectedBuffer.length
+    && crypto.timingSafeEqual(actualBuffer, expectedBuffer);
 }
 
 function decodeLocation(value, maxLength) {

--- a/api/analytics/event.js
+++ b/api/analytics/event.js
@@ -1,5 +1,6 @@
 import * as productionDatabase from "../_db.js";
 import {
+  hasOwnerExclusionCookie,
   isAutomatedRequest,
   isSameSiteRequest,
   normalizeWebsiteEvent,
@@ -21,6 +22,9 @@ export function createWebsiteEventHandler(database = productionDatabase) {
     }
     if (!isSameSiteRequest(req.headers)) {
       return res.status(403).json({ error: "forbidden" });
+    }
+    if (hasOwnerExclusionCookie(req.headers)) {
+      return res.status(202).json({ ok: true, ignored: true });
     }
     if (isAutomatedRequest(req.headers)) {
       return res.status(202).json({ ok: true, ignored: true });

--- a/api/analytics/owner-opt-out.js
+++ b/api/analytics/owner-opt-out.js
@@ -1,0 +1,42 @@
+import {
+  isAuthorizedOwnerExclusion,
+  OWNER_EXCLUSION_COOKIE,
+  setPrivateResponseHeaders,
+} from "../_websiteAnalytics.js";
+
+const DASHBOARD_ORIGIN = "https://openvoiceflow-analytics.vercel.app";
+const RETURN_URL = `${DASHBOARD_ORIGIN}/?owner_excluded=1`;
+
+function parseBody(body) {
+  if (body && typeof body === "object" && !Array.isArray(body)) return body;
+  if (typeof body !== "string") return {};
+  return Object.fromEntries(new URLSearchParams(body));
+}
+
+export function createOwnerOptOutHandler({
+  secret = process.env.ANALYTICS_REPORT_TOKEN,
+  now = Date.now,
+} = {}) {
+  return async function handler(req, res) {
+    setPrivateResponseHeaders(res);
+    if (req.method !== "POST") {
+      res.setHeader("Allow", "POST");
+      return res.status(405).json({ error: "method not allowed" });
+    }
+    if (req.headers?.origin !== DASHBOARD_ORIGIN) {
+      return res.status(403).json({ error: "forbidden" });
+    }
+    if (!isAuthorizedOwnerExclusion(parseBody(req.body), secret, now())) {
+      return res.status(403).json({ error: "forbidden" });
+    }
+
+    res.setHeader(
+      "Set-Cookie",
+      `${OWNER_EXCLUSION_COOKIE}=1; Max-Age=31536000; Path=/; HttpOnly; Secure; SameSite=Lax`
+    );
+    res.setHeader("Location", RETURN_URL);
+    return res.status(303).end();
+  };
+}
+
+export default createOwnerOptOutHandler();

--- a/docs/site.js
+++ b/docs/site.js
@@ -370,7 +370,7 @@
       headers: { 'Content-Type': 'application/json' },
       body: payload,
       keepalive: true,
-      credentials: 'omit',
+      credentials: 'same-origin',
     }).catch(() => {});
   }
 

--- a/tests/test_website_behavior_analytics.py
+++ b/tests/test_website_behavior_analytics.py
@@ -34,6 +34,13 @@ def test_site_tracks_visits_pages_and_allowlisted_actions_without_persistent_bro
     assert "navigator.doNotTrack" in site
 
 
+def test_analytics_fetch_fallback_sends_first_party_owner_exclusion_cookie() -> None:
+    site = read("docs/site.js")
+
+    assert "credentials: 'same-origin'" in site
+    assert "credentials: 'omit'" not in site
+
+
 def test_every_interactive_site_page_loads_analytics_but_embedded_release_notes_do_not() -> None:
     missing = []
     for page in (ROOT / "docs").rglob("*.html"):


### PR DESCRIPTION
## Summary
- bootstrap a privacy-safe owner exclusion from the authenticated analytics dashboard
- set a signed, host-only first-party cookie and stop event persistence before database access
- preserve same-origin credentials in both beacon and fetch delivery paths

## Privacy and security
- no IP matching, fingerprinting, precise location, or cross-site identifier
- short-lived HMAC request, exact Origin check, HttpOnly/Secure/SameSite cookie
- dashboard credentials and report token never cross to the public site

## Verification
- `pytest -q` — 329 passed, 1 optional skip
- `npm run test:api` — 24 passed
- `npm run build` — passed
- Ruff, syntax, and diff checks — passed
- web authorization static scan — 0 findings
- dashboard auth/live/fallback/robots tests — passed
- cross-project dashboard-to-endpoint signature compatibility — passed
- independent final security/logic review — passed with no blockers