### PR TITLE
docs: repair cross-references broken by the website split

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,14 +3,14 @@
 > **This document describes the legacy Python app (≤ 0.3.6), which is
 > end-of-life.** The shipping app is native Swift under `native/` — for its
 > architecture, start with the module map in
-> [`native/README.md`](../native/README.md): HotkeyEngine (CGEvent tap) →
+> [`native/README.md`](native/README.md): HotkeyEngine (CGEvent tap) →
 > AudioCapture → Transcriber (WhisperKit) → CleanupProvider (optional) →
 > Paster, orchestrated by AppController and surfaced through HUDController,
 > DashboardView, and OnboardingView.
 
 
 
-> Audience: humans contributing code. For an AI-coding-agent contributor's view, see [`AGENTS.md`](../AGENTS.md) at the repo root.
+> Audience: humans contributing code. For an AI-coding-agent contributor's view, see [`AGENTS.md`](AGENTS.md) at the repo root.
 
 ## 1. Elevator pitch
 
@@ -289,7 +289,7 @@ Version lives in two places — `pyproject.toml` (`[project] version`) and `voic
 
 ## See also
 
-- [`README.md`](../README.md) — user-facing overview and CLI cheat sheet.
-- [`PRIVACY.md`](../PRIVACY.md) — privacy posture in plain English.
-- [`docs/THREAT_MODEL.md`](THREAT_MODEL.md) — what we defend against and what we don't.
-- [`AGENTS.md`](../AGENTS.md) — contributor guide for AI coding agents.
+- [`README.md`](README.md) — user-facing overview and CLI cheat sheet.
+- [`PRIVACY.md`](PRIVACY.md) — privacy posture in plain English.
+- [`THREAT_MODEL.md`](THREAT_MODEL.md) — what we defend against and what we don't.
+- [`AGENTS.md`](AGENTS.md) — contributor guide for AI coding agents.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 This page lists what we test on, what we expect to work, and what we don't support. OpenVoiceFlow is an OSS project with no dedicated QA team, so "tested" means "exercised by maintainers on a real machine"; "expected to work" means "no known reason it wouldn't, but we haven't run it ourselves."
 
-Source of truth for the version constraints: [`pyproject.toml`](../pyproject.toml).
+Source of truth for the version constraints: [`pyproject.toml`](pyproject.toml).
 
 ---
 

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Compliance posture
 
-> Sibling docs: [`PRIVACY.md`](../PRIVACY.md) · [`SECURITY.md`](../SECURITY.md) · [`THREAT_MODEL.md`](THREAT_MODEL.md) · [`legal/DPA-template.md`](legal/DPA-template.md)
+> Sibling docs: [`PRIVACY.md`](PRIVACY.md) · [`SECURITY.md`](SECURITY.md) · [`THREAT_MODEL.md`](THREAT_MODEL.md) · [`legal/DPA-template.md`](legal/DPA-template.md)
 
 ## TL;DR
 
@@ -82,7 +82,7 @@ OpenVoiceFlow can work for low-stakes BYOK-tolerant teams. It is **not** a manag
 - **Decide whether the LLM-backend data flow is acceptable** under your DLP, data-residency, and acceptable-use policies. Different employees may pick different backends; the deployment is only as restrictive as the locked configuration.
 - **Consider Ollama-only deployments** to keep transcripts on-device. This eliminates the cloud LLM as a sub-processor entirely.
 - **Pre-stage `whisper-cpp` and the model file** via your MDM (Jamf, Mosyle) or a `brew bundle` so the bootstrap doesn't pull from external networks at first launch on a managed Mac.
-- **Ship a managed config** by writing `~/.openvoiceflow/config.json` during provisioning. For lock-down, pin: `update_check: false`, `log_transcripts: false`, `auto_learn: false`, `llm_backend: "ollama"`. (See [`PRIVACY.md`](../PRIVACY.md) for the full config-key list.)
+- **Ship a managed config** by writing `~/.openvoiceflow/config.json` during provisioning. For lock-down, pin: `update_check: false`, `log_transcripts: false`, `auto_learn: false`, `llm_backend: "ollama"`. (See [`PRIVACY.md`](PRIVACY.md) for the full config-key list.)
 - **Note that the current v0.3.6 hosted DMGs are Developer ID signed, Apple-notarized, and stapled.** MDM-aware orgs may still want to wrap the install differently (re-sign with an internal Developer ID, ship as a signed `.pkg`, or build from source in-house).
 - **There is no enterprise key-management story.** Each employee's API keys land in their own `~/.openvoiceflow/config.json` (mode 600). No central rotation, no SSO, no SCIM.
 
@@ -110,13 +110,13 @@ We do not centrally retain audio, dictated text, profile content, dictionary ent
 
 ## Changes
 
-This document is versioned with the code. Material changes are surfaced under the relevant release in [`CHANGELOG.md`](../CHANGELOG.md). The sibling [`PRIVACY.md`](../PRIVACY.md) carries the matching privacy-side commitments.
+This document is versioned with the code. Material changes are surfaced under the relevant release in [`CHANGELOG.md`](CHANGELOG.md). The sibling [`PRIVACY.md`](PRIVACY.md) carries the matching privacy-side commitments.
 
 ---
 
 ## Cross-references
 
-- [`PRIVACY.md`](../PRIVACY.md) — what data exists, where it goes, what you can opt out of.
-- [`SECURITY.md`](../SECURITY.md) — supported versions, vulnerability reporting, scope.
+- [`PRIVACY.md`](PRIVACY.md) — what data exists, where it goes, what you can opt out of.
+- [`SECURITY.md`](SECURITY.md) — supported versions, vulnerability reporting, scope.
 - [`THREAT_MODEL.md`](THREAT_MODEL.md) — what we defend against and what we explicitly don't.
 - [`legal/DPA-template.md`](legal/DPA-template.md) — a fill-in-the-blanks template for documenting an OpenVoiceFlow deployment in your own data-flow inventory.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -66,7 +66,7 @@ A historical third-party contribution included in the current tree was accepted
 when the project used MIT terms. Rights in that contributor's material remain
 available under MIT; the current reciprocal license governs Shimoverse Studios'
 new and modified material. The provenance and preserved MIT notice are in
-[docs/legal/LEGACY_MIT_PORTIONS.md](docs/legal/LEGACY_MIT_PORTIONS.md). This
+[legal/LEGACY_MIT_PORTIONS.md](legal/LEGACY_MIT_PORTIONS.md). This
 means the reciprocal condition cannot be imposed retroactively on that
 contributor's pre-existing copyright. It does apply to new contributions made
 under the current contribution terms.
@@ -81,7 +81,7 @@ and separate commercial and organizational licenses.
 ## Third-party software and brand
 
 Third-party components are governed by their own licenses, listed in
-[docs/legal/THIRD_PARTY_NOTICES.md](docs/legal/THIRD_PARTY_NOTICES.md). The
+[legal/THIRD_PARTY_NOTICES.md](legal/THIRD_PARTY_NOTICES.md). The
 OpenVoiceFlow name and logo are governed separately by
 [TRADEMARKS.md](TRADEMARKS.md); derivatives must rebrand and state **"Based on OpenVoiceFlow by Shimoverse
 Studios"** with a working link to the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,7 +100,7 @@ No bug bounty. We can't pay; the project earns $0.
 
 - The native macOS app — everything under `native/` (the shipped `OpenVoiceFlow.app`).
 - The Sparkle update feed and release pipeline (`.github/workflows/release-native.yml`, `native/scripts/`).
-- The website and its download/appcast serving (`docs/`, `vercel.json`).
+- The website and its download/appcast serving (the private `shimoverse/openvoiceflow-web` repo).
 - The GitHub Actions workflows under `.github/workflows/`.
 - The legacy Python package (`voiceflow/`, `install.sh`, `build-dmg.sh`) is EOL: reports are
   welcome for awareness, but fixes ship only if the macOS 12–13 fallback is affected.
@@ -134,7 +134,7 @@ If you're not sure, send it anyway and we'll route it.
 ## Threat model
 
 A short pointer, not a full document. The full version lives at
-[`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
+[`THREAT_MODEL.md`](THREAT_MODEL.md).
 
 OpenVoiceFlow holds three strong privileges on the user's Mac:
 
