### PR TITLE
docs(legal): add a grace period while permission is requested

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -72,6 +72,16 @@ includes, without limitation:
 Commercial or organizational rights require separate written permission or a
 separate written license from Shimoverse Studios. Contact `contact@openvoiceflow.com`.
 
+### 4.1 Grace period while permission is requested
+
+If you begin a commercial or organizational use in good faith and send a written
+request to `contact@openvoiceflow.com`, you may continue that use for thirty days
+after sending the request, or until Shimoverse Studios responds, whichever is
+later. This grace period applies once per organization, not once per person, and
+does not waive the attribution and source-sharing conditions in Section 5. If
+permission is declined, you must stop the commercial or organizational use
+within thirty days of that response.
+
 ## 5. Attribution and source-sharing conditions
 
 If you create a Covered Work or Integration—including a fork, derivative, or

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -51,6 +51,13 @@ permission or a separate written license from Shimoverse Studios. Contact
 - where procurement, support, warranty, indemnity, or other commercial terms are
   required.
 
+If you start a commercial or organizational use in good faith and email us, you
+are covered while we sort it out: Section 4.1 of the license gives you thirty
+days from the date of your request, or until we reply, whichever is later. You do
+not have to stop using OpenVoiceFlow while waiting on an answer. That grace
+period is one per organization, not one per person, and it does not suspend the
+credit and source-sharing conditions in Section 5.
+
 Shimoverse Studios can provide separate commercial or organizational terms,
 including negotiated closed-source rights where appropriate. Receiving the
 source, downloading a build, publishing modifications, or making a contribution


### PR DESCRIPTION
> **This changes the licence text. It should have your eyes on it before merging — I have not merged it.**

Adds **Section 4.1** to `LICENSE`: someone who begins commercial or organizational use in good faith and sends a written request keeps that use for **thirty days from the request, or until Shimoverse Studios replies, whichever is later**. One grace period per organization, not per person. It does not suspend the attribution and source-sharing conditions in Section 5, and if permission is declined the use must stop within thirty days of that response.

`LICENSING.md` states the same rule in plain language.

### Note on the contact address
Your draft pointed §4.1 at `shimoverse@gmail.com` while the line directly above it said `contact@openvoiceflow.com` — two addresses two lines apart, inside the clause telling people where to send permission requests. I aligned §4.1 to `contact@openvoiceflow.com`, matching what #152 standardized across the project. No test caught this: the licensing tests assert the new address is *present*, not that the old one is absent.

If licensing requests should in fact go to a monitored personal address, this is the line to change back — but then the line above it should match.

### Verification
`273 passed, 2 skipped`; `ruff` clean; `tests/test_licensing.py` `10 passed, 2 skipped` locally (the 2 skips are the `OVF_WEB_ROOT` site assertions, which run in the site repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)