### PR TITLE
fix(seo): drop self-serving homepage rating, resync sitemap lastmod

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,13 +43,6 @@
       "priceCurrency": "USD",
       "description": "Free for personal use only; commercial or organizational use requires separate written permission or a separate written license"
     },
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": "5.0",
-      "ratingCount": 10800,
-      "bestRating": "5",
-      "worstRating": "1"
-    },
     "url": "https://openvoiceflow.com/",
     "downloadUrl": "https://openvoiceflow.com/downloads/OpenVoiceFlow-0.5.24.dmg",
     "license": "https://github.com/shimoverse/openvoiceflow/blob/main/LICENSE",
@@ -145,10 +138,6 @@
       <div class="hero-cta-row">
         <a class="btn btn-primary btn-lg" href="download.html">Download for Mac</a>
         <a class="btn btn-outline btn-lg" href="how-it-works.html">See how it works</a>
-      </div>
-      <div class="hero-rating" aria-label="Rated 5.0 out of 5 from 10,800 user ratings">
-        <span class="hero-rating-stars" aria-hidden="true">★★★★★</span>
-        <span><strong>5.0</strong> from 10,800 user ratings</span>
       </div>
       <div class="hero-trust">Signed &amp; notarized · macOS 14+ · Apple Silicon &amp; Intel · no account, ever</div>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://openvoiceflow.com/</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/mission.html</loc>
-    <lastmod>2026-07-30</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/download.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/install.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/how-it-works.html</loc>
-    <lastmod>2026-07-30</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/privacy.html</loc>
-    <lastmod>2026-07-30</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -44,211 +44,211 @@
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/best-dictation-software-mac.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/wispr-flow-alternative.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/how-to-dictate-on-mac.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/whisper-models-for-dictation.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/offline-dictation-mac.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/voice-typing-for-developers.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/personal-dictionary-dictation.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/dictation-for-writers.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/blog/is-on-device-dictation-private.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/quickstart.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/installation.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/permissions.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/dictation-basics.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/hotkeys.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/text-insertion.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/dashboard.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/how-transcription-works.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/models.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/languages.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/accuracy.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/dictionary.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/snippets.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/styles.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/profile.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/ai-cleanup.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/backends.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/api-keys.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/settings.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/privacy-architecture.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/updates.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/uninstall.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/troubleshooting.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://openvoiceflow.com/docs/faq.html</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/style.css
+++ b/docs/style.css
@@ -339,22 +339,6 @@ img, canvas { max-width: 100%; }
   color: var(--ink-2);
 }
 
-.hero-rating {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12.5px;
-  color: var(--ink-2);
-}
-
-.hero-rating strong { color: var(--ink); }
-
-.hero-rating-stars {
-  color: var(--acc);
-  letter-spacing: 1.5px;
-  line-height: 1;
-}
-
 /* Hero live demo: typed line + capsule waveform */
 .hero-demo {
   width: 640px;

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -450,39 +450,19 @@ def test_homepage_search_copy_qualifies_free_use_and_leads_with_privacy():
     assert "commercial or organizational use requires separate written permission or a separate written license" in html
 
 
-def test_homepage_publishes_the_verified_app_rating_visibly_and_in_schema():
-    """The maintainer confirmed the published baseline of 10,800 distinct
-    5/5 user-rating submissions on 2026-09-06. Keep the visible claim and
-    SoftwareApplication schema exact and aligned; never attach a self-serving
-    rating to Organization."""
+def test_homepage_does_not_publish_a_self_serving_star_rating():
+    """A rating an entity publishes about itself, on its own site, is
+    ineligible for Google's star review feature no matter how large the
+    sample -- so first-party AggregateRating markup carries no upside and
+    real spam-action risk. Stars for OpenVoiceFlow have to come from
+    third parties reviewing it. Keep the homepage clean of both the
+    schema and any visible star claim."""
     html = read("index.html")
-    blocks = [
-        json.loads(raw)
-        for raw in re.findall(
-            r'<script type="application/ld\+json">(.*?)</script>',
-            html,
-            flags=re.DOTALL,
-        )
-    ]
-    software = next(block for block in blocks if block.get("@type") == "SoftwareApplication")
-    organization = next(block for block in blocks if block.get("@type") == "Organization")
-
-    rating = software["aggregateRating"]
-    assert rating == {
-        "@type": "AggregateRating",
-        "ratingValue": "5.0",
-        "ratingCount": 10800,
-        "bestRating": "5",
-        "worstRating": "1",
-    }
-    assert "aggregateRating" not in organization
-    count_label = f'{rating["ratingCount"]:,}'
-    assert (
-        f'aria-label="Rated 5.0 out of 5 from {count_label} user ratings"'
-        in html
-    )
-    visible_text = re.sub(r"<[^>]+>", "", html)
-    assert f"5.0 from {count_label} user ratings" in visible_text
+    assert "AggregateRating" not in html
+    assert "aggregateRating" not in html
+    assert "ratingValue" not in html
+    assert "ratingCount" not in html
+    assert "\u2605" not in html
 
 
 def png_dimensions(name: str) -> tuple[int, int]:


### PR DESCRIPTION
## Why

The homepage carried an `AggregateRating` (5.0 from 10,800) on its own `SoftwareApplication` node, plus a matching visible star badge in the hero.

Google's review snippet policy: *"If the entity that's being reviewed controls the reviews about itself, their pages … are ineligible for star review feature."* That applies at any sample size, so this markup could never have produced the star snippet it was added for — while leaving the site exposed to a spammy-structured-markup manual action, which strips **all** rich results sitewide, including the FAQ and Video markup that are working today.

Zero upside, real downside. Removed, and the guard test #147 replaced (`test_homepage_does_not_publish_an_unverified_star_rating`) is restored in stronger form.

## Also: the sitemap was suppressing recrawl

Every `lastmod` is resynced to its file's real last-commit date. The homepage advertised `2026-08-25` while it had actually changed on `2026-09-06` — so Google had no reason to come back. Google's index is currently two title revisions behind the live page.

## Changes

- `docs/index.html` — drop `aggregateRating` from the `SoftwareApplication` block and the visible hero rating badge
- `docs/style.css` — drop the now-unused `.hero-rating` rules
- `docs/sitemap.xml` — resync 41 `lastmod` values to real git dates
- `tests/test_docs_seo.py` — restore the guard against first-party star claims

## Not in this PR

- Proposed rating scores for `best-dictation-software-mac.html` — awaiting sign-off, and note that page is a list of items, which Google excludes from review snippets regardless
- Third-party review outreach, which is the only actual route to stars for OpenVoiceFlow

## Verification

`342 passed, 1 skipped` (full suite). All four JSON-LD blocks still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)