### PR TITLE
fix: publish valid video upload datetime

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,7 +96,7 @@
     "thumbnailUrl": "https://openvoiceflow.com/assets/demo-poster.jpg",
     "contentUrl": "https://openvoiceflow.com/assets/openvoiceflow-demo.mp4",
     "embedUrl": "https://openvoiceflow.com/",
-    "uploadDate": "2026-07-31",
+    "uploadDate": "2026-07-31T04:32:32+00:00",
     "duration": "PT45S",
     "publisher": {"@type": "Organization", "name": "OpenVoiceFlow", "url": "https://openvoiceflow.com/"}
   }

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -11,7 +11,7 @@ are visible on the rendered page — which is exactly why they're tests.
 import json
 import re
 import struct
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -310,6 +310,24 @@ def test_the_product_film_ships_with_its_plumbing():
 
     site_js = read("site.js")
     assert "demo_play" in site_js, "film plays must be visible in analytics"
+
+
+def test_product_film_upload_date_is_a_timezone_aware_datetime():
+    """Google Video rich results require uploadDate to contain a valid time;
+    an explicit timezone prevents Googlebot from guessing one."""
+    blocks = [
+        json.loads(raw)
+        for raw in re.findall(
+            r'<script type="application/ld\+json">(.*?)</script>',
+            read("index.html"),
+            flags=re.DOTALL,
+        )
+    ]
+    video = next(block for block in blocks if block.get("@type") == "VideoObject")
+
+    upload_date = datetime.fromisoformat(video["uploadDate"])
+    assert upload_date.tzinfo is not None
+    assert upload_date.utcoffset() is not None
 
 
 def test_every_page_links_the_public_github_repo():


### PR DESCRIPTION
## Summary
- replace the date-only VideoObject `uploadDate` with the original publication timestamp in ISO 8601 UTC
- add a regression test requiring a parseable, timezone-aware datetime

## Root cause
The homepage published `uploadDate` as `2026-07-31`, while Google Video structured data expects a date **and time** and recommends an explicit timezone. Search Console therefore reported both an invalid datetime and a missing timezone.

## Verification
- `python3 -m pytest tests/test_docs_seo.py::test_product_film_upload_date_is_a_timezone_aware_datetime -q`
- `python3 -m pytest tests/test_docs_seo.py tests/test_docs_distribution.py -q` — 41 passed
- `python3 -m pytest -q` — 345 passed, 1 optional skip
- `uvx ruff check .`
- `uvx --from build pyproject-build`
- `npm run build`
- `npm run test:api` — 34 passed
- local HTTP read-back parsed `2026-07-31T04:32:32+00:00` as timezone-aware
- independent review: PASS; no security or logic findings