### PR TITLE
test: stop launch self-check from touching macOS TCC

### DIFF
--- a/tests/test_launch_self_check.py
+++ b/tests/test_launch_self_check.py
@@ -18,6 +18,15 @@ def stub_validate_setup_inputs(monkeypatch, tmp_path):
     # Build an OpenVoiceFlow instance with a synthetic config — no real recorder.
     monkeypatch.setattr(appmod, "AudioRecorder", lambda *a, **kw: object())
 
+    # Never touch macOS TCC from a test: no AXIsProcessTrusted / IOHIDCheckAccess,
+    # and never pop the consent dialog or open System Settings. Without these
+    # stubs the happy path only passes on Macs where the interpreter already
+    # holds Accessibility trust. Tests that need the failure path override
+    # ``_is_accessibility_trusted`` themselves.
+    monkeypatch.setattr(appmod, "_is_accessibility_trusted", lambda: True)
+    monkeypatch.setattr(appmod, "_prompt_accessibility_consent", lambda: None)
+    monkeypatch.setattr(appmod.platform_support, "input_monitoring_status", lambda: None)
+
     return appmod
 
 


### PR DESCRIPTION
The happy-path launch self-check called into the real Accessibility and Input Monitoring APIs. That made it **machine-dependent**: it only passed where the running interpreter already held Accessibility trust, and on a machine without it the test could pop a consent dialog or open System Settings mid-run.

Stubs `_is_accessibility_trusted`, `_prompt_accessibility_consent` and `platform_support.input_monitoring_status` in the shared fixture. Tests that exercise the *failure* path still override `_is_accessibility_trusted` themselves, so that coverage is unchanged.

All three stubbed symbols verified to exist: `voiceflow/app.py:87`, `voiceflow/app.py:94`, `voiceflow/platform_support.py:142`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)