### PR TITLE
chore(release): bump to 0.5.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.25] — 2026-09-12
+
+### Added
+- **The install DMG window is no longer bare.** It now shows the background artwork it shipped with but never displayed — a dotted arrow leading from the app icon to Applications — with both icons positioned along it and the toolbar hidden. A missing Finder Automation permission degrades to the old plain window instead of failing the build.
+- **Double-click the app in the DMG and it installs itself.** It copies itself into /Applications, relaunches from there, and ejects the disk image — no separate drag step, no hunting through Spotlight afterward. Dragging the icon onto the Applications shortcut by hand still works exactly as before. Guards against replacing a running installed copy, downgrading a newer install, or leaving a half-copied app behind on a failed copy.
+
 ### Changed
+- Onboarding now starts the speech-engine download from the engine already recommended for the Mac (Large Turbo on capable Apple Silicon, Small otherwise) instead of waiting for a tap on an empty picker — still freely overridable. The footer's blank "waiting on your pick" text during the download is now a greyed-out "Try it" pill that fills in step with the transfer.
 - Current source and future releases are now offered under the OpenVoiceFlow Personal and Reciprocal Source License 1.0: use is free for personal purposes only; commercial or organizational use requires separate written permission or a separate written license from Shimoverse Studios. Every Integration must visibly credit OpenVoiceFlow with a link to the original code, including an independent program that merely communicates with an unmodified build through a documented interface. Only a Covered Work that is distributed or offered over a network must publish complete Corresponding Source under the same license. Earlier versions already released under MIT remain available under their original terms, and retained third-party contribution portions remain separately identified under MIT.
 
 ## [0.5.24] — 2026-09-06

--- a/native/Info.plist
+++ b/native/Info.plist
@@ -8,8 +8,8 @@
     <key>CFBundleExecutable</key><string>OpenVoiceFlow</string>
     <key>CFBundleIconFile</key><string>OpenVoiceFlow.icns</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.5.24</string>
-    <key>CFBundleVersion</key><string>29</string>
+    <key>CFBundleShortVersionString</key><string>0.5.25</string>
+    <key>CFBundleVersion</key><string>30</string>
     <key>NSHumanReadableCopyright</key><string>© Shimoverse Studios. Personal + reciprocal source license; commercial or organizational use requires separate written permission or a separate written license.</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <!-- Launch as an accessory so the dashboard Window scene stays dormant (a

--- a/native/project.yml
+++ b/native/project.yml
@@ -38,8 +38,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.openvoiceflow
         INFOPLIST_FILE: Info.plist
         CODE_SIGN_ENTITLEMENTS: OpenVoiceFlow.entitlements
-        MARKETING_VERSION: 0.5.24
-        CURRENT_PROJECT_VERSION: 29
+        MARKETING_VERSION: 0.5.25
+        CURRENT_PROJECT_VERSION: 30
         GENERATE_INFOPLIST_FILE: NO
         COMBINE_HIDPI_IMAGES: YES
 schemes:


### PR DESCRIPTION
## Summary
- Bumps MARKETING_VERSION/CURRENT_PROJECT_VERSION (native/project.yml) and CFBundleShortVersionString/CFBundleVersion (native/Info.plist) from 0.5.24/29 to 0.5.25/30, per RELEASE.md step 1.
- Adds the 0.5.25 CHANGELOG entry, folding in the DMG install-window styling, self-relocating first launch, and onboarding auto-select changes from #161, plus the already-`[Unreleased]` license change note.

## Test plan
- [x] CI (build, native-build, tests) green on this branch
- [ ] Merge on green, then tag `native-v0.5.25` via the "Create release tag" workflow per RELEASE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)