@@ -194,5 +194,5 @@ GitHub Security Advisory on the repo.
 - The repo lives at `github.com/shimoverse/openvoiceflow` today and may move to a
   personal account before public release. URLs in this file will be updated if so.
 - This document is part of the v0.3 readiness bundle. Pair reading:
-  [`PRIVACY.md`](PRIVACY.md), [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md),
+  [`PRIVACY.md`](PRIVACY.md), [`THREAT_MODEL.md`](THREAT_MODEL.md),
   [`COMPLIANCE.md`](COMPLIANCE.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -31,7 +31,7 @@ Use GitHub Discussions: <https://github.com/shimoverse/openvoiceflow/discussions
 
 ## Privacy or compliance question?
 
-See [PRIVACY.md](PRIVACY.md) and [docs/COMPLIANCE.md](docs/COMPLIANCE.md). For questions not covered there, open a Discussion.
+See [PRIVACY.md](PRIVACY.md) and [COMPLIANCE.md](COMPLIANCE.md). For questions not covered there, open a Discussion.
 
 ## Want to contribute?
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -150,7 +150,7 @@ Threats we **do not** try to defend against, because either the threat is the us
 
 - **`SECURITY.md`** (repo root) — vulnerability disclosure: where to report, supported versions, response SLA.
 - **`PRIVACY.md`** (planned for v0.3 wave 3) — full data-flow diagram, sub-processor list, retention, opt-outs.
-- **This document (`docs/THREAT_MODEL.md`)** — the page you are reading.
+- **This document (`THREAT_MODEL.md`)** — the page you are reading.
 
 ### Strong-privilege source files (read these to verify the mitigations above)
 

--- a/legal/DPA-template.md
+++ b/legal/DPA-template.md
@@ -1,6 +1,6 @@
 # OpenVoiceFlow deployment record (DPA-style template)
 
-> Sibling docs: [`../../PRIVACY.md`](../../PRIVACY.md) · [`../COMPLIANCE.md`](../COMPLIANCE.md) · [`../../SECURITY.md`](../../SECURITY.md)
+> Sibling docs: [`../PRIVACY.md`](../PRIVACY.md) · [`../COMPLIANCE.md`](../COMPLIANCE.md) · [`../SECURITY.md`](../SECURITY.md)
 
 ## Purpose of this template
 
@@ -82,7 +82,7 @@ In v0.3, OpenVoiceFlow ships with the following on each Mac:
 - **Update check is opt-out-able** via `update_check: false`.
 - **Audio never leaves the Mac.** Whisper.cpp processes locally; temp WAV is deleted in the `finally` block of each dictation.
 - **No central server.** There is nothing for the maintainer to compromise that would expose your data.
-- **Public source** is auditable at <https://github.com/shimoverse/openvoiceflow>; see [`../../LICENSING.md`](../../LICENSING.md) for the applicable use rights.
+- **Public source** is auditable at <https://github.com/shimoverse/openvoiceflow>; see [`../LICENSING.md`](../LICENSING.md) for the applicable use rights.
 
 Your organization adds (fill in):
 
@@ -105,5 +105,5 @@ If you change which LLM provider you use, also update or sign a fresh DPA **with
 ## Cross-references
 
 - [`../COMPLIANCE.md`](../COMPLIANCE.md) — full compliance posture (what we are, what we are not, GDPR/HIPAA notes).
-- [`../../PRIVACY.md`](../../PRIVACY.md) — what data exists, where it goes, what you can opt out of.
-- [`../../SECURITY.md`](../../SECURITY.md) — supported versions and vulnerability reporting.
+- [`../PRIVACY.md`](../PRIVACY.md) — what data exists, where it goes, what you can opt out of.
+- [`../SECURITY.md`](../SECURITY.md) — supported versions and vulnerability reporting.

--- a/legal/THIRD_PARTY_NOTICES.md
+++ b/legal/THIRD_PARTY_NOTICES.md
@@ -8,11 +8,11 @@ over a network must publish corresponding source under the same license, while
 every Integration must retain the required attribution. Commercial or
 organizational use requires separate written permission or a separate written
 license. See
-[`LICENSE`](../../LICENSE) and [`LICENSING.md`](../../LICENSING.md). Third-party
+[`LICENSE`](../LICENSE) and [`LICENSING.md`](../LICENSING.md). Third-party
 components remain governed by their own licenses below.
 
 Repository: <https://github.com/shimoverse/openvoiceflow>
-Sources of truth for runtime dependencies: [`pyproject.toml`](../../pyproject.toml), [`Package.swift`](../../native/Package.swift), and [`package.json`](../../package.json).
+Sources of truth for runtime dependencies: [`pyproject.toml`](../pyproject.toml) and [`Package.swift`](../native/Package.swift). (The website's npm dependencies are not distributed with the app and live in the private site repo.)
 
 ---
 
@@ -94,7 +94,7 @@ The leaderboard API deployed with the website uses the following server-side dep
 
 ## 7. Bundled docs, fonts, and assets
 
-The native app bundles small app-identification marks for cases where macOS cannot resolve an installed app icon. Simple Icons assets are CC0 1.0; the SVG Logos assets used here are CC0 1.0; the Microsoft marks sourced from theSVG Color are MIT; Superhuman and Panic fallbacks are vendor-provided public identification marks. File-by-file sources are recorded in [`native/Resources/BrandIcons/README.md`](../../native/Resources/BrandIcons/README.md). Brand names and marks remain the property of their respective owners and are used nominatively; their presence does not imply endorsement.
+The native app bundles small app-identification marks for cases where macOS cannot resolve an installed app icon. Simple Icons assets are CC0 1.0; the SVG Logos assets used here are CC0 1.0; the Microsoft marks sourced from theSVG Color are MIT; Superhuman and Panic fallbacks are vendor-provided public identification marks. File-by-file sources are recorded in [`native/Resources/BrandIcons/README.md`](../native/Resources/BrandIcons/README.md). Brand names and marks remain the property of their respective owners and are used nominatively; their presence does not imply endorsement.
 
 The overlay HUD draws using macOS system fonts (San Francisco), which carry no separate licensing obligation for an app running on macOS.
 
@@ -135,7 +135,7 @@ The product and company names shown in OpenVoiceFlow, including Apple, Claude, D
 
 This file is regenerated each release. Pull requests that touch `pyproject.toml`, `native/Package.swift`, or `package.json` (adding, removing, or upgrading a runtime dependency) **must** update this file in the same PR.
 
-**Follow-up flagged for the maintainer:** add this rule to the [`CONTRIBUTING.md`](../../CONTRIBUTING.md) PR checklist so the obligation is enforced at review time rather than relying on memory.
+**Follow-up flagged for the maintainer:** add this rule to the [`CONTRIBUTING.md`](../CONTRIBUTING.md) PR checklist so the obligation is enforced at review time rather than relying on memory.
 
 Last reviewed against:
 

--- a/native/BUILD_RUNBOOK.md
+++ b/native/BUILD_RUNBOOK.md
@@ -206,9 +206,10 @@ for the copy-paste version):
    (they are, since the Python DMGs ship signed).
 3. **Push the tag** `native-v0.4.0` (a `native-v0.4.0-rc1` first is wise). Tag
    pushes are blocked from the Linux agent — this is yours.
-4. The pipeline publishes the notarized DMG + appcast to the Release. **Merge
-   the staged website PR** (`docs/` already prepped for 0.4.0) once the DMG is
-   downloadable, or drop the DMG into `docs/downloads/` per that PR.
+4. The pipeline publishes the notarized DMG + appcast to the Release. Then, in
+   the private `shimoverse/openvoiceflow-web` repo, drop the DMG into
+   `docs/downloads/` and the appcast into `docs/appcast.xml` and merge — that
+   merge is what starts updates. See RELEASE.md.
 
 CI note: `ci.yml` compiles the *Python* app only — the native Swift is not in
 CI, so a `swift build` (or the archive step above) on your Mac is what

--- a/native/scripts/appcast.sh
+++ b/native/scripts/appcast.sh
@@ -41,9 +41,9 @@ FEED_URL="${OVF_APPCAST_URL:-https://openvoiceflow.com/appcast.xml}"
 # the item: releaseNotesLink fills the WebView in the update sheet, and
 # fullReleaseNotesLink is what the "Version History" button opens — including
 # on the "You're up to date!" alert, which is the only place a current user
-# ever sees it. Both must be real pages; scripts/build_releases.py generates
-# them from CHANGELOG.md, so the changelog entry has to land before this
-# appcast goes live (RELEASE.md).
+# ever sees it. Both must be real pages; build_releases.py in the private site
+# repo generates them from this repo's CHANGELOG.md, so the changelog entry has
+# to land before this appcast goes live (RELEASE.md).
 SITE_BASE="${OVF_SITE_BASE:-https://openvoiceflow.com}"
 SPARKLE_VERSION="${SPARKLE_VERSION:-2.9.4}"
 


### PR DESCRIPTION
Follow-up to #156. Moving `ARCHITECTURE.md`, `THREAT_MODEL.md`, `COMPLIANCE.md`, `COMPATIBILITY.md` out of `docs/` and `legal/` up one level broke their relative links — my miss in that PR.

**25 links pointed outside the repo** (`../PRIVACY.md`, `../../LICENSE`, …) and **5 root docs still linked at `docs/*`**. These are on the licensing and security surfaces the split was specifically meant to keep publicly auditable, so a procurement reader following `LICENSING.md` → third-party notices, or `SECURITY.md` → threat model, got a 404.

### Changes
- Rebase `../` / `../../` links in the moved files to their new depth.
- `LICENSING.md`, `SUPPORT.md`, `SECURITY.md` now point at `legal/`, `COMPLIANCE.md`, `THREAT_MODEL.md`.
- `THIRD_PARTY_NOTICES.md` no longer cites `package.json` — the website's npm deps aren't distributed with the app and now live in the private site repo.
- `SECURITY.md`'s disclosure scope names the private site repo instead of the removed `docs/` + `vercel.json`.
- `BUILD_RUNBOOK.md` and `native/scripts/appcast.sh` describe publishing from the site repo.

`CHANGELOG.md` is deliberately untouched — its `docs/…` mentions are historical record, not links.

### Verification
- Full-repo markdown link audit: **0 unresolved relative links** (was 30).
- `272 passed, 2 skipped`; `ruff` clean.
- Cross-repo licensing contract with `OVF_WEB_ROOT` set: `12 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